### PR TITLE
Use screen size to determine toast notification size #154

### DIFF
--- a/src/JuliusSweetland.OptiKey/App.config
+++ b/src/JuliusSweetland.OptiKey/App.config
@@ -76,7 +76,7 @@
         <value>0,0,0,0</value>
       </setting>
       <setting name="ToastNotificationVerticalFillPercentage" serializeAs="String">
-        <value>75</value>
+        <value>50</value>
       </setting>
       <setting name="ToastNotificationSecondsPerCharacter" serializeAs="String">
         <value>0.03</value>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -286,7 +286,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("75")]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public int ToastNotificationVerticalFillPercentage {
             get {

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -63,7 +63,7 @@
       <Value Profile="(Default)">0,0,0,0</Value>
     </Setting>
     <Setting Name="ToastNotificationVerticalFillPercentage" Roaming="true" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">75</Value>
+      <Value Profile="(Default)">50</Value>
     </Setting>
     <Setting Name="ToastNotificationSecondsPerCharacter" Roaming="true" Type="System.Decimal" Scope="User">
       <Value Profile="(Default)">0.03</Value>

--- a/src/JuliusSweetland.OptiKey/UI/Controls/ToastNotificationPopup.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/ToastNotificationPopup.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media.Animation;
 using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.UI.Utilities;
 using JuliusSweetland.OptiKey.UI.ViewModels;
@@ -88,13 +89,15 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
         #region Set Size
 
-        private void SetSize(FrameworkElement target, FrameworkElement parent)
+        private static void SetSize(FrameworkElement target, Window parent)
         {
-            target.MaxHeight = target.MinHeight = target.Height = 
-                parent.ActualHeight * Settings.Default.ToastNotificationVerticalFillPercentage / 100;
+            var screen = parent.GetScreen();
+
+            target.MaxHeight = target.MinHeight = target.Height =
+                screen.Bounds.Height * Settings.Default.ToastNotificationVerticalFillPercentage / 100.0;
 
             target.MaxWidth = target.MinWidth = target.Width =
-                parent.ActualWidth * Settings.Default.ToastNotificationHorizontalFillPercentage / 100;
+                screen.Bounds.Width * Settings.Default.ToastNotificationHorizontalFillPercentage / 100.0;
         }
 
         #endregion


### PR DESCRIPTION
I gave up trying to fix the start up order and moved to setting the toast notification popup from the screen size. Will require a change to the user's local settings as the percentage height has changed. This has a more global impact then perhaps you were envisaging.