### PR TITLE
Add tolerance for incorrect spelling #69

### DIFF
--- a/src/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey.csproj
@@ -255,6 +255,7 @@
     <Compile Include="Services\AutoComplete\IManageAutoComplete.cs" />
     <Compile Include="Services\AutoComplete\OriginalAutoComplete.cs" />
     <Compile Include="Services\AutoComplete\IAutoComplete.cs" />
+    <Compile Include="Services\AutoComplete\NGramAutoComplete.cs" />
     <Compile Include="Services\ICalibrationService.cs" />
     <Compile Include="Services\IMouseOutputService.cs" />
     <Compile Include="Services\INotifyErrors.cs" />

--- a/src/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey.csproj
@@ -16,6 +16,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -30,7 +31,6 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -252,6 +252,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Services\AutoComplete\OriginalAutoComplete.cs" />
+    <Compile Include="Services\AutoComplete\IAutoComplete.cs" />
     <Compile Include="Services\ICalibrationService.cs" />
     <Compile Include="Services\IMouseOutputService.cs" />
     <Compile Include="Services\INotifyErrors.cs" />

--- a/src/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey.csproj
@@ -252,6 +252,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Services\AutoComplete\IManageAutoComplete.cs" />
     <Compile Include="Services\AutoComplete\OriginalAutoComplete.cs" />
     <Compile Include="Services\AutoComplete\IAutoComplete.cs" />
     <Compile Include="Services\ICalibrationService.cs" />

--- a/src/Models/DictionaryEntry.cs
+++ b/src/Models/DictionaryEntry.cs
@@ -3,18 +3,14 @@
     public class DictionaryEntry
     {
 
-        private readonly string entry;
-
         public DictionaryEntry(string entry) : this(entry, 0) { }
         public DictionaryEntry(string entry, int usageCount)
         {
-            this.entry = entry;
+            Entry = entry;
             UsageCount = usageCount;
         }
 
-        public string Entry {
-            get { return entry; }
-        }
+        public string Entry { get; }
         public int UsageCount { get; set; }
     }
 }

--- a/src/Models/DictionaryEntry.cs
+++ b/src/Models/DictionaryEntry.cs
@@ -2,7 +2,19 @@
 {
     public class DictionaryEntry
     {
-        public string Entry { get; set; }
+
+        private readonly string entry;
+
+        public DictionaryEntry(string entry) : this(entry, 0) { }
+        public DictionaryEntry(string entry, int usageCount)
+        {
+            this.entry = entry;
+            UsageCount = usageCount;
+        }
+
+        public string Entry {
+            get { return entry; }
+        }
         public int UsageCount { get; set; }
     }
 }

--- a/src/Services/AutoComplete/IAutoComplete.cs
+++ b/src/Services/AutoComplete/IAutoComplete.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JuliusSweetland.OptiKey.Services.AutoComplete
+{
+    interface IAutoComplete
+    {
+        IEnumerable<string> GetSuggestions(string root);
+    }
+}

--- a/src/Services/AutoComplete/IManageAutoComplete.cs
+++ b/src/Services/AutoComplete/IManageAutoComplete.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 
 namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
-    public interface IAutoComplete
+    public interface IManageAutoComplete<T> : IAutoComplete
     {
-        IEnumerable<string> GetSuggestions(string root);
+        void AddEntry(string entry, T metaData);
+
+        void RemoveEntry(string entry);
     }
 }

--- a/src/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/Services/AutoComplete/NGramAutoComplete.cs
@@ -1,0 +1,139 @@
+﻿using JuliusSweetland.OptiKey.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JuliusSweetland.OptiKey.Services.AutoComplete
+{
+    public class NGramAutoComplete : IManageAutoComplete<DictionaryEntry>
+    {
+        private readonly Dictionary<string, HashSet<EntryMetadata>> entries = new Dictionary<string, HashSet<EntryMetadata>>();
+        private readonly Func<string, string> normalize;
+        private readonly string leadingSpaces;
+        private readonly string trailingSpaces;
+
+        public static readonly Func<string, string> DefaultNormalizeFunc = x => x.Trim().Normalize(NormalizationForm.FormKD).ToUpperInvariant();
+
+        /// <summary>
+        /// An auto suggest class using the trigram algorithm.
+        /// https://en.wikipedia.org/wiki/N-gram
+        /// n-grams provide a quick way to do a fuzzy search that works decently across a wide range of languages.
+        /// </summary>
+        public NGramAutoComplete()
+            : this(DefaultNormalizeFunc) { }
+
+        /// <summary>
+        /// An auto suggest class using the trigram algorithm.
+        /// https://en.wikipedia.org/wiki/N-gram
+        /// n-grams provide a quick way to do a fuzzy search that works decently across a wide range of languages.
+        /// </summary>
+        /// <param name="normalizeFunc">A function to normalize input. This function should convert the string into a base form for comparison.</param>
+        public NGramAutoComplete(Func<string, string> normalizeFunc)
+            : this(normalizeFunc, 3, 2, 1) { }
+
+        /// <summary>
+        /// An auto suggest class using the n-gram algorithm.
+        /// https://en.wikipedia.org/wiki/N-gram
+        /// n-grams provide a quick way to do a fuzzy search that works decently across a wide range of languages.
+        /// </summary>
+        /// <param name="normalizeFunc">A function to normalize input. This function should convert the string into a base form for comparison.</param>
+        /// <param name="gramCount">The size of each gram.</param>
+        /// <param name="leadingSpaceCount">Number of leading spaces. The more spaces the higher priority the start of the string has.</param>
+        /// <param name="trailingSpaceCount">Number of trailing spaces. The more spaces the higher priority the end of the string has.</param>
+        public NGramAutoComplete(Func<string, string> normalizeFunc, int gramCount, int leadingSpaceCount, int trailingSpaceCount)
+        {
+            if (gramCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(gramCount), gramCount, "Must be greater than 0");
+            }
+            if (leadingSpaceCount < 0 || leadingSpaceCount >= gramCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(leadingSpaceCount), leadingSpaceCount, "Must be 0 or larger, and less than gramCount");
+            }
+            if (trailingSpaceCount < 0 || trailingSpaceCount >= gramCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(trailingSpaceCount), trailingSpaceCount, "Must be 0 or larger, and less than gramCount");
+            }
+
+            normalize = normalizeFunc;
+            leadingSpaces = new string(' ', leadingSpaceCount);
+            trailingSpaces = new string(' ', trailingSpaceCount);
+
+        }
+
+        public void AddEntry(string entry, DictionaryEntry dictionaryEntry)
+        {
+            var ngrams = ToNGrams(entry);
+            var metaData = new EntryMetadata(dictionaryEntry, ngrams.Count());
+
+            foreach(var ngram in ngrams)
+            {
+                if (entries.ContainsKey(ngram))
+                {
+                    entries[ngram].Add(metaData);
+                } else
+                {
+                    entries[ngram] = new HashSet<EntryMetadata> { metaData };
+                }
+
+            }
+        }
+
+        public IEnumerable<string> GetSuggestions(string root)
+        {
+            var nGrams = ToNGrams(root);
+            var nGramcount = nGrams.Count();
+
+            return nGrams
+                .Where(x => entries.ContainsKey(x))
+                .SelectMany(x => entries[x])
+                .GroupBy(x => x)
+                .Select(x => new {
+                    MetaData = x.Key,
+                    Score = CalculateScore(x.Count(), nGramcount, x.Key.NGramCount)
+                })
+                .OrderByDescending(x => x.Score)
+                .ThenByDescending(x => x.MetaData.DictionaryEntry.UsageCount)
+                .Select(x => x.MetaData.DictionaryEntry.Entry);
+        }
+
+        public void RemoveEntry(string entry)
+        {
+            foreach(var trigram in ToNGrams(entry))
+            {
+                if (entries.ContainsKey(trigram))
+                {
+                    entries[trigram].RemoveWhere(x => x.DictionaryEntry.Entry == entry);
+                }
+            }
+        }
+
+        private IEnumerable<string> ToNGrams(string word)
+        {
+            var normalizedWord = leadingSpaces + normalize(word) + trailingSpaces;
+            for (int i = 0; i < normalizedWord.Length-2; i++)
+            {
+                yield return normalizedWord.Substring(i, 3);
+            }
+        }
+
+        private double CalculateScore(double numberOfMatches, double numberOfRootNGrams, double numberOfEntryNGrams)
+        {
+            return 2 * numberOfMatches / (numberOfRootNGrams + numberOfEntryNGrams);
+        }
+
+        private class EntryMetadata
+        {
+            public EntryMetadata(DictionaryEntry dictionaryEntry, int nGramCount)
+            {
+                DictionaryEntry = dictionaryEntry;
+                NGramCount = nGramCount;
+            }
+
+            public DictionaryEntry DictionaryEntry { get; }
+            public int NGramCount { get; }
+        }
+    }
+}

--- a/src/Services/AutoComplete/OriginalAutoComplete.cs
+++ b/src/Services/AutoComplete/OriginalAutoComplete.cs
@@ -1,0 +1,89 @@
+﻿using JuliusSweetland.OptiKey.Extensions;
+using JuliusSweetland.OptiKey.Models;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JuliusSweetland.OptiKey.Services.AutoComplete
+{
+    public class OriginalAutoComplete : IAutoComplete
+    {
+        private Dictionary<string, List<DictionaryEntry>> entriesForAutoComplete = new Dictionary<string, List<DictionaryEntry>>();
+
+        private readonly static ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public IEnumerable<string> GetSuggestions(string root)
+        {
+            Log.DebugFormat("GetAutoCompleteSuggestions called with root '{0}'", root);
+
+            if (entriesForAutoComplete != null)
+            {
+                var simplifiedRoot = root.CreateAutoCompleteDictionaryEntryHash();
+
+                if (!string.IsNullOrWhiteSpace(simplifiedRoot))
+                {
+                    var enumerator =
+                        new List<DictionaryEntry> { new DictionaryEntry { Entry = root } } //Include the typed root as first result
+                        .Union(entriesForAutoComplete
+                                .Where(kvp => kvp.Key.StartsWith(simplifiedRoot))
+                                .SelectMany(kvp => kvp.Value)
+                                .Where(de => de.Entry.Length > root.Length)
+                                .Distinct() //Phrases are stored in entriesForAutoComplete with multiple hashes (one the full version of the phrase and one the first letter of each word so you can look them up by either)
+                                .OrderByDescending(de => de.UsageCount)
+                                .ThenBy(de => de.Entry.Length))
+                        .Select(de => de.Entry)
+                        .GetEnumerator();
+
+                    while (enumerator.MoveNext())
+                    {
+                        yield return enumerator.Current;
+                    }
+                }
+
+                yield break; //Not strictly necessary
+            }
+        }
+
+        public void AddEntry(string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)
+        {
+            if (!string.IsNullOrWhiteSpace(autoCompleteHash))
+            {
+                if (entriesForAutoComplete.ContainsKey(autoCompleteHash))
+                {
+                    if (entriesForAutoComplete[autoCompleteHash].All(nwwuc => nwwuc.Entry != entry))
+                    {
+                        entriesForAutoComplete[autoCompleteHash].Add(newEntryWithUsageCount);
+                    }
+                }
+                else
+                {
+                    entriesForAutoComplete.Add(autoCompleteHash, new List<DictionaryEntry> { newEntryWithUsageCount });
+                }
+            }
+        }
+
+        public void RemoveEntry(string entry)
+        {
+            var autoCompleteHash = entry.CreateAutoCompleteDictionaryEntryHash(log: false);
+            if (!string.IsNullOrWhiteSpace(autoCompleteHash)
+                && entriesForAutoComplete.ContainsKey(autoCompleteHash))
+            {
+                var foundEntryForAutoComplete = entriesForAutoComplete[autoCompleteHash].FirstOrDefault(ewuc => ewuc.Entry == entry);
+
+                if (foundEntryForAutoComplete != null)
+                {
+                    entriesForAutoComplete[autoCompleteHash].Remove(foundEntryForAutoComplete);
+
+                    if (!entriesForAutoComplete[autoCompleteHash].Any())
+                    {
+                        entriesForAutoComplete.Remove(autoCompleteHash);
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/src/Services/AutoComplete/OriginalAutoComplete.cs
+++ b/src/Services/AutoComplete/OriginalAutoComplete.cs
@@ -26,7 +26,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
                 if (!string.IsNullOrWhiteSpace(simplifiedRoot))
                 {
                     var enumerator =
-                        new List<DictionaryEntry> { new DictionaryEntry { Entry = root } } //Include the typed root as first result
+                        new List<DictionaryEntry> { new DictionaryEntry (root) } //Include the typed root as first result
                         .Union(entriesForAutoComplete
                                 .Where(kvp => kvp.Key.StartsWith(simplifiedRoot))
                                 .SelectMany(kvp => kvp.Value)

--- a/src/Services/AutoComplete/OriginalAutoComplete.cs
+++ b/src/Services/AutoComplete/OriginalAutoComplete.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
-    public class OriginalAutoComplete : IAutoComplete
+    public class OriginalAutoComplete : IManageAutoComplete<DictionaryEntry>
     {
         private Dictionary<string, List<DictionaryEntry>> entriesForAutoComplete = new Dictionary<string, List<DictionaryEntry>>();
 
@@ -47,8 +47,25 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             }
         }
 
-        public void AddEntry(string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)
+        public void AddEntry(string entry, DictionaryEntry newEntryWithUsageCount)
         {
+
+            //Also add to entries for auto complete
+            var autoCompleteHash = entry.CreateAutoCompleteDictionaryEntryHash(log: false);
+            AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
+            if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
+            {
+                //Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
+                var phraseAutoCompleteHash = entry.CreateDictionaryEntryHash(log: false);
+                AddToDictionary(entry, phraseAutoCompleteHash, newEntryWithUsageCount);
+            }
+
+
+        }
+
+        private void AddToDictionary (string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)
+        { 
+
             if (!string.IsNullOrWhiteSpace(autoCompleteHash))
             {
                 if (entriesForAutoComplete.ContainsKey(autoCompleteHash))

--- a/src/Services/DictionaryService.cs
+++ b/src/Services/DictionaryService.cs
@@ -30,7 +30,7 @@ namespace JuliusSweetland.OptiKey.Services
         private readonly static ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         
         private Dictionary<string, List<DictionaryEntry>> entries;
-        private OriginalAutoComplete autoComplete;
+        private IManageAutoComplete<DictionaryEntry> autoComplete;
 
         #endregion
 
@@ -43,7 +43,11 @@ namespace JuliusSweetland.OptiKey.Services
         #region Ctor
 
         public DictionaryService()
+         : this(new OriginalAutoComplete()) { }
+
+        public DictionaryService(IManageAutoComplete<DictionaryEntry> autoComplete)
         {
+            this.autoComplete = autoComplete;
             MigrateLegacyDictionaries();
             LoadDictionary();
         }
@@ -270,14 +274,7 @@ namespace JuliusSweetland.OptiKey.Services
                     }
 
                     //Also add to entries for auto complete
-                    var autoCompleteHash = entry.CreateAutoCompleteDictionaryEntryHash(log: false);
-                    autoComplete.AddEntry(entry, autoCompleteHash, newEntryWithUsageCount);
-                    if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
-                    {
-                        //Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
-                        var phraseAutoCompleteHash = entry.CreateDictionaryEntryHash(log: !loadedFromDictionaryFile);
-                        autoComplete.AddEntry(entry, phraseAutoCompleteHash, newEntryWithUsageCount);
-                    }
+                    autoComplete.AddEntry(entry, newEntryWithUsageCount);
                     
                     if (!loadedFromDictionaryFile)
                     {

--- a/src/Services/DictionaryService.cs
+++ b/src/Services/DictionaryService.cs
@@ -255,7 +255,7 @@ namespace JuliusSweetland.OptiKey.Services
                 var hash = entry.CreateDictionaryEntryHash(log: !loadedFromDictionaryFile);
                 if (!string.IsNullOrWhiteSpace(hash))
                 {
-                    var newEntryWithUsageCount = new DictionaryEntry { UsageCount = usageCount, Entry = entry };
+                    var newEntryWithUsageCount = new DictionaryEntry (entry, usageCount);
 
                     if (entries.ContainsKey(hash))
                     {

--- a/src/Services/DictionaryService.cs
+++ b/src/Services/DictionaryService.cs
@@ -43,7 +43,8 @@ namespace JuliusSweetland.OptiKey.Services
         #region Ctor
 
         public DictionaryService()
-         : this(new OriginalAutoComplete()) { }
+         //: this(new OriginalAutoComplete()) { } 
+         : this(new NGramAutoComplete()) { }
 
         public DictionaryService(IManageAutoComplete<DictionaryEntry> autoComplete)
         {
@@ -97,7 +98,6 @@ namespace JuliusSweetland.OptiKey.Services
             try
             {
                 entries = new Dictionary<string, List<DictionaryEntry>>();
-                autoComplete = new OriginalAutoComplete();
 
                 //Load the user dictionary
                 var userDictionaryPath = GetUserDictionaryPath(Settings.Default.Language);

--- a/src/Services/IDictionaryService.cs
+++ b/src/Services/IDictionaryService.cs
@@ -13,7 +13,7 @@ namespace JuliusSweetland.OptiKey.Services
         void LoadDictionary();
         bool ExistsInDictionary(string entryToFind);
         IEnumerable<DictionaryEntry> GetAllEntries();
-        IEnumerable<DictionaryEntry> GetAutoCompleteSuggestions(string root);
+        IEnumerable<string> GetAutoCompleteSuggestions(string root);
         void AddNewEntryToDictionary(string entry);
         void RemoveEntryFromDictionary(string entry);
         void IncrementEntryUsageCount(string entry);

--- a/src/Services/KeyboardOutputService.cs
+++ b/src/Services/KeyboardOutputService.cs
@@ -538,7 +538,6 @@ namespace JuliusSweetland.OptiKey.Services
                         Log.DebugFormat("Generating auto complete suggestions from '{0}'.", inProgressWord);
 
                         var suggestions = dictionaryService.GetAutoCompleteSuggestions(inProgressWord)
-                            .Select(de => de.Entry)
                             .Take(Settings.Default.MaxDictionaryMatchesOrSuggestions)
                             .ToList();
 


### PR DESCRIPTION
Parts of the DictionaryService class were refactored into OrginalAutoComplete, and NGramAutoComplete was added as an alternative implementation.

N-gram works fairly well across multiple languages for fuzzy searching, and is pretty fast to compute. The exact parameters for some languages might need some adjustments for best results. We should look at how best to allow languages to set these parameters.

The settings hard coded works well for the English language, and most of the [common misspellings](http://www.oxforddictionaries.com/words/common-misspellings) are returned in the top 10 results. 

We might want to look at adjusting the scoring in NGramAutoComplete to better use word frequence.

MapCaptureToEntries hasn't been modified yet, but it shouldn't be too hard to do. N-gram should perform a lot faster than the current method.

The IAutoComplete and IManageAutoComoplete were added as interfaces that the OriginalAutoComplete and NGramAutoComplete classes use. When we start implementing east Asian languages, we'll want to use the built in IME support for those languages in place of the current auto complete and dictionaries.