### PR TITLE
#171 Clean up old log4net log files 

### DIFF
--- a/src/JuliusSweetland.OptiKey/log4net.config
+++ b/src/JuliusSweetland.OptiKey/log4net.config
@@ -5,7 +5,7 @@
   </configSections>
   <log4net>
     <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file type="log4net.Util.PatternString" value="${APPDATA}\JuliusSweetland\OptiKey\Logs\OptiKey.%date{yyyy-MM-dd_HH-mm-ss}.log" />
+      <file type="log4net.Util.PatternString" value="${APPDATA}\JuliusSweetland\OptiKey\Logs\OptiKey.log" />
       <appendToFile value="false" />
       <staticLogFileName value="true" />
       <rollingStyle value="Once" />


### PR DESCRIPTION
The date pattern on the logfile name (on log4net.config) caused the maxSizeRollBackups to not work correctly, since it is not supported for dates. Removing it makes things work correctly.

This will still create a logfile per application run as you wanted. However, if for some reason you really need the date to also be on the filename, then let me know to search for another solution or something.

Since I left the staticLogFileName value="true" (as before), now the most recent logfile will be called Optikey.log ,  the previous Optikey.log.1, before that Optikey.log.2 etc.

However, since I do not have experience with Nbug and how it sends the email with the logfile, I could not find whether you have to change something there too so that it sends the correct file (if it decides which log file to send by its name).

Also, while on #171 comments you mentioned "For arguments sake I'd say 10 log files should be stored" , you had set the maxSizeRollBackups to 25, so I decided to keep it as is and let it be 25 (you can change this to 10 if needed).

(For your tests, note it will keep current log + 25, so a total of 26).
