### PR TITLE
KeyboardKeyDownUpSource tests

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -37,6 +37,11 @@
       <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Reactive.Testing, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Testing.2.2.5\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
@@ -57,6 +62,23 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
@@ -65,9 +87,15 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="TestStack.BDDfy, Version=4.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\TestStack.BDDfy.4.2.0\lib\net40\TestStack.BDDfy.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Observables\TriggerSources\KeyboardKeyDownUpNominalScenario.cs" />
+    <Compile Include="Observables\TriggerSources\KeyboardKeyDownUpSourceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\KeyboardOutputServiceTests.cs" />
     <Compile Include="TestBase.cs" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/Observables/TriggerSources/KeyboardKeyDownUpNominalScenario.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Observables/TriggerSources/KeyboardKeyDownUpNominalScenario.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Windows;
+using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Observables.PointSources;
+using JuliusSweetland.OptiKey.Observables.TriggerSources;
+using Microsoft.Reactive.Testing;
+using Moq;
+using NUnit.Framework;
+
+namespace JuliusSweetland.OptiKey.UnitTests.Observables.TriggerSources
+{
+    public class KeyboardKeyDownUpNominalScenario
+    {
+        #region Fields
+
+        private readonly TestScheduler testScheduler;
+
+        private readonly Keys triggerKey;
+        private readonly PointAndKeyValue? pushedPoint;
+
+        private readonly IList<Recorded<Notification<KeyDirection>>> keyPressEvents =
+            new List<Recorded<Notification<KeyDirection>>>();
+
+        private readonly IList<Recorded<Notification<PointAndKeyValue?>>> pointEvents =
+            new List<Recorded<Notification<PointAndKeyValue?>>>();
+
+        private readonly Lazy<IList<Recorded<Notification<TriggerSignal>>>> messages;
+        private readonly Lazy<KeyboardKeyDownUpSource> sut;
+        private RunningStates state;
+        private long clock;
+
+        #endregion
+
+        public KeyboardKeyDownUpNominalScenario()
+        {
+            testScheduler = new TestScheduler();
+            sut = new Lazy<KeyboardKeyDownUpSource>(CreateSystemUnderTest);
+            messages = new Lazy<IList<Recorded<Notification<TriggerSignal>>>>(GetObservedData);
+
+            triggerKey = Enums.Keys.Insert;
+            pushedPoint = new PointAndKeyValue(new Point(1, 2),
+                new KeyValue { FunctionKey = Enums.FunctionKeys.Escape });
+        }
+
+        public void Given_a_Running_KeyboardKeyDownUpSource()
+        {
+            state = Enums.RunningStates.Running;
+        }
+        public void Given_a_Paused_KeyboardKeyDownUpSource()
+        {
+            state = Enums.RunningStates.Paused;
+        }
+
+        public void When_a_triggerkey_down()
+        {
+            keyPressEvents.Add(ReactiveTest.OnNext(NextTick(), KeyDirection.KeyDown));
+        }
+        public void When_a_triggerkey_up()
+        {
+            keyPressEvents.Add(ReactiveTest.OnNext(NextTick(), KeyDirection.KeyUp));
+        }
+        public void When_PointSource_event()
+        {
+            pointEvents.Add(ReactiveTest.OnNext(NextTick(), pushedPoint));
+        }
+        public void When_Paused()
+        {
+            var dueTime = TimeSpan.FromTicks(NextTick());
+            testScheduler.Schedule(dueTime, () => { sut.Value.State = Enums.RunningStates.Paused; });
+        }
+
+        public void Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown()
+        {
+            var expected = new Recorded<Notification<TriggerSignal>>[]
+            {
+                ReactiveTest.OnNext(200, new TriggerSignal(1, null, pushedPoint)),
+            };
+            CollectionAssert.AreEqual(expected, messages.Value);
+        }
+        public void Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown_then_KeyUp()
+        {
+            var expected = new Recorded<Notification<TriggerSignal>>[]
+            {
+                ReactiveTest.OnNext(200, new TriggerSignal(1, null, pushedPoint)),
+                ReactiveTest.OnNext(300, new TriggerSignal(-1, null, pushedPoint)),
+            };
+            CollectionAssert.AreEqual(expected, messages.Value);
+        }
+        public void Then_Sequence_yeilds_no_values()
+        {
+            var expected = new Recorded<Notification<TriggerSignal>>[]
+            {
+            };
+            CollectionAssert.AreEqual(expected, messages.Value);
+        }
+
+        #region Private Methods
+
+        private IList<Recorded<Notification<TriggerSignal>>> GetObservedData()
+        {
+            var testableObserver = testScheduler.CreateObserver<TriggerSignal>();
+            using (sut.Value.Sequence.Subscribe(testableObserver))
+            {
+                testScheduler.Start();
+            }
+            return testableObserver.Messages;
+        }
+
+        private KeyboardKeyDownUpSource CreateSystemUnderTest()
+        {
+            var pointSource = CreatePointSource();
+            var keyboardHookListener = CreateKeyboardHookListener();
+
+            return new KeyboardKeyDownUpSource(
+                triggerKey,
+                keyboardHookListener,
+                pointSource)
+            { State = state };
+
+        }
+
+        private IPointSource CreatePointSource()
+        {
+            var sequence = testScheduler.CreateHotObservable(this.pointEvents.ToArray());
+            var pointSource = new Mock<IPointSource>();
+            pointSource.Setup(ps => ps.Sequence).Returns(sequence.Timestamp(testScheduler));
+            return pointSource.Object;
+        }
+
+        private IKeyboardHookListener CreateKeyboardHookListener()
+        {
+            var keyPresses = testScheduler.CreateHotObservable(this.keyPressEvents.ToArray());
+            var keyboardHookListenerMock = new Mock<IKeyboardHookListener>();
+            keyboardHookListenerMock.Setup(khl => khl.KeyMovements(It.IsAny<System.Windows.Forms.Keys>()))
+                .Returns(Observable.Never<KeyDirection>());
+            var expected = (System.Windows.Forms.Keys)triggerKey;
+            keyboardHookListenerMock.Setup(khl => khl.KeyMovements(expected))
+                .Returns(keyPresses);
+            return keyboardHookListenerMock.Object;
+        }
+
+        private long NextTick()
+        {
+            return (clock += 100);
+        }
+        
+        #endregion
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/Observables/TriggerSources/KeyboardKeyDownUpSourceTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Observables/TriggerSources/KeyboardKeyDownUpSourceTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Reactive.Testing;
+using NUnit.Framework;
+using TestStack.BDDfy;
+
+namespace JuliusSweetland.OptiKey.UnitTests.Observables.TriggerSources
+{
+    [TestFixture]
+    public class KeyboardKeyDownUpSourceTests : ReactiveTest
+    {
+        [Test]
+        public void KeyDown_with_PointSource_yields_TriggerSignal()
+        {
+            new KeyboardKeyDownUpNominalScenario()
+                .Given(s => s.Given_a_Running_KeyboardKeyDownUpSource())
+                .When(s => s.When_PointSource_event())
+                .When(s => s.When_a_triggerkey_down())
+                .Then(s => s.Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown())
+                .BDDfy();
+
+            new KeyboardKeyDownUpNominalScenario()
+                .Given(s => s.Given_a_Running_KeyboardKeyDownUpSource())
+                .When(s => s.When_a_triggerkey_down())
+                .When(s => s.When_PointSource_event())
+                .Then(s => s.Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown())
+                .BDDfy();
+        }
+
+        [Test]
+        public void KeyDown_KeyUp_with_PointSource_yields_two_TriggerSignals()
+        {
+            new KeyboardKeyDownUpNominalScenario()
+                .Given(s => s.Given_a_Running_KeyboardKeyDownUpSource())
+                .When(s => s.When_PointSource_event())
+                .When(s => s.When_a_triggerkey_down())
+                .When(s => s.When_a_triggerkey_up())
+                .Then(s => s.Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown_then_KeyUp())
+                .BDDfy();
+
+            new KeyboardKeyDownUpNominalScenario()
+                .Given(s => s.Given_a_Running_KeyboardKeyDownUpSource())
+                .When(s => s.When_a_triggerkey_down())
+                .When(s => s.When_PointSource_event())
+                .When(s => s.When_a_triggerkey_up())
+                .Then(s => s.Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown_then_KeyUp())
+                .BDDfy();
+        }
+
+        [Test]
+        public void Paused_does_not_yield_values()
+        {
+            new KeyboardKeyDownUpNominalScenario()
+                .Given(s => s.Given_a_Paused_KeyboardKeyDownUpSource())
+                .When(s => s.When_PointSource_event())
+                .When(s => s.When_a_triggerkey_down())
+                .Then(s => s.Then_Sequence_yeilds_no_values())
+                .BDDfy();
+        }
+
+        [Test]
+        public void Pausing_mutes_sequence()
+        {
+            new KeyboardKeyDownUpNominalScenario()
+                .Given(s => s.Given_a_Running_KeyboardKeyDownUpSource())
+                .When(s => s.When_PointSource_event())
+                .When(s => s.When_a_triggerkey_down())
+                .When(s => s.When_Paused())
+                .When(s => s.When_a_triggerkey_up())
+                .Then(s => s.Then_Sequence_yields_TriggerSignal_with_PointSource_location_and_KeyDown())
+                .BDDfy();
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.UnitTests/packages.config
+++ b/src/JuliusSweetland.OptiKey.UnitTests/packages.config
@@ -5,4 +5,11 @@
   <package id="NUnit" version="2.6.4" targetFramework="net46" />
   <package id="Prism.Core" version="6.0.1" targetFramework="net46" />
   <package id="Prism.Wpf" version="6.0.1" targetFramework="net46" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Testing" version="2.2.5" targetFramework="net46" />
+  <package id="TestStack.BDDfy" version="4.2.0" targetFramework="net46" />
 </packages>

--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -395,7 +395,8 @@ namespace JuliusSweetland.OptiKey
                 case TriggerSources.KeyboardKeyDownsUps:
                     keySelectionTriggerSource = new KeyboardKeyDownUpSource(
                         Settings.Default.KeySelectionTriggerKeyboardKeyDownUpKey,
-                        pointSource.Sequence);
+                        new KeyboardHookListenerWrapper(), 
+                        pointSource);
                     break;
 
                 case TriggerSources.MouseButtonDownUps:
@@ -425,7 +426,8 @@ namespace JuliusSweetland.OptiKey
                 case TriggerSources.KeyboardKeyDownsUps:
                     pointSelectionTriggerSource = new KeyboardKeyDownUpSource(
                         Settings.Default.PointSelectionTriggerKeyboardKeyDownUpKey,
-                        pointSource.Sequence);
+                        new KeyboardHookListenerWrapper(), 
+                        pointSource);
                     break;
 
                 case TriggerSources.MouseButtonDownUps:

--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -250,6 +250,9 @@
     <Compile Include="Observables\PointSources\IPointSource.cs" />
     <Compile Include="Observables\PointSources\MousePositionSource.cs" />
     <Compile Include="Observables\PointSources\PointServiceSource.cs" />
+    <Compile Include="Observables\TriggerSources\IKeyboardHookListener.cs" />
+    <Compile Include="Observables\TriggerSources\KeyboardHookListenerWrapper.cs" />
+    <Compile Include="Observables\TriggerSources\KeyDirection.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
@@ -4,6 +4,10 @@ using JuliusSweetland.OptiKey.Extensions;
 
 namespace JuliusSweetland.OptiKey.Models
 {
+    //TODO: Make KeyValue struct immutable
+    //http://stackoverflow.com/questions/3751911/why-are-c-sharp-structs-immutable
+    //https://msdn.microsoft.com/en-us/library/ms229031(v=vs.110).aspx
+    //TODO: Implement IEquatable<T>
     public struct KeyValue
     {
         public FunctionKeys? FunctionKey { get; set; }

--- a/src/JuliusSweetland.OptiKey/Observables/TriggerSources/IKeyboardHookListener.cs
+++ b/src/JuliusSweetland.OptiKey/Observables/TriggerSources/IKeyboardHookListener.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace JuliusSweetland.OptiKey.Observables.TriggerSources
+{
+    //TODO: Should this become a service? i.e. renamed and moved to .Services\IKeyboardBoardService? -LC
+    public interface IKeyboardHookListener
+    {
+        IObservable<KeyDirection> KeyMovements(System.Windows.Forms.Keys triggerKey);
+    }
+}

--- a/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyDirection.cs
+++ b/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyDirection.cs
@@ -1,0 +1,15 @@
+﻿namespace JuliusSweetland.OptiKey.Observables.TriggerSources
+{
+    public sealed class KeyDirection
+    {
+        public static readonly KeyDirection KeyDown = new KeyDirection(true);
+        public static readonly KeyDirection KeyUp = new KeyDirection(false);
+
+        private KeyDirection(bool isKeyDown)
+        {
+            IsKeyDown = isKeyDown;
+        }
+
+        public bool IsKeyDown { get;}
+    }
+}

--- a/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyboardHookListenerWrapper.cs
+++ b/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyboardHookListenerWrapper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using MouseKeyboardActivityMonitor;
+using MouseKeyboardActivityMonitor.WinApi;
+
+namespace JuliusSweetland.OptiKey.Observables.TriggerSources
+{
+    public sealed class KeyboardHookListenerWrapper : IKeyboardHookListener
+    {
+        private readonly KeyboardHookListener underlying;
+        private readonly IObservable<System.Windows.Forms.Keys> keyDowns;
+        private readonly IObservable<System.Windows.Forms.Keys> keyUps;
+
+        public KeyboardHookListenerWrapper()
+        {
+            this.underlying = new KeyboardHookListener(new GlobalHooker())
+            {
+                Enabled = true
+            };
+            keyDowns = Observable.FromEventPattern<KeyEventHandler, KeyEventArgs>(
+                handler => new KeyEventHandler(handler),
+                h => underlying.KeyDown += h,
+                h => underlying.KeyDown -= h)
+                .Select(e => e.EventArgs.KeyCode);
+
+            keyUps = Observable.FromEventPattern<KeyEventHandler, KeyEventArgs>(
+                handler => new KeyEventHandler(handler),
+                h => underlying.KeyUp += h,
+                h => underlying.KeyUp -= h)
+                .Select(e => e.EventArgs.KeyCode);
+        }
+
+        public IObservable<KeyDirection> KeyMovements(System.Windows.Forms.Keys triggerKey)
+        {
+            var downs = keyDowns.Where(keyCode => keyCode == triggerKey).Select(_ => KeyDirection.KeyDown);
+            var ups = keyUps.Where(keyCode => keyCode == triggerKey).Select(_ => KeyDirection.KeyUp);
+
+            return downs.Merge(ups)
+                .DistinctUntilChanged()
+                .SkipWhile(keyDirection=> !keyDirection.IsKeyDown);//Ensure the first value we hit is a true, i.e. a key down
+        } 
+    }
+}

--- a/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyboardKeyDownUpSource.cs
+++ b/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyboardKeyDownUpSource.cs
@@ -1,40 +1,21 @@
 ﻿using System;
-using System.Reactive;
 using System.Reactive.Linq;
-using System.Windows.Forms;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Models;
-using MouseKeyboardActivityMonitor;
-using MouseKeyboardActivityMonitor.WinApi;
-using Keys = System.Windows.Forms.Keys;
+using JuliusSweetland.OptiKey.Observables.PointSources;
 
 namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 {
-    public class KeyboardKeyDownUpSource : ITriggerSource
+    public sealed class KeyboardKeyDownUpSource : ITriggerSource
     {
-        #region Fields
-
-        private readonly Keys triggerKey;
-        private readonly IObservable<Timestamped<PointAndKeyValue?>> pointAndKeyValueSource;
-        private readonly KeyboardHookListener keyboardHookListener;
-
-        private IObservable<TriggerSignal> sequence;
-
-        #endregion
-
         #region Ctor
 
         public KeyboardKeyDownUpSource(
             Enums.Keys triggerKey,
-            IObservable<Timestamped<PointAndKeyValue?>> pointAndKeyValueSource)
+            IKeyboardHookListener keyboardHookListener,
+            IPointSource pointSource)
         {
-            this.triggerKey = (System.Windows.Forms.Keys)triggerKey; //Cast to the Windows.Forms.Keys enum
-            this.pointAndKeyValueSource = pointAndKeyValueSource;
-
-            keyboardHookListener = new KeyboardHookListener(new GlobalHooker())
-            {
-                Enabled = true
-            };
+            var wfTriggerKey = (System.Windows.Forms.Keys)triggerKey; //Cast to the Windows.Forms.Keys enum
 
             /*
              * Keys: http://msdn.microsoft.com/en-GB/library/system.windows.forms.keys.aspx
@@ -42,6 +23,15 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
              * KeyPress: happens when a key is pressed and then released.
              * KeyUp: happens when the key is released
              */
+
+            var keyPresses = keyboardHookListener.KeyMovements(wfTriggerKey);
+            var pointAndKeyValueSource = pointSource.Sequence.Select(ts => ts.Value);
+            Sequence = keyPresses
+                .CombineLatest(pointAndKeyValueSource, (keyDirection, point) => new TriggerSignal(keyDirection.IsKeyDown ? 1 : -1, null, point.Value))
+                .DistinctUntilChanged(signal => signal.Signal) //Combining latest will output a trigger signal for every change in BOTH sequences - only output when the trigger signal changes
+                .Where(_ => State == RunningStates.Running)
+                .Publish()
+                .RefCount();
         }
 
         #endregion
@@ -50,39 +40,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 
         public RunningStates State { get; set; }
 
-        public IObservable<TriggerSignal> Sequence
-        {
-            get
-            {
-                if (sequence == null)
-                {
-                    var keyDowns = Observable.FromEventPattern<KeyEventHandler, KeyEventArgs>(
-                            handler => new KeyEventHandler(handler),
-                            h => keyboardHookListener.KeyDown += h,
-                            h => keyboardHookListener.KeyDown -= h)
-                        .Where(ep => ep.EventArgs.KeyCode == triggerKey)
-                        .Select(_ => true);
-
-                    var keyUps = Observable.FromEventPattern<KeyEventHandler, KeyEventArgs>(
-                            handler => new KeyEventHandler(handler),
-                            h => keyboardHookListener.KeyUp += h,
-                            h => keyboardHookListener.KeyUp -= h)
-                        .Where(ep => ep.EventArgs.KeyCode == triggerKey)
-                        .Select(_ => false);
-
-                    sequence = keyDowns.Merge(keyUps)
-                        .DistinctUntilChanged()
-                        .SkipWhile(b => b == false) //Ensure the first value we hit is a true, i.e. a key down
-                        .CombineLatest(pointAndKeyValueSource, (b, point) => new TriggerSignal(b ? 1 : -1, null, point.Value))
-                        .DistinctUntilChanged(signal => signal.Signal) //Combining latest will output a trigger signal for every change in BOTH sequences - only output when the trigger signal changes
-                        .Where(_ => State == RunningStates.Running)
-                        .Publish()
-                        .RefCount();
-                }
-
-                return sequence;
-            }
-        }
+        public IObservable<TriggerSignal> Sequence { get; }
 
         #endregion
     }


### PR DESCRIPTION
Added Unit tests for `KeyboardKeyDownUpSource`.
Introduces `Rx-Testing` and `BDDfy` dependencies to _JuliusSweetland.OptiKey.UnitTests_ project.
Minor refactoring of the `KeyboardKeyDownUpSource` class to delegate some responsibilities out. This enables mocking of the underlying point source and key Up/Down sequences.