### PR TITLE
Show button text if dwell in progress, fixes #188.

### DIFF
--- a/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Dark.xaml
+++ b/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Dark.xaml
@@ -115,12 +115,24 @@
                         </MultiDataTrigger.Setters>
                     </MultiDataTrigger>
 
-                    <!--Is there text and a symbol then only display the text when the key is current)-->
+                    <!--If there is text and a symbol then display the text when the key is current -->
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
                             <Condition Binding="{Binding Path=HasSymbol, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
                             <Condition Binding="{Binding Path=IsCurrent, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
+                        </MultiDataTrigger.Conditions>
+                        <MultiDataTrigger.Setters>
+                            <Setter Property="Visibility" Value="Visible" />
+                        </MultiDataTrigger.Setters>
+                    </MultiDataTrigger>
+
+                    <!-- Also display the text is the key is progressing -->
+                    <MultiDataTrigger>
+                        <MultiDataTrigger.Conditions>
+                            <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding Path=HasSymbol, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding Path=IsProgressing, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
                         </MultiDataTrigger.Conditions>
                         <MultiDataTrigger.Setters>
                             <Setter Property="Visibility" Value="Visible" />
@@ -181,7 +193,18 @@
                             <Setter Property="Visibility" Value="Collapsed" />
                         </MultiDataTrigger.Setters>
                     </MultiDataTrigger>
-                    
+
+                    <!-- ...or if there's Text and the key is progressing -->
+                    <MultiDataTrigger>
+                        <MultiDataTrigger.Conditions>
+                            <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding Path=IsProgressing, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
+                        </MultiDataTrigger.Conditions>
+                        <MultiDataTrigger.Setters>
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </MultiDataTrigger.Setters>
+                    </MultiDataTrigger>
+
                     <!--This key is in a key down state of Down-->
                     <DataTrigger Binding="{Binding Path=KeyDownState, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="{x:Static enums:KeyDownStates.Down}">
                         <Setter Property="Fill" Value="{StaticResource KeyDownStateIsDownForegroundBrush}" />

--- a/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Light.xaml
+++ b/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Light.xaml
@@ -114,12 +114,24 @@
                         </MultiDataTrigger.Setters>
                     </MultiDataTrigger>
 
-                    <!--Is there text and a symbol then only display the text when the key is current)-->
+                    <!--If there is text and a symbol then display the text when the key is current -->
                     <MultiDataTrigger>
                         <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
                             <Condition Binding="{Binding Path=HasSymbol, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
                             <Condition Binding="{Binding Path=IsCurrent, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
+                        </MultiDataTrigger.Conditions>
+                        <MultiDataTrigger.Setters>
+                            <Setter Property="Visibility" Value="Visible" />
+                        </MultiDataTrigger.Setters>
+                    </MultiDataTrigger>
+
+                    <!-- Also display the text if the key is progressing -->
+                    <MultiDataTrigger>
+                        <MultiDataTrigger.Conditions>
+                            <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding Path=HasSymbol, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding Path=IsProgressing, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
                         </MultiDataTrigger.Conditions>
                         <MultiDataTrigger.Setters>
                             <Setter Property="Visibility" Value="Visible" />
@@ -175,6 +187,17 @@
                         <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
                             <Condition Binding="{Binding Path=IsCurrent, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
+                        </MultiDataTrigger.Conditions>
+                        <MultiDataTrigger.Setters>
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </MultiDataTrigger.Setters>
+                    </MultiDataTrigger>
+
+                    <!-- ...or if there's Text and the key is progressing -->
+                    <MultiDataTrigger>
+                        <MultiDataTrigger.Conditions>
+                            <Condition Binding="{Binding Path=HasText, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True" />
+                            <Condition Binding="{Binding Path=IsProgressing, RelativeSource={RelativeSource AncestorType=controls:Key}}" Value="True" />
                         </MultiDataTrigger.Conditions>
                         <MultiDataTrigger.Setters>
                             <Setter Property="Visibility" Value="Collapsed" />

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
@@ -60,6 +60,13 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             onUnloaded.Add(keySelectionProgressSubscription);
             SelectionProgress = keyStateService.KeySelectionProgress[Value].Value;
 
+            //Calculate IsProgressing
+            var IsProgressingSubscription = keyStateService.KeySelectionProgress[Value]
+               .OnPropertyChanges(ksp => ksp.Value)
+               .Subscribe(value => IsProgressing = (value > 0.0));
+            onUnloaded.Add(IsProgressingSubscription);
+            IsProgressing = keyStateService.KeySelectionProgress[Value].Value > 0.0;
+
             //Calculate IsEnabled
             Action calculateIsEnabled = () => IsEnabled = keyStateService.KeyEnabledStates[Value];
             var keyEnabledSubscription = keyStateService.KeyEnabledStates
@@ -149,6 +156,15 @@ namespace JuliusSweetland.OptiKey.UI.Controls
         {
             get { return (bool) GetValue(IsCurrentProperty); }
             set { SetValue(IsCurrentProperty, value); }
+        }
+
+        public static readonly DependencyProperty IsProgressingProperty =
+            DependencyProperty.Register("IsProgressing", typeof(bool), typeof(Key), new PropertyMetadata(default(bool)));
+
+        public bool IsProgressing
+        {
+            get { return ((double) GetValue(SelectionProgressProperty)) > 0; }
+            set { SetValue(IsProgressingProperty, value); }
         }
 
         public static readonly DependencyProperty SelectionProgressProperty =


### PR DESCRIPTION
This prevents flicker between icon and text if the gaze jumps
outside of the key that you're trying to dwell on.