### PR TITLE
Delay showing splash screen until sizing complete #154

### DIFF
--- a/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
@@ -357,7 +357,7 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.Info("ResizeDockToCollapsed called");
 
-            if (getWindowState() != WindowStates.Docked || getDockSize() == DockSizes.Collapsed) return;
+            if (getWindowState() != WindowStates.Docked) return;
             saveDockSize(DockSizes.Collapsed);
             var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(getDockPosition(), DockSizes.Collapsed);
             SetAppBarSizeAndPosition(getDockPosition(), dockSizeAndPositionInPx); //PersistSizeAndPosition() is called indirectly by SetAppBarSizeAndPosition - no need to call explicitly
@@ -367,7 +367,7 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.Info("ResizeDockToFull called");
 
-            if (getWindowState() != WindowStates.Docked || getDockSize() == DockSizes.Full) return;
+            if (getWindowState() != WindowStates.Docked) return;
             saveDockSize(DockSizes.Full); 
             var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(getDockPosition(), DockSizes.Full);
             SetAppBarSizeAndPosition(getDockPosition(), dockSizeAndPositionInPx); //PersistSizeAndPosition() is called indirectly by SetAppBarSizeAndPosition - no need to call explicitly
@@ -574,7 +574,7 @@ namespace JuliusSweetland.OptiKey.Services
             PublishSizeAndPositionInitialised();
         }
 
-        private void ApplySavedState()
+        private void ApplySavedState(bool isInitialising = false)
         {
             Log.Info("ApplySavedState called");
 
@@ -587,7 +587,7 @@ namespace JuliusSweetland.OptiKey.Services
                     window.WindowState = System.Windows.WindowState.Normal;
                     var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(dockPosition, getDockSize());
                     RegisterAppBar();
-                    SetAppBarSizeAndPosition(dockPosition, dockSizeAndPositionInPx);
+                    SetAppBarSizeAndPosition(dockPosition, dockSizeAndPositionInPx, isInitialising);
                     break;
 
                 case WindowStates.Floating:
@@ -765,7 +765,7 @@ namespace JuliusSweetland.OptiKey.Services
                 }    
             }
 
-            ApplySavedState();
+            ApplySavedState(true);
         }
 
         private bool Move(MoveToDirections direction, double amountInPx, double distanceToTopBoundaryIfFloating,
@@ -1140,7 +1140,7 @@ namespace JuliusSweetland.OptiKey.Services
             source.AddHook(AppBarPositionChangeCallback);
         }
 
-        private void SetAppBarSizeAndPosition(DockEdges dockPosition, Rect sizeAndPosition)
+        private void SetAppBarSizeAndPosition(DockEdges dockPosition, Rect sizeAndPosition, bool isInitialising = false)
         {
             Log.InfoFormat("SetAppBarSizeAndPosition called with dockPosition:{0}, sizeAndPosition.Top:{1}, sizeAndPosition.Bottom:{2}, sizeAndPosition.Left:{3}, sizeAndPosition.Right:{4}",
                     dockPosition, sizeAndPosition.Top, sizeAndPosition.Bottom, sizeAndPosition.Left, sizeAndPosition.Right);
@@ -1210,7 +1210,7 @@ namespace JuliusSweetland.OptiKey.Services
                 savePreviousWindowState(WindowStates.Floating);
                 PublishError(this, new ApplicationException("There was a problem positioning OptiKey - reverting to floating position"));
             }
-            else
+            else if (!isInitialising)
             {
                 //Apply final size and position to the window. This is dispatched with ApplicationIdle priority 
                 //as WPF will send a resize after a new appbar is added. We need to apply the received size & position after this happens.


### PR DESCRIPTION
If the size of the window was different when the application was last
closed, the WindowManipulationService will place a resize event on the
dispatcher queue with the old size. The keyboard service will then resize
the window to the correct dimensions based on the user's startup
preferences. The way the dispatcher queue works means that messages are
not handled until a handler is attached and so the splash screen creation
is triggered too early when the window is still the old size.

To fix this, in the WindowManipulationService, we suppress the resize
message if we are initialising.

However, if the window is the correct size at startup then the call
from the keyboard service into the WindowManipulationService would assume
there was no work to do and wouldn't perform a resize.

So, we also remove checks to see whether we are already in the correct
state when resizing. This ensures the message from the keyboard startup
workflow is always raised and it is this message that triggers the splash
screen, when we are sized correctly.