### PR TITLE
KeyValue struct to be immutable 

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenFireKeySelectionEvent.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenFireKeySelectionEvent.cs
@@ -7,7 +7,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
     [TestFixture]
     public class WhenFireKeySelectionEventGivenKeySelectionEventHandler : MainViewModelTestBase
     {
-        protected KeyValue KeyValue { get { return new KeyValue { FunctionKey = FunctionKeys.Break, String = "Coffee" }; } }
+        protected KeyValue KeyValue { get { return new KeyValue(FunctionKeys.Break, "Coffee"); } }
 
         protected override void Act()
         {

--- a/src/JuliusSweetland.OptiKey/Models/KeyEnabledStates.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyEnabledStates.cs
@@ -81,7 +81,7 @@ namespace JuliusSweetland.OptiKey.Models
                 }
                 
                 //Key is MultiKeySelection, but a key which prevents text capture is down or locked down
-                if (keyValue == KeyValues.MultiKeySelectionKey
+                if (keyValue == KeyValues.MultiKeySelectionIsOnKey
                     && KeyValues.KeysWhichPreventTextCaptureIfDownOrLocked.Any(kv =>
                         keyStateService.KeyDownStates[kv].Value.IsDownOrLockedDown()))
                 {
@@ -291,7 +291,7 @@ namespace JuliusSweetland.OptiKey.Models
                 }
 
                 //Multi-key capture is disabled
-                if (keyValue == KeyValues.MultiKeySelectionKey
+                if (keyValue == KeyValues.MultiKeySelectionIsOnKey
                     && !Settings.Default.MultiKeySelectionEnabled)
                 {
                     return false;

--- a/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
@@ -1,10 +1,11 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 
 namespace JuliusSweetland.OptiKey.Models
 {
-    public struct KeyValue
+    public struct KeyValue : IEquatable<KeyValue>
     {
         public KeyValue(FunctionKeys functionKey)
         {
@@ -22,14 +23,16 @@ namespace JuliusSweetland.OptiKey.Models
             String = text;
         }
 
-        public FunctionKeys? FunctionKey { get; private set; }
-        public string String { get; private set; }
+        public FunctionKeys? FunctionKey { get; }
+        public string String { get; }
         
         public bool StringIsLetter
         {
             get { return String != null && String.Length == 1 && char.IsLetter(String, 0); }
         }
         
+        #region Equality 
+
         public bool Equals(KeyValue kv)
         {
             // Return true if the fields match:
@@ -46,6 +49,22 @@ namespace JuliusSweetland.OptiKey.Models
         {
             return !(x == y);
         }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is KeyValue && Equals((KeyValue) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (FunctionKey.GetHashCode()*397) ^ (String != null ? String.GetHashCode() : 0);
+            }
+        }
+
+        #endregion
 
         public override string ToString()
         {

--- a/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
@@ -6,8 +6,24 @@ namespace JuliusSweetland.OptiKey.Models
 {
     public struct KeyValue
     {
-        public FunctionKeys? FunctionKey { get; set; }
-        public string String { get; set; }
+        public KeyValue(FunctionKeys functionKey)
+        {
+            FunctionKey = functionKey;
+            String = null;
+        }
+        public KeyValue(string text)
+        {
+            FunctionKey = null;
+            String = text;
+        }
+        public KeyValue(FunctionKeys? functionKey, string text)
+        {
+            FunctionKey = functionKey;
+            String = text;
+        }
+
+        public FunctionKeys? FunctionKey { get; private set; }
+        public string String { get; private set; }
         
         public bool StringIsLetter
         {

--- a/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValue.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 
 namespace JuliusSweetland.OptiKey.Models
 {
+    [TypeConverter(typeof(KeyValueConverter))]
     public struct KeyValue : IEquatable<KeyValue>
     {
         public KeyValue(FunctionKeys functionKey)
@@ -88,6 +91,45 @@ namespace JuliusSweetland.OptiKey.Models
             }
             
             return stringBuilder.ToString();
+        }
+    }
+
+    public sealed class KeyValueConverter : TypeConverter
+    {
+        // Overrides the CanConvertFrom method of TypeConverter.
+        // The ITypeDescriptorContext interface provides the context for the
+        // conversion. Typically, this interface is used at design time to 
+        // provide information about the design-time container.
+        public override bool CanConvertFrom(ITypeDescriptorContext context,
+           Type sourceType)
+        {
+
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+            return base.CanConvertFrom(context, sourceType);
+        }
+        // Overrides the ConvertFrom method of TypeConverter.
+        public override object ConvertFrom(ITypeDescriptorContext context,
+           CultureInfo culture, object value)
+        {
+            var text = value as string;
+            if (text!=null)
+            {
+                return new KeyValue(text);
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+        // Overrides the ConvertTo method of TypeConverter.
+        public override object ConvertTo(ITypeDescriptorContext context,
+           CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return ((KeyValue)value).String;
+            }
+            return base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -8,71 +8,71 @@ namespace JuliusSweetland.OptiKey.Models
 {
     public static class KeyValues
     {
-        public static readonly KeyValue CalibrateKey = new KeyValue { FunctionKey = FunctionKeys.Calibrate };
-        public static readonly KeyValue CollapseDockKey = new KeyValue { FunctionKey = FunctionKeys.CollapseDock };
-        public static readonly KeyValue ExpandDockKey = new KeyValue { FunctionKey = FunctionKeys.ExpandDock };
-        public static readonly KeyValue ExpandToBottomKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToBottom };
-        public static readonly KeyValue ExpandToBottomAndLeftKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToBottomAndLeft };
-        public static readonly KeyValue ExpandToBottomAndRightKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToBottomAndRight };
-        public static readonly KeyValue ExpandToLeftKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToLeft };
-        public static readonly KeyValue ExpandToRightKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToRight };
-        public static readonly KeyValue ExpandToTopKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToTop };
-        public static readonly KeyValue ExpandToTopAndLeftKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToTopAndLeft };
-        public static readonly KeyValue ExpandToTopAndRightKey = new KeyValue { FunctionKey = FunctionKeys.ExpandToTopAndRight };
-        public static readonly KeyValue LeftAltKey = new KeyValue { FunctionKey = FunctionKeys.LeftAlt };
-        public static readonly KeyValue LeftCtrlKey = new KeyValue { FunctionKey = FunctionKeys.LeftCtrl };
-        public static readonly KeyValue LeftShiftKey = new KeyValue { FunctionKey = FunctionKeys.LeftShift };
-        public static readonly KeyValue LeftWinKey = new KeyValue { FunctionKey = FunctionKeys.LeftWin };
-        public static readonly KeyValue MouseDragKey = new KeyValue { FunctionKey = FunctionKeys.MouseDrag };
-        public static readonly KeyValue MouseLeftClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseLeftClick };
-        public static readonly KeyValue MouseLeftDoubleClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseLeftDoubleClick };
-        public static readonly KeyValue MouseLeftDownUpKey = new KeyValue { FunctionKey = FunctionKeys.MouseLeftDownUp };
-        public static readonly KeyValue MouseMagneticCursorKey = new KeyValue { FunctionKey = FunctionKeys.MouseMagneticCursor };
-        public static readonly KeyValue MouseMagnifierKey = new KeyValue { FunctionKey = FunctionKeys.MouseMagnifier };
-        public static readonly KeyValue MouseMiddleClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseMiddleClick };
-        public static readonly KeyValue MouseMiddleDownUpKey = new KeyValue { FunctionKey = FunctionKeys.MouseMiddleDownUp };
-        public static readonly KeyValue MouseMoveAndLeftClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseMoveAndLeftClick };
-        public static readonly KeyValue MouseMoveAndLeftDoubleClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseMoveAndLeftDoubleClick };
-        public static readonly KeyValue MouseMoveAndMiddleClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseMoveAndMiddleClick };
-        public static readonly KeyValue MouseMoveAndRightClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseMoveAndRightClick };
-        public static readonly KeyValue MouseRightClickKey = new KeyValue { FunctionKey = FunctionKeys.MouseRightClick };
-        public static readonly KeyValue MouseRightDownUpKey = new KeyValue { FunctionKey = FunctionKeys.MouseRightDownUp };
-        public static readonly KeyValue MoveToBottomKey = new KeyValue { FunctionKey = FunctionKeys.MoveToBottom };
-        public static readonly KeyValue MoveToBottomAndLeftKey = new KeyValue { FunctionKey = FunctionKeys.MoveToBottomAndLeft };
-        public static readonly KeyValue MoveToBottomAndLeftBoundariesKey = new KeyValue { FunctionKey = FunctionKeys.MoveToBottomAndLeftBoundaries };
-        public static readonly KeyValue MoveToBottomAndRightKey = new KeyValue { FunctionKey = FunctionKeys.MoveToBottomAndRight };
-        public static readonly KeyValue MoveToBottomAndRightBoundariesKey = new KeyValue { FunctionKey = FunctionKeys.MoveToBottomAndRightBoundaries };
-        public static readonly KeyValue MoveToBottomBoundaryKey = new KeyValue { FunctionKey = FunctionKeys.MoveToBottomBoundary };
-        public static readonly KeyValue MoveToLeftKey = new KeyValue { FunctionKey = FunctionKeys.MoveToLeft };
-        public static readonly KeyValue MoveToLeftBoundaryKey = new KeyValue { FunctionKey = FunctionKeys.MoveToLeftBoundary };
-        public static readonly KeyValue MoveToRightKey = new KeyValue { FunctionKey = FunctionKeys.MoveToRight };
-        public static readonly KeyValue MoveToRightBoundaryKey = new KeyValue { FunctionKey = FunctionKeys.MoveToRightBoundary };
-        public static readonly KeyValue MoveToTopKey = new KeyValue { FunctionKey = FunctionKeys.MoveToTop };
-        public static readonly KeyValue MoveToTopAndLeftKey = new KeyValue { FunctionKey = FunctionKeys.MoveToTopAndLeft };
-        public static readonly KeyValue MoveToTopAndLeftBoundariesKey = new KeyValue { FunctionKey = FunctionKeys.MoveToTopAndLeftBoundaries };
-        public static readonly KeyValue MoveToTopAndRightKey = new KeyValue { FunctionKey = FunctionKeys.MoveToTopAndRight };
-        public static readonly KeyValue MoveToTopAndRightBoundariesKey = new KeyValue { FunctionKey = FunctionKeys.MoveToTopAndRightBoundaries };
-        public static readonly KeyValue MoveToTopBoundaryKey = new KeyValue { FunctionKey = FunctionKeys.MoveToTopBoundary };
-        public static readonly KeyValue MultiKeySelectionKey = new KeyValue { FunctionKey = FunctionKeys.MultiKeySelectionIsOn };
-        public static readonly KeyValue NextSuggestionsKey = new KeyValue { FunctionKey = FunctionKeys.NextSuggestions };
-        public static readonly KeyValue PreviousSuggestionsKey = new KeyValue { FunctionKey = FunctionKeys.PreviousSuggestions };
-        public static readonly KeyValue RepeatLastMouseActionKey = new KeyValue { FunctionKey = FunctionKeys.RepeatLastMouseAction };
-        public static readonly KeyValue ShrinkFromBottomKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromBottom };
-        public static readonly KeyValue ShrinkFromBottomAndLeftKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromBottomAndLeft };
-        public static readonly KeyValue ShrinkFromBottomAndRightKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromBottomAndRight };
-        public static readonly KeyValue ShrinkFromLeftKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromLeft };
-        public static readonly KeyValue ShrinkFromRightKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromRight };
-        public static readonly KeyValue ShrinkFromTopKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromTop };
-        public static readonly KeyValue ShrinkFromTopAndLeftKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromTopAndLeft };
-        public static readonly KeyValue ShrinkFromTopAndRightKey = new KeyValue { FunctionKey = FunctionKeys.ShrinkFromTopAndRight };
-        public static readonly KeyValue SpeakKey = new KeyValue { FunctionKey = FunctionKeys.Speak };
-        public static readonly KeyValue Suggestion1Key = new KeyValue { FunctionKey = FunctionKeys.Suggestion1 };
-        public static readonly KeyValue Suggestion2Key = new KeyValue { FunctionKey = FunctionKeys.Suggestion2 };
-        public static readonly KeyValue Suggestion3Key = new KeyValue { FunctionKey = FunctionKeys.Suggestion3 };
-        public static readonly KeyValue Suggestion4Key = new KeyValue { FunctionKey = FunctionKeys.Suggestion4 };
-        public static readonly KeyValue Suggestion5Key = new KeyValue { FunctionKey = FunctionKeys.Suggestion5 };
-        public static readonly KeyValue Suggestion6Key = new KeyValue { FunctionKey = FunctionKeys.Suggestion6 };
-        public static readonly KeyValue SleepKey = new KeyValue { FunctionKey = FunctionKeys.Sleep };
+        public static readonly KeyValue CalibrateKey = new KeyValue(FunctionKeys.Calibrate);
+        public static readonly KeyValue CollapseDockKey = new KeyValue(FunctionKeys.CollapseDock);
+        public static readonly KeyValue ExpandDockKey = new KeyValue(FunctionKeys.ExpandDock);
+        public static readonly KeyValue ExpandToBottomKey = new KeyValue(FunctionKeys.ExpandToBottom);
+        public static readonly KeyValue ExpandToBottomAndLeftKey = new KeyValue(FunctionKeys.ExpandToBottomAndLeft);
+        public static readonly KeyValue ExpandToBottomAndRightKey = new KeyValue(FunctionKeys.ExpandToBottomAndRight);
+        public static readonly KeyValue ExpandToLeftKey = new KeyValue(FunctionKeys.ExpandToLeft);
+        public static readonly KeyValue ExpandToRightKey = new KeyValue(FunctionKeys.ExpandToRight);
+        public static readonly KeyValue ExpandToTopKey = new KeyValue(FunctionKeys.ExpandToTop);
+        public static readonly KeyValue ExpandToTopAndLeftKey = new KeyValue(FunctionKeys.ExpandToTopAndLeft);
+        public static readonly KeyValue ExpandToTopAndRightKey = new KeyValue(FunctionKeys.ExpandToTopAndRight);
+        public static readonly KeyValue LeftAltKey = new KeyValue(FunctionKeys.LeftAlt);
+        public static readonly KeyValue LeftCtrlKey = new KeyValue(FunctionKeys.LeftCtrl);
+        public static readonly KeyValue LeftShiftKey = new KeyValue(FunctionKeys.LeftShift);
+        public static readonly KeyValue LeftWinKey = new KeyValue(FunctionKeys.LeftWin);
+        public static readonly KeyValue MouseDragKey = new KeyValue(FunctionKeys.MouseDrag);
+        public static readonly KeyValue MouseLeftClickKey = new KeyValue(FunctionKeys.MouseLeftClick);
+        public static readonly KeyValue MouseLeftDoubleClickKey = new KeyValue(FunctionKeys.MouseLeftDoubleClick);
+        public static readonly KeyValue MouseLeftDownUpKey = new KeyValue(FunctionKeys.MouseLeftDownUp);
+        public static readonly KeyValue MouseMagneticCursorKey = new KeyValue(FunctionKeys.MouseMagneticCursor);
+        public static readonly KeyValue MouseMagnifierKey = new KeyValue(FunctionKeys.MouseMagnifier);
+        public static readonly KeyValue MouseMiddleClickKey = new KeyValue(FunctionKeys.MouseMiddleClick);
+        public static readonly KeyValue MouseMiddleDownUpKey = new KeyValue(FunctionKeys.MouseMiddleDownUp);
+        public static readonly KeyValue MouseMoveAndLeftClickKey = new KeyValue(FunctionKeys.MouseMoveAndLeftClick);
+        public static readonly KeyValue MouseMoveAndLeftDoubleClickKey = new KeyValue(FunctionKeys.MouseMoveAndLeftDoubleClick);
+        public static readonly KeyValue MouseMoveAndMiddleClickKey = new KeyValue(FunctionKeys.MouseMoveAndMiddleClick);
+        public static readonly KeyValue MouseMoveAndRightClickKey = new KeyValue(FunctionKeys.MouseMoveAndRightClick);
+        public static readonly KeyValue MouseRightClickKey = new KeyValue(FunctionKeys.MouseRightClick);
+        public static readonly KeyValue MouseRightDownUpKey = new KeyValue(FunctionKeys.MouseRightDownUp);
+        public static readonly KeyValue MoveToBottomKey = new KeyValue(FunctionKeys.MoveToBottom);
+        public static readonly KeyValue MoveToBottomAndLeftKey = new KeyValue(FunctionKeys.MoveToBottomAndLeft);
+        public static readonly KeyValue MoveToBottomAndLeftBoundariesKey = new KeyValue(FunctionKeys.MoveToBottomAndLeftBoundaries);
+        public static readonly KeyValue MoveToBottomAndRightKey = new KeyValue(FunctionKeys.MoveToBottomAndRight);
+        public static readonly KeyValue MoveToBottomAndRightBoundariesKey = new KeyValue(FunctionKeys.MoveToBottomAndRightBoundaries);
+        public static readonly KeyValue MoveToBottomBoundaryKey = new KeyValue(FunctionKeys.MoveToBottomBoundary);
+        public static readonly KeyValue MoveToLeftKey = new KeyValue(FunctionKeys.MoveToLeft);
+        public static readonly KeyValue MoveToLeftBoundaryKey = new KeyValue(FunctionKeys.MoveToLeftBoundary);
+        public static readonly KeyValue MoveToRightKey = new KeyValue(FunctionKeys.MoveToRight);
+        public static readonly KeyValue MoveToRightBoundaryKey = new KeyValue(FunctionKeys.MoveToRightBoundary);
+        public static readonly KeyValue MoveToTopKey = new KeyValue(FunctionKeys.MoveToTop);
+        public static readonly KeyValue MoveToTopAndLeftKey = new KeyValue(FunctionKeys.MoveToTopAndLeft);
+        public static readonly KeyValue MoveToTopAndLeftBoundariesKey = new KeyValue(FunctionKeys.MoveToTopAndLeftBoundaries);
+        public static readonly KeyValue MoveToTopAndRightKey = new KeyValue(FunctionKeys.MoveToTopAndRight);
+        public static readonly KeyValue MoveToTopAndRightBoundariesKey = new KeyValue(FunctionKeys.MoveToTopAndRightBoundaries);
+        public static readonly KeyValue MoveToTopBoundaryKey = new KeyValue(FunctionKeys.MoveToTopBoundary);
+        public static readonly KeyValue MultiKeySelectionKey = new KeyValue(FunctionKeys.MultiKeySelectionIsOn);
+        public static readonly KeyValue NextSuggestionsKey = new KeyValue(FunctionKeys.NextSuggestions);
+        public static readonly KeyValue PreviousSuggestionsKey = new KeyValue(FunctionKeys.PreviousSuggestions);
+        public static readonly KeyValue RepeatLastMouseActionKey = new KeyValue(FunctionKeys.RepeatLastMouseAction);
+        public static readonly KeyValue ShrinkFromBottomKey = new KeyValue(FunctionKeys.ShrinkFromBottom);
+        public static readonly KeyValue ShrinkFromBottomAndLeftKey = new KeyValue(FunctionKeys.ShrinkFromBottomAndLeft);
+        public static readonly KeyValue ShrinkFromBottomAndRightKey = new KeyValue(FunctionKeys.ShrinkFromBottomAndRight);
+        public static readonly KeyValue ShrinkFromLeftKey = new KeyValue(FunctionKeys.ShrinkFromLeft);
+        public static readonly KeyValue ShrinkFromRightKey = new KeyValue(FunctionKeys.ShrinkFromRight);
+        public static readonly KeyValue ShrinkFromTopKey = new KeyValue(FunctionKeys.ShrinkFromTop);
+        public static readonly KeyValue ShrinkFromTopAndLeftKey = new KeyValue(FunctionKeys.ShrinkFromTopAndLeft);
+        public static readonly KeyValue ShrinkFromTopAndRightKey = new KeyValue(FunctionKeys.ShrinkFromTopAndRight);
+        public static readonly KeyValue SpeakKey = new KeyValue(FunctionKeys.Speak);
+        public static readonly KeyValue Suggestion1Key = new KeyValue(FunctionKeys.Suggestion1);
+        public static readonly KeyValue Suggestion2Key = new KeyValue(FunctionKeys.Suggestion2);
+        public static readonly KeyValue Suggestion3Key = new KeyValue(FunctionKeys.Suggestion3);
+        public static readonly KeyValue Suggestion4Key = new KeyValue(FunctionKeys.Suggestion4);
+        public static readonly KeyValue Suggestion5Key = new KeyValue(FunctionKeys.Suggestion5);
+        public static readonly KeyValue Suggestion6Key = new KeyValue(FunctionKeys.Suggestion6);
+        public static readonly KeyValue SleepKey = new KeyValue(FunctionKeys.Sleep);
 
         private static readonly Dictionary<Languages, List<KeyValue>> multiKeySelectionKeys;
 
@@ -80,7 +80,7 @@ namespace JuliusSweetland.OptiKey.Models
         {
             var defaultList = "abcdefghijklmnopqrstuvwxyz"
                 .ToCharArray()
-                .Select(c => new KeyValue {String = c.ToString(CultureInfo.InvariantCulture)})
+                .Select(c => new KeyValue(c.ToString(CultureInfo.InvariantCulture)))
                 .ToList();
 
             multiKeySelectionKeys = new Dictionary<Languages, List<KeyValue>>
@@ -91,9 +91,9 @@ namespace JuliusSweetland.OptiKey.Models
                 { Languages.FrenchFrance, defaultList }, //Could be customised to include àçéèù
                 { Languages.GermanGermany, defaultList }, //Could be customised to include äöüß
 				{ Languages.RussianRussia, "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
-				                                .ToCharArray()
-				                                .Select(c => new KeyValue { String = c.ToString(CultureInfo.InvariantCulture) })
-				                                .ToList() }
+                                                .ToCharArray()
+                                                .Select(c => new KeyValue (c.ToString(CultureInfo.InvariantCulture) ))
+                                                .ToList() }
             };
         }
 
@@ -161,41 +161,41 @@ namespace JuliusSweetland.OptiKey.Models
             {
                 return new List<KeyValue>
                 {
-                    new KeyValue {FunctionKey = FunctionKeys.LeftCtrl},
-                    new KeyValue {FunctionKey = FunctionKeys.LeftWin},
-                    new KeyValue {FunctionKey = FunctionKeys.LeftAlt},
-                    new KeyValue {FunctionKey = FunctionKeys.F1},
-                    new KeyValue {FunctionKey = FunctionKeys.F2},
-                    new KeyValue {FunctionKey = FunctionKeys.F3},
-                    new KeyValue {FunctionKey = FunctionKeys.F4},
-                    new KeyValue {FunctionKey = FunctionKeys.F5},
-                    new KeyValue {FunctionKey = FunctionKeys.F6},
-                    new KeyValue {FunctionKey = FunctionKeys.F7},
-                    new KeyValue {FunctionKey = FunctionKeys.F8},
-                    new KeyValue {FunctionKey = FunctionKeys.F9},
-                    new KeyValue {FunctionKey = FunctionKeys.F10},
-                    new KeyValue {FunctionKey = FunctionKeys.F11},
-                    new KeyValue {FunctionKey = FunctionKeys.F12},
-                    new KeyValue {FunctionKey = FunctionKeys.PrintScreen},
-                    new KeyValue {FunctionKey = FunctionKeys.ScrollLock},
-                    new KeyValue {FunctionKey = FunctionKeys.NumberLock},
-                    new KeyValue {FunctionKey = FunctionKeys.Menu},
-                    new KeyValue {FunctionKey = FunctionKeys.ArrowUp},
-                    new KeyValue {FunctionKey = FunctionKeys.ArrowLeft},
-                    new KeyValue {FunctionKey = FunctionKeys.ArrowRight},
-                    new KeyValue {FunctionKey = FunctionKeys.ArrowDown},
-                    new KeyValue {FunctionKey = FunctionKeys.Break},
-                    new KeyValue {FunctionKey = FunctionKeys.Insert},
-                    new KeyValue {FunctionKey = FunctionKeys.Home},
-                    new KeyValue {FunctionKey = FunctionKeys.PgUp},
-                    new KeyValue {FunctionKey = FunctionKeys.PgDn},
-                    new KeyValue {FunctionKey = FunctionKeys.Delete},
-                    new KeyValue {FunctionKey = FunctionKeys.End},
-                    new KeyValue {FunctionKey = FunctionKeys.Escape},
-                    new KeyValue {FunctionKey = FunctionKeys.SelectAll},
-                    new KeyValue {FunctionKey = FunctionKeys.Cut},
-                    new KeyValue {FunctionKey = FunctionKeys.Copy},
-                    new KeyValue {FunctionKey = FunctionKeys.Paste}
+                    new KeyValue(FunctionKeys.LeftCtrl),
+                    new KeyValue(FunctionKeys.LeftWin),
+                    new KeyValue(FunctionKeys.LeftAlt),
+                    new KeyValue(FunctionKeys.F1),
+                    new KeyValue(FunctionKeys.F2),
+                    new KeyValue(FunctionKeys.F3),
+                    new KeyValue(FunctionKeys.F4),
+                    new KeyValue(FunctionKeys.F5),
+                    new KeyValue(FunctionKeys.F6),
+                    new KeyValue(FunctionKeys.F7),
+                    new KeyValue(FunctionKeys.F8),
+                    new KeyValue(FunctionKeys.F9),
+                    new KeyValue(FunctionKeys.F10),
+                    new KeyValue(FunctionKeys.F11),
+                    new KeyValue(FunctionKeys.F12),
+                    new KeyValue(FunctionKeys.PrintScreen),
+                    new KeyValue(FunctionKeys.ScrollLock),
+                    new KeyValue(FunctionKeys.NumberLock),
+                    new KeyValue(FunctionKeys.Menu),
+                    new KeyValue(FunctionKeys.ArrowUp),
+                    new KeyValue(FunctionKeys.ArrowLeft),
+                    new KeyValue(FunctionKeys.ArrowRight),
+                    new KeyValue(FunctionKeys.ArrowDown),
+                    new KeyValue(FunctionKeys.Break),
+                    new KeyValue(FunctionKeys.Insert),
+                    new KeyValue(FunctionKeys.Home),
+                    new KeyValue(FunctionKeys.PgUp),
+                    new KeyValue(FunctionKeys.PgDn),
+                    new KeyValue(FunctionKeys.Delete),
+                    new KeyValue(FunctionKeys.End),
+                    new KeyValue(FunctionKeys.Escape),
+                    new KeyValue(FunctionKeys.SelectAll),
+                    new KeyValue(FunctionKeys.Cut),
+                    new KeyValue(FunctionKeys.Copy),
+                    new KeyValue(FunctionKeys.Paste)
                 };
             }
         }

--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -8,9 +8,34 @@ namespace JuliusSweetland.OptiKey.Models
 {
     public static class KeyValues
     {
+        public static readonly KeyValue AddToDictionaryKey = new KeyValue(FunctionKeys.AddToDictionary);
+        public static readonly KeyValue AlphaKeyboardKey = new KeyValue(FunctionKeys.AlphaKeyboard);
+        public static readonly KeyValue Diacritic1KeyboardKey = new KeyValue(FunctionKeys.Diacritic1Keyboard);
+        public static readonly KeyValue Diacritic2KeyboardKey = new KeyValue(FunctionKeys.Diacritic2Keyboard);
+        public static readonly KeyValue Diacritic3KeyboardKey = new KeyValue(FunctionKeys.Diacritic3Keyboard);
+        public static readonly KeyValue ArrowDownKey = new KeyValue(FunctionKeys.ArrowDown);
+        public static readonly KeyValue ArrowLeftKey = new KeyValue(FunctionKeys.ArrowLeft);
+        public static readonly KeyValue ArrowRightKey = new KeyValue(FunctionKeys.ArrowRight);
+        public static readonly KeyValue ArrowUpKey = new KeyValue(FunctionKeys.ArrowUp);
+        public static readonly KeyValue BackFromKeyboardKey = new KeyValue(FunctionKeys.BackFromKeyboard);
+        public static readonly KeyValue BackManyKey = new KeyValue(FunctionKeys.BackMany);
+        public static readonly KeyValue BackOneKey = new KeyValue(FunctionKeys.BackOne);
+        public static readonly KeyValue BreakKey = new KeyValue(FunctionKeys.Break);
         public static readonly KeyValue CalibrateKey = new KeyValue(FunctionKeys.Calibrate);
+        public static readonly KeyValue ClearScratchpadKey = new KeyValue(FunctionKeys.ClearScratchpad);
         public static readonly KeyValue CollapseDockKey = new KeyValue(FunctionKeys.CollapseDock);
-        public static readonly KeyValue ExpandDockKey = new KeyValue(FunctionKeys.ExpandDock);
+        public static readonly KeyValue ConversationAlphaKeyboardKey = new KeyValue(FunctionKeys.ConversationAlphaKeyboard);
+        public static readonly KeyValue ConversationNumericAndSymbolsKeyboardKey = new KeyValue(FunctionKeys.ConversationNumericAndSymbolsKeyboard);
+        public static readonly KeyValue CopyKey = new KeyValue(FunctionKeys.Copy);
+        public static readonly KeyValue Currencies1KeyboardKey = new KeyValue(FunctionKeys.Currencies1Keyboard);
+        public static readonly KeyValue Currencies2KeyboardKey = new KeyValue(FunctionKeys.Currencies2Keyboard);
+        public static readonly KeyValue CutKey = new KeyValue(FunctionKeys.Cut);
+        public static readonly KeyValue DecreaseOpacityKey = new KeyValue(FunctionKeys.DecreaseOpacity);
+        public static readonly KeyValue DeleteKey = new KeyValue(FunctionKeys.Delete);
+        public static readonly KeyValue EndKey = new KeyValue(FunctionKeys.End);
+        public static readonly KeyValue EnglishCanadaKey = new KeyValue(FunctionKeys.EnglishCanada);
+        public static readonly KeyValue EnglishUKKey = new KeyValue(FunctionKeys.EnglishUK);
+        public static readonly KeyValue EnglishUSKey = new KeyValue(FunctionKeys.EnglishUS);
         public static readonly KeyValue ExpandToBottomKey = new KeyValue(FunctionKeys.ExpandToBottom);
         public static readonly KeyValue ExpandToBottomAndLeftKey = new KeyValue(FunctionKeys.ExpandToBottomAndLeft);
         public static readonly KeyValue ExpandToBottomAndRightKey = new KeyValue(FunctionKeys.ExpandToBottomAndRight);
@@ -19,24 +44,60 @@ namespace JuliusSweetland.OptiKey.Models
         public static readonly KeyValue ExpandToTopKey = new KeyValue(FunctionKeys.ExpandToTop);
         public static readonly KeyValue ExpandToTopAndLeftKey = new KeyValue(FunctionKeys.ExpandToTopAndLeft);
         public static readonly KeyValue ExpandToTopAndRightKey = new KeyValue(FunctionKeys.ExpandToTopAndRight);
+        public static readonly KeyValue EscapeKey = new KeyValue(FunctionKeys.Escape);
+        public static readonly KeyValue ExpandDockKey = new KeyValue(FunctionKeys.ExpandDock);
+        public static readonly KeyValue F1Key = new KeyValue(FunctionKeys.F1);
+        public static readonly KeyValue F10Key = new KeyValue(FunctionKeys.F10);
+        public static readonly KeyValue F11Key = new KeyValue(FunctionKeys.F11);
+        public static readonly KeyValue F12Key = new KeyValue(FunctionKeys.F12);
+        public static readonly KeyValue F2Key = new KeyValue(FunctionKeys.F2);
+        public static readonly KeyValue F3Key = new KeyValue(FunctionKeys.F3);
+        public static readonly KeyValue F4Key = new KeyValue(FunctionKeys.F4);
+        public static readonly KeyValue F5Key = new KeyValue(FunctionKeys.F5);
+        public static readonly KeyValue F6Key = new KeyValue(FunctionKeys.F6);
+        public static readonly KeyValue F7Key = new KeyValue(FunctionKeys.F7);
+        public static readonly KeyValue F8Key = new KeyValue(FunctionKeys.F8);
+        public static readonly KeyValue F9Key = new KeyValue(FunctionKeys.F9);
+        public static readonly KeyValue FrenchFranceKey = new KeyValue(FunctionKeys.FrenchFrance);
+        public static readonly KeyValue GermanGermanyKey = new KeyValue(FunctionKeys.GermanGermany);
+        public static readonly KeyValue HomeKey = new KeyValue(FunctionKeys.Home);
+        public static readonly KeyValue IncreaseOpacityKey = new KeyValue(FunctionKeys.IncreaseOpacity);
+        public static readonly KeyValue InsertKey = new KeyValue(FunctionKeys.Insert);
+        public static readonly KeyValue LanguageKey = new KeyValue(FunctionKeys.Language);
         public static readonly KeyValue LeftAltKey = new KeyValue(FunctionKeys.LeftAlt);
         public static readonly KeyValue LeftCtrlKey = new KeyValue(FunctionKeys.LeftCtrl);
         public static readonly KeyValue LeftShiftKey = new KeyValue(FunctionKeys.LeftShift);
         public static readonly KeyValue LeftWinKey = new KeyValue(FunctionKeys.LeftWin);
+        public static readonly KeyValue MenuKey = new KeyValue(FunctionKeys.Menu);
+        public static readonly KeyValue MenuKeyboardKey = new KeyValue(FunctionKeys.MenuKeyboard);
+        public static readonly KeyValue MinimiseKey = new KeyValue(FunctionKeys.Minimise);
         public static readonly KeyValue MouseDragKey = new KeyValue(FunctionKeys.MouseDrag);
+        public static readonly KeyValue MouseKeyboardKey = new KeyValue(FunctionKeys.MouseKeyboard);
         public static readonly KeyValue MouseLeftClickKey = new KeyValue(FunctionKeys.MouseLeftClick);
         public static readonly KeyValue MouseLeftDoubleClickKey = new KeyValue(FunctionKeys.MouseLeftDoubleClick);
         public static readonly KeyValue MouseLeftDownUpKey = new KeyValue(FunctionKeys.MouseLeftDownUp);
         public static readonly KeyValue MouseMagneticCursorKey = new KeyValue(FunctionKeys.MouseMagneticCursor);
-        public static readonly KeyValue MouseMagnifierKey = new KeyValue(FunctionKeys.MouseMagnifier);
         public static readonly KeyValue MouseMiddleClickKey = new KeyValue(FunctionKeys.MouseMiddleClick);
         public static readonly KeyValue MouseMiddleDownUpKey = new KeyValue(FunctionKeys.MouseMiddleDownUp);
+        public static readonly KeyValue MouseMoveAmountInPixelsKey = new KeyValue(FunctionKeys.MouseMoveAmountInPixels);
         public static readonly KeyValue MouseMoveAndLeftClickKey = new KeyValue(FunctionKeys.MouseMoveAndLeftClick);
         public static readonly KeyValue MouseMoveAndLeftDoubleClickKey = new KeyValue(FunctionKeys.MouseMoveAndLeftDoubleClick);
         public static readonly KeyValue MouseMoveAndMiddleClickKey = new KeyValue(FunctionKeys.MouseMoveAndMiddleClick);
         public static readonly KeyValue MouseMoveAndRightClickKey = new KeyValue(FunctionKeys.MouseMoveAndRightClick);
+        public static readonly KeyValue MouseMoveToKey = new KeyValue(FunctionKeys.MouseMoveTo);
+        public static readonly KeyValue MouseMoveToBottomKey = new KeyValue(FunctionKeys.MouseMoveToBottom);
+        public static readonly KeyValue MouseMoveToLeftKey = new KeyValue(FunctionKeys.MouseMoveToLeft);
+        public static readonly KeyValue MouseMoveToRightKey = new KeyValue(FunctionKeys.MouseMoveToRight);
+        public static readonly KeyValue MouseMoveToTopKey = new KeyValue(FunctionKeys.MouseMoveToTop);
         public static readonly KeyValue MouseRightClickKey = new KeyValue(FunctionKeys.MouseRightClick);
         public static readonly KeyValue MouseRightDownUpKey = new KeyValue(FunctionKeys.MouseRightDownUp);
+        public static readonly KeyValue MouseScrollAmountInClicksKey = new KeyValue(FunctionKeys.MouseScrollAmountInClicks);
+        public static readonly KeyValue MouseMoveAndScrollToBottomKey = new KeyValue(FunctionKeys.MouseMoveAndScrollToBottom);
+        public static readonly KeyValue MouseMoveAndScrollToLeftKey = new KeyValue(FunctionKeys.MouseMoveAndScrollToLeft);
+        public static readonly KeyValue MouseMoveAndScrollToRightKey = new KeyValue(FunctionKeys.MouseMoveAndScrollToRight);
+        public static readonly KeyValue MouseMoveAndScrollToTopKey = new KeyValue(FunctionKeys.MouseMoveAndScrollToTop);
+        public static readonly KeyValue MouseMagnifierKey = new KeyValue(FunctionKeys.MouseMagnifier);
+        public static readonly KeyValue MoveAndResizeAdjustmentAmountKey = new KeyValue(FunctionKeys.MoveAndResizeAdjustmentAmount);
         public static readonly KeyValue MoveToBottomKey = new KeyValue(FunctionKeys.MoveToBottom);
         public static readonly KeyValue MoveToBottomAndLeftKey = new KeyValue(FunctionKeys.MoveToBottomAndLeft);
         public static readonly KeyValue MoveToBottomAndLeftBoundariesKey = new KeyValue(FunctionKeys.MoveToBottomAndLeftBoundaries);
@@ -53,10 +114,24 @@ namespace JuliusSweetland.OptiKey.Models
         public static readonly KeyValue MoveToTopAndRightKey = new KeyValue(FunctionKeys.MoveToTopAndRight);
         public static readonly KeyValue MoveToTopAndRightBoundariesKey = new KeyValue(FunctionKeys.MoveToTopAndRightBoundaries);
         public static readonly KeyValue MoveToTopBoundaryKey = new KeyValue(FunctionKeys.MoveToTopBoundary);
-        public static readonly KeyValue MultiKeySelectionKey = new KeyValue(FunctionKeys.MultiKeySelectionIsOn);
+        public static readonly KeyValue MultiKeySelectionIsOnKey = new KeyValue(FunctionKeys.MultiKeySelectionIsOn);
         public static readonly KeyValue NextSuggestionsKey = new KeyValue(FunctionKeys.NextSuggestions);
+        public static readonly KeyValue NoQuestionResultKey = new KeyValue(FunctionKeys.NoQuestionResult);
+        public static readonly KeyValue NumberLockKey = new KeyValue(FunctionKeys.NumberLock);
+        public static readonly KeyValue NumericAndSymbols1KeyboardKey = new KeyValue(FunctionKeys.NumericAndSymbols1Keyboard);
+        public static readonly KeyValue NumericAndSymbols2KeyboardKey = new KeyValue(FunctionKeys.NumericAndSymbols2Keyboard);
+        public static readonly KeyValue NumericAndSymbols3KeyboardKey = new KeyValue(FunctionKeys.NumericAndSymbols3Keyboard);
+        public static readonly KeyValue PasteKey = new KeyValue(FunctionKeys.Paste);
+        public static readonly KeyValue PgDnKey = new KeyValue(FunctionKeys.PgDn);
+        public static readonly KeyValue PgUpKey = new KeyValue(FunctionKeys.PgUp);
+        public static readonly KeyValue PhysicalKeysKeyboardKey = new KeyValue(FunctionKeys.PhysicalKeysKeyboard);
         public static readonly KeyValue PreviousSuggestionsKey = new KeyValue(FunctionKeys.PreviousSuggestions);
+        public static readonly KeyValue PrintScreenKey = new KeyValue(FunctionKeys.PrintScreen);
+        public static readonly KeyValue QuitKey = new KeyValue(FunctionKeys.Quit);
         public static readonly KeyValue RepeatLastMouseActionKey = new KeyValue(FunctionKeys.RepeatLastMouseAction);
+        public static readonly KeyValue RussianRussiaKey = new KeyValue(FunctionKeys.RussianRussia);
+        public static readonly KeyValue ScrollLockKey = new KeyValue(FunctionKeys.ScrollLock);
+        public static readonly KeyValue SelectAllKey = new KeyValue(FunctionKeys.SelectAll);
         public static readonly KeyValue ShrinkFromBottomKey = new KeyValue(FunctionKeys.ShrinkFromBottom);
         public static readonly KeyValue ShrinkFromBottomAndLeftKey = new KeyValue(FunctionKeys.ShrinkFromBottomAndLeft);
         public static readonly KeyValue ShrinkFromBottomAndRightKey = new KeyValue(FunctionKeys.ShrinkFromBottomAndRight);
@@ -65,6 +140,8 @@ namespace JuliusSweetland.OptiKey.Models
         public static readonly KeyValue ShrinkFromTopKey = new KeyValue(FunctionKeys.ShrinkFromTop);
         public static readonly KeyValue ShrinkFromTopAndLeftKey = new KeyValue(FunctionKeys.ShrinkFromTopAndLeft);
         public static readonly KeyValue ShrinkFromTopAndRightKey = new KeyValue(FunctionKeys.ShrinkFromTopAndRight);
+        public static readonly KeyValue SizeAndPositionKeyboardKey = new KeyValue(FunctionKeys.SizeAndPositionKeyboard);
+        public static readonly KeyValue SleepKey = new KeyValue(FunctionKeys.Sleep);
         public static readonly KeyValue SpeakKey = new KeyValue(FunctionKeys.Speak);
         public static readonly KeyValue Suggestion1Key = new KeyValue(FunctionKeys.Suggestion1);
         public static readonly KeyValue Suggestion2Key = new KeyValue(FunctionKeys.Suggestion2);
@@ -72,7 +149,8 @@ namespace JuliusSweetland.OptiKey.Models
         public static readonly KeyValue Suggestion4Key = new KeyValue(FunctionKeys.Suggestion4);
         public static readonly KeyValue Suggestion5Key = new KeyValue(FunctionKeys.Suggestion5);
         public static readonly KeyValue Suggestion6Key = new KeyValue(FunctionKeys.Suggestion6);
-        public static readonly KeyValue SleepKey = new KeyValue(FunctionKeys.Sleep);
+        public static readonly KeyValue YesQuestionResultKey = new KeyValue(FunctionKeys.YesQuestionResult);
+
 
         private static readonly Dictionary<Languages, List<KeyValue>> multiKeySelectionKeys;
 
@@ -111,7 +189,7 @@ namespace JuliusSweetland.OptiKey.Models
                     MouseMagnifierKey,
                     MouseMiddleDownUpKey,
                     MouseRightDownUpKey,
-                    MultiKeySelectionKey
+                    MultiKeySelectionIsOnKey
                 };
             }
         }
@@ -128,7 +206,7 @@ namespace JuliusSweetland.OptiKey.Models
                     LeftWinKey,
                     MouseMagneticCursorKey,
                     MouseMagnifierKey,
-                    MultiKeySelectionKey,
+                    MultiKeySelectionIsOnKey,
                     SleepKey
                 };
             }

--- a/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
@@ -145,7 +145,7 @@ namespace JuliusSweetland.OptiKey.Services
                             Log.Debug("Selection mode is KEY and the key on which the trigger occurred is enabled.");
 
                             if (MultiKeySelectionSupported
-                                && keyStateService.KeyDownStates[KeyValues.MultiKeySelectionKey].Value.IsDownOrLockedDown()
+                                && keyStateService.KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value.IsDownOrLockedDown()
                                 && triggerSignal.PointAndKeyValue.Value.KeyValue != null
                                 && KeyValues.MultiKeySelectionKeys.Contains(triggerSignal.PointAndKeyValue.Value.KeyValue.Value))
                             {

--- a/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
@@ -111,7 +111,7 @@ namespace JuliusSweetland.OptiKey.Services
 
         private void SetMultiKeySelectionKeyStateFromSetting()
         {
-            KeyDownStates[KeyValues.MultiKeySelectionKey].Value =
+            KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value =
                 Settings.Default.MultiKeySelectionEnabled &&
                 ((SimulateKeyStrokes && Settings.Default.MultiKeySelectionLockedDownWhenSimulatingKeyStrokes)
                 || (!SimulateKeyStrokes && Settings.Default.MultiKeySelectionLockedDownWhenNotSimulatingKeyStrokes))
@@ -126,7 +126,7 @@ namespace JuliusSweetland.OptiKey.Services
             Settings.Default.OnPropertyChanges(s => s.MultiKeySelectionEnabled).Where(mkse => !mkse).Subscribe(_ =>
             {
                 //Release multi-key selection key if multi-key selection is disabled from the settings
-                KeyDownStates[KeyValues.MultiKeySelectionKey].Value = Enums.KeyDownStates.Up;
+                KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.Up;
             });
         }
 
@@ -194,17 +194,17 @@ namespace JuliusSweetland.OptiKey.Services
             KeyDownStates[KeyValues.MouseMagnifierKey].OnPropertyChanges(s => s.Value).Subscribe(value => 
                 Settings.Default.MouseMagnifierLockedDown = KeyDownStates[KeyValues.MouseMagnifierKey].Value == Enums.KeyDownStates.LockedDown);
 
-            KeyDownStates[KeyValues.MultiKeySelectionKey].OnPropertyChanges(s => s.Value).Subscribe(value =>
+            KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].OnPropertyChanges(s => s.Value).Subscribe(value =>
             {
                 if (SimulateKeyStrokes)
                 {
                     Settings.Default.MultiKeySelectionLockedDownWhenSimulatingKeyStrokes = 
-                        KeyDownStates[KeyValues.MultiKeySelectionKey].Value == Enums.KeyDownStates.LockedDown;
+                        KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value == Enums.KeyDownStates.LockedDown;
                 }
                 else
                 {
                     Settings.Default.MultiKeySelectionLockedDownWhenNotSimulatingKeyStrokes = 
-                        KeyDownStates[KeyValues.MultiKeySelectionKey].Value == Enums.KeyDownStates.LockedDown;
+                        KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value == Enums.KeyDownStates.LockedDown;
                 }
             });
 
@@ -217,17 +217,17 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.Info("CalculateMultiKeySelectionSupported called.");
 
-            if (KeyDownStates[KeyValues.MultiKeySelectionKey].Value.IsDownOrLockedDown()
+            if (KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value.IsDownOrLockedDown()
                 && KeyValues.KeysWhichPreventTextCaptureIfDownOrLocked.Any(kv => KeyDownStates[kv].Value.IsDownOrLockedDown()))
             {
                 Log.Info("A key which prevents text capture is down - toggling MultiKeySelectionIsOn to false.");
 
                 //Automatically turn multi-key capture back on again when appropriate if it is currently locked down (if it is just down then let it go)
                 turnOnMultiKeySelectionWhenKeysWhichPreventTextCaptureAreReleased =
-                    KeyDownStates[KeyValues.MultiKeySelectionKey].Value == Enums.KeyDownStates.LockedDown;
+                    KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value == Enums.KeyDownStates.LockedDown;
 
-                KeyDownStates[KeyValues.MultiKeySelectionKey].Value = Enums.KeyDownStates.Up;
-                if (fireKeySelectionEvent != null) fireKeySelectionEvent(KeyValues.MultiKeySelectionKey);
+                KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.Up;
+                if (fireKeySelectionEvent != null) fireKeySelectionEvent(KeyValues.MultiKeySelectionIsOnKey);
             }
             else if (turnOnMultiKeySelectionWhenKeysWhichPreventTextCaptureAreReleased
                 && !KeyValues.KeysWhichPreventTextCaptureIfDownOrLocked.Any(kv => KeyDownStates[kv].Value.IsDownOrLockedDown())
@@ -235,8 +235,8 @@ namespace JuliusSweetland.OptiKey.Services
             {
                 Log.Info("No keys which prevents text capture is down - returing setting MultiKeySelectionIsOn to true.");
 
-                KeyDownStates[KeyValues.MultiKeySelectionKey].Value = Enums.KeyDownStates.LockedDown;
-                if (fireKeySelectionEvent != null) fireKeySelectionEvent(KeyValues.MultiKeySelectionKey);
+                KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.LockedDown;
+                if (fireKeySelectionEvent != null) fireKeySelectionEvent(KeyValues.MultiKeySelectionIsOnKey);
                 turnOnMultiKeySelectionWhenKeysWhichPreventTextCaptureAreReleased = false;
             }
         }

--- a/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
@@ -32,7 +32,7 @@ namespace JuliusSweetland.OptiKey.Services
         private bool suppressNextAutoSpace = true;
         private bool keyboardIsShiftAware;
         private bool shiftStateSetAutomatically;
-        
+
         #endregion
 
         #region Ctor
@@ -146,7 +146,7 @@ namespace JuliusSweetland.OptiKey.Services
                             //Removing more than one character - only decrement removed string
                             dictionaryService.DecrementEntryUsageCount(Text.Substring(Text.Length - backOneCount, backOneCount).Trim());
                         }
-                        else if(!string.IsNullOrEmpty(lastTextChange)
+                        else if (!string.IsNullOrEmpty(lastTextChange)
                             && lastTextChange.Length == 1
                             && !char.IsWhiteSpace(lastTextChange[0]))
                         {
@@ -223,7 +223,7 @@ namespace JuliusSweetland.OptiKey.Services
 
                         //If the key cannot be pressed or locked down (these are handled in 
                         //ReactToPublishableKeyDownStateChanges) then publish it and release unlocked keys
-                        var keyValue = new KeyValue { FunctionKey = functionKey };
+                        var keyValue = new KeyValue(functionKey);
                         if (!KeyValues.KeysWhichCanBePressedDown.Contains(keyValue)
                             && !KeyValues.KeysWhichCanBeLockedDown.Contains(keyValue))
                         {
@@ -249,7 +249,7 @@ namespace JuliusSweetland.OptiKey.Services
 
         public void ProcessMultiKeyTextAndSuggestions(List<string> captureAndSuggestions)
         {
-            Log.DebugFormat("Processing {0} captured multi-key selection results", 
+            Log.DebugFormat("Processing {0} captured multi-key selection results",
                 captureAndSuggestions != null ? captureAndSuggestions.Count : 0);
 
             if (captureAndSuggestions == null || !captureAndSuggestions.Any()) return;
@@ -326,13 +326,13 @@ namespace JuliusSweetland.OptiKey.Services
                 if (!string.IsNullOrEmpty(textBeforeCaptureText))
                 {
                     var previousInProgressWord = textBeforeCaptureText.InProgressWord(textBeforeCaptureText.Length);
-                    dictionaryService.DecrementEntryUsageCount(previousInProgressWord);    
+                    dictionaryService.DecrementEntryUsageCount(previousInProgressWord);
                 }
 
                 if (!string.IsNullOrEmpty(Text))
                 {
                     var currentInProgressWord = Text.InProgressWord(Text.Length);
-                    dictionaryService.IncrementEntryUsageCount(currentInProgressWord);    
+                    dictionaryService.IncrementEntryUsageCount(currentInProgressWord);
                 }
             }
 
@@ -542,7 +542,7 @@ namespace JuliusSweetland.OptiKey.Services
                             .Take(Settings.Default.MaxDictionaryMatchesOrSuggestions)
                             .ToList();
 
-                        Log.DebugFormat("{0} suggestions generated (possibly capped to {1} by MaxDictionaryMatchesOrSuggestions setting)", 
+                        Log.DebugFormat("{0} suggestions generated (possibly capped to {1} by MaxDictionaryMatchesOrSuggestions setting)",
                             suggestions.Count(), Settings.Default.MaxDictionaryMatchesOrSuggestions);
 
                         //Correctly case auto complete suggestions
@@ -584,7 +584,7 @@ namespace JuliusSweetland.OptiKey.Services
                         return;
                     }
                 }
-                
+
                 ClearSuggestions();
             }
         }
@@ -599,7 +599,7 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.DebugFormat("Modifying {0} suggestions.", suggestions != null ? suggestions.Count : 0);
 
-            if(suggestions == null || !suggestions.Any()) return null;
+            if (suggestions == null || !suggestions.Any()) return null;
 
             var modifiedSuggestions = suggestions
                 .Select(ModifyText)
@@ -620,7 +620,7 @@ namespace JuliusSweetland.OptiKey.Services
                 ? suggestions
                 : null;
         }
-        
+
         private void PublishKeyPress(FunctionKeys functionKey)
         {
             if (keyStateService.SimulateKeyStrokes)
@@ -682,7 +682,7 @@ namespace JuliusSweetland.OptiKey.Services
                 if (vkKeyScan != -1)
                 {
                     Log.InfoFormat("Publishing '{0}' => as virtual key code {1}(0x{1:X}){2}{3}{4} (using VkKeyScanEx with keyboard layout:{5})",
-                        character.ConvertEscapedCharToLiteral(), vkCode, shift ? "+SHIFT" : null, 
+                        character.ConvertEscapedCharToLiteral(), vkCode, shift ? "+SHIFT" : null,
                         ctrl ? "+CTRL" : null, alt ? "+ALT" : null, keyboardCulture);
 
                     bool releaseShift = false;
@@ -724,7 +724,7 @@ namespace JuliusSweetland.OptiKey.Services
                 }
                 else
                 {
-                    Log.InfoFormat("No virtual key code found for '{0}' so publishing as text (keyboard:{1})", 
+                    Log.InfoFormat("No virtual key code found for '{0}' so publishing as text (keyboard:{1})",
                         character.ConvertEscapedCharToLiteral(), keyboardCulture);
                     publishService.TypeText(character.ToString());
                 }

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Output.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Output.xaml
@@ -41,10 +41,8 @@
         <controls:Key Grid.Row="0" Grid.Column="0"
                       SymbolGeometry="{StaticResource SuggestionLeftIcon}"
                       Text="{x:Static resx:Resources.PREV}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PreviousSuggestions}" />
-            </controls:Key.Value>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PreviousSuggestions}">
         </controls:Key>
         <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3">
             <Grid.ColumnDefinitions>
@@ -53,7 +51,8 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <controls:Key Grid.Row="0" Grid.Column="0" SharedSizeGroup="KeyWithSuggestion" Case="None">
+            <controls:Key Grid.Row="0" Grid.Column="0" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static enums:FunctionKeys.Suggestion1}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -66,11 +65,9 @@
                         </Binding>
                     </MultiBinding>
                 </controls:Key.Text>
-                <controls:Key.Value>
-                    <models:KeyValue FunctionKey="Suggestion1" />
-                </controls:Key.Value>
             </controls:Key>
-            <controls:Key Grid.Row="0" Grid.Column="1" SharedSizeGroup="KeyWithSuggestion" Case="None">
+            <controls:Key Grid.Row="0" Grid.Column="1" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static enums:FunctionKeys.Suggestion2}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -83,11 +80,9 @@
                         </Binding>
                     </MultiBinding>
                 </controls:Key.Text>
-                <controls:Key.Value>
-                    <models:KeyValue FunctionKey="Suggestion2" />
-                </controls:Key.Value>
             </controls:Key>
-            <controls:Key Grid.Row="0" Grid.Column="2" SharedSizeGroup="KeyWithSuggestion" Case="None">
+            <controls:Key Grid.Row="0" Grid.Column="2" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static enums:FunctionKeys.Suggestion3}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -100,11 +95,9 @@
                         </Binding>
                     </MultiBinding>
                 </controls:Key.Text>
-                <controls:Key.Value>
-                    <models:KeyValue FunctionKey="Suggestion3" />
-                </controls:Key.Value>
             </controls:Key>
-            <controls:Key Grid.Row="0" Grid.Column="3" SharedSizeGroup="KeyWithSuggestion" Case="None">
+            <controls:Key Grid.Row="0" Grid.Column="3" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static enums:FunctionKeys.Suggestion4}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -117,53 +110,35 @@
                         </Binding>
                     </MultiBinding>
                 </controls:Key.Text>
-                <controls:Key.Value>
-                    <models:KeyValue FunctionKey="Suggestion4" />
-                </controls:Key.Value>
             </controls:Key>
         </Grid>
         <controls:Key Grid.Row="0" Grid.Column="4"
                       SymbolGeometry="{StaticResource SuggestionRightIcon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NextSuggestions}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                          Value="{x:Static enums:FunctionKeys.NextSuggestions}"/>
 
         <controls:Key Grid.Row="1" Grid.Column="0"
                       SymbolGeometry="{StaticResource AddToDictionaryIcon}" 
                       Text="{x:Static resx:Resources.ADD_TO_DICTIONARY_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AddToDictionary}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AddToDictionary}"/>
         <controls:Key Grid.Row="1" Grid.Column="1"
                       SymbolGeometry="{StaticResource ClearIcon}" 
                       Text="{x:Static resx:Resources.CLEAR}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ClearScratchpad}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ClearScratchpad}"/>
         <controls:Scratchpad Grid.Row="1" Grid.Column="2"
                              Text="{Binding DataContext.KeyboardOutputService.Text, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=OneWay}" />
         <controls:Key Grid.Row="1" Grid.Column="3"
                       SymbolGeometry="{StaticResource SpeakIcon}" 
                       Text="{x:Static resx:Resources.SPEAK}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Speak}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Speak}"/>
         <controls:Key Grid.Row="1" Grid.Column="4"
                       SymbolGeometry="{StaticResource SleepIcon}"
                       Text="{x:Static resx:Resources.SLEEP}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Sleep}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Sleep}"/>
     </Grid>
 </UserControl>

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Output.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Output.xaml
@@ -6,9 +6,8 @@
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
              xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-             xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-             xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
              xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+             xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     
@@ -42,7 +41,7 @@
                       SymbolGeometry="{StaticResource SuggestionLeftIcon}"
                       Text="{x:Static resx:Resources.PREV}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PreviousSuggestions}">
+                      Value="{x:Static models:KeyValues.PreviousSuggestionsKey}">
         </controls:Key>
         <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3">
             <Grid.ColumnDefinitions>
@@ -52,7 +51,7 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <controls:Key Grid.Row="0" Grid.Column="0" SharedSizeGroup="KeyWithSuggestion" Case="None"
-                          Value="{x:Static enums:FunctionKeys.Suggestion1}">
+                          Value="{x:Static models:KeyValues.Suggestion1Key}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -67,7 +66,7 @@
                 </controls:Key.Text>
             </controls:Key>
             <controls:Key Grid.Row="0" Grid.Column="1" SharedSizeGroup="KeyWithSuggestion" Case="None"
-                          Value="{x:Static enums:FunctionKeys.Suggestion2}">
+                          Value="{x:Static models:KeyValues.Suggestion2Key}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -82,7 +81,7 @@
                 </controls:Key.Text>
             </controls:Key>
             <controls:Key Grid.Row="0" Grid.Column="2" SharedSizeGroup="KeyWithSuggestion" Case="None"
-                          Value="{x:Static enums:FunctionKeys.Suggestion3}">
+                          Value="{x:Static models:KeyValues.Suggestion3Key}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -97,7 +96,7 @@
                 </controls:Key.Text>
             </controls:Key>
             <controls:Key Grid.Row="0" Grid.Column="3" SharedSizeGroup="KeyWithSuggestion" Case="None"
-                          Value="{x:Static enums:FunctionKeys.Suggestion4}">
+                          Value="{x:Static models:KeyValues.Suggestion4Key}">
                 <controls:Key.Text>
                     <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
                         <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
@@ -116,29 +115,29 @@
                       SymbolGeometry="{StaticResource SuggestionRightIcon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                          Value="{x:Static enums:FunctionKeys.NextSuggestions}"/>
+                          Value="{x:Static models:KeyValues.NextSuggestionsKey}"/>
 
         <controls:Key Grid.Row="1" Grid.Column="0"
                       SymbolGeometry="{StaticResource AddToDictionaryIcon}" 
                       Text="{x:Static resx:Resources.ADD_TO_DICTIONARY_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AddToDictionary}"/>
+                      Value="{x:Static models:KeyValues.AddToDictionaryKey}"/>
         <controls:Key Grid.Row="1" Grid.Column="1"
                       SymbolGeometry="{StaticResource ClearIcon}" 
                       Text="{x:Static resx:Resources.CLEAR}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ClearScratchpad}"/>
+                      Value="{x:Static models:KeyValues.ClearScratchpadKey}"/>
         <controls:Scratchpad Grid.Row="1" Grid.Column="2"
                              Text="{Binding DataContext.KeyboardOutputService.Text, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=OneWay}" />
         <controls:Key Grid.Row="1" Grid.Column="3"
                       SymbolGeometry="{StaticResource SpeakIcon}" 
                       Text="{x:Static resx:Resources.SPEAK}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Speak}"/>
+                      Value="{x:Static models:KeyValues.SpeakKey}"/>
         <controls:Key Grid.Row="1" Grid.Column="4"
                       SymbolGeometry="{StaticResource SleepIcon}"
                       Text="{x:Static resx:Resources.SLEEP}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Sleep}"/>
+                      Value="{x:Static models:KeyValues.SleepKey}"/>
     </Grid>
 </UserControl>

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -99,7 +99,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                 var points = tuple.Item1;
                 var singleKeyValue = tuple.Item2 != null || tuple.Item3 != null
-                    ? new KeyValue { FunctionKey = tuple.Item2, String = tuple.Item3 }
+                    ? new KeyValue (tuple.Item2, tuple.Item3 )
                     : (KeyValue?)null;
                 var multiKeySelection = tuple.Item4;
 

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/ConversationNumericAndSymbols.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/ConversationNumericAndSymbols.xaml
@@ -1,350 +1,239 @@
 ﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.ConversationNumericAndSymbols"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
-                       mc:Ignorable="d" 
+                       mc:Ignorable="d"
                        d:DesignHeight="300" d:DesignWidth="300">
 
-    <UserControl.Resources>
-        <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
-    </UserControl.Resources>
-    
-    <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
-          Grid.IsSharedSizeScope="True">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
+  <UserControl.Resources>
+    <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
+  </UserControl.Resources>
 
-        <controls:Output Grid.Row="0" Grid.Column="0"
-                         Grid.RowSpan="2" Grid.ColumnSpan="20" 
-                         ScratchpadWidthInKeys="6"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+  <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
+        Grid.IsSharedSizeScope="True">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
 
-        <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
-                      Text="1"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="1" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
-                      Text="2"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="2" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
-                      Text="3"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="3" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
-                      Text="4"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="4" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
-                      Text="5"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="5" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
-                      Text="6"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="6" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
-                      Text="7"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="7" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
-                      Text="8"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="8" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
-                      Text="9"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="9" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
-                      Text="0"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="0" />
-            </controls:Key.Value>
-        </controls:Key>
+    <controls:Output Grid.Row="0" Grid.Column="0"
+                       Grid.RowSpan="2" Grid.ColumnSpan="20"
+                       ScratchpadWidthInKeys="6"
+                       NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+    <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
-        <controls:Key Grid.Row="3" Grid.Column="0" />
-        <controls:Key Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Case="None"
-                      Text="-"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="-" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="3" Grid.ColumnSpan="2" Case="None"
-                      Text="_"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="_" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
-                      Text="%"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="%" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="7" Grid.ColumnSpan="2" Case="None"
-                      Text="@"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="@" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="9" Grid.ColumnSpan="2" Case="None"
-                      Text="&amp;"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="&amp;" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
-                      Text="¡"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¡" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
-                      Text="¿"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¿" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="15" Grid.ColumnSpan="2" Case="None"
-                      Text="!"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="!" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="17" Grid.ColumnSpan="2" Case="None"
-                      Text="?"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="?" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="3" Grid.Column="19" />
+    <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
+                  Text="1"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="1"/>
+    <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
+                  Text="2"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="2"/>
+    <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
+                  Text="3"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="3"/>
+    <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
+                  Text="4"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="4"/>
+    <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
+                  Text="5"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="5"/>
+    <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
+                  Text="6"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="6"/>
+    <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
+                  Text="7"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="7"/>
+    <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
+                  Text="8"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="8"/>
+    <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
+                    Text="9"
+                    SharedSizeGroup="KeyWithSingleLetter"
+                    Value="9"/>
+    <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
+                    Text="0"
+                    SharedSizeGroup="KeyWithSingleLetter"
+                    Value="0"/>
+    <controls:Key Grid.Row="3" Grid.Column="0" />
+    <controls:Key Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Case="None"
+                  Text="-"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="-"/>
+    <controls:Key Grid.Row="3" Grid.Column="3" Grid.ColumnSpan="2" Case="None"
+                  Text="_"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="_"/>
+    <controls:Key Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
+                  Text="%"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="%" />
 
-        <controls:Key Grid.Row="4" Grid.Column="0" />
-        <controls:Key Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Case="None"
-                      Text="'"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="'" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2" Case="None"
-                      Text="&quot;"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="&quot;" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
-                      Text="¢"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¢" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="7" Grid.ColumnSpan="2" Case="None"
-                      Text="$"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="$" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="9" Grid.ColumnSpan="2" Case="None"
-                      Text="€"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="€" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
-                      Text="£"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="£" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
-                      Text="¥"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¥" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="15" Grid.ColumnSpan="2"
-                      SymbolGeometry="{StaticResource BackOneIcon}"
-                      Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="17" Grid.ColumnSpan="2"
-                      SymbolGeometry="{StaticResource BackManyIcon}"
-                      Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="4" Grid.Column="19" />
+    <controls:Key Grid.Row="3" Grid.Column="7" Grid.ColumnSpan="2" Case="None"
+                  Text="@"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="@" />
+    <controls:Key Grid.Row="3" Grid.Column="9" Grid.ColumnSpan="2" Case="None"
+                  Text="&amp;"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="&amp;" />
+    <controls:Key Grid.Row="3" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
+                  Text="¡"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="¡" />
+    <controls:Key Grid.Row="3" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
+                  Text="¿"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="¿" />
+    <controls:Key Grid.Row="3" Grid.Column="15" Grid.ColumnSpan="2" Case="None"
+                  Text="!"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="!" />
+    <controls:Key Grid.Row="3" Grid.Column="17" Grid.ColumnSpan="2" Case="None"
+                  Text="?"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="?" />
+    <controls:Key Grid.Row="3" Grid.Column="19" />
 
-        <controls:Key Grid.Row="5" Grid.Column="0" />
-        <controls:Key Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
-                      SymbolGeometry="{StaticResource ShiftIcon}"
-                      Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
-                      SymbolGeometry="{StaticResource AlphaIcon}"
-                      Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ConversationAlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
-                      Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="5" Grid.Column="7" Grid.ColumnSpan="4"
-                      SymbolGeometry="{StaticResource SpaceIcon}"
-                      Text="{x:Static resx:Resources.SPACE}"
-                      WidthSpan="2"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="5" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
-                      Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="5" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
-                      Text="+"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="+" />
-            </controls:Key.Value>
-        </controls:Key>
-        <ContentControl Grid.Row="5" Grid.Column="15" Grid.ColumnSpan="2">
-            <ContentControl.Style>
-                <Style TargetType="{x:Type ContentControl}">
-                    <Setter Property="Content">
-                        <Setter.Value>
-                            <controls:Key SymbolGeometry="{StaticResource BackIcon}"
-                                          Text="{x:Static resx:Resources.BACK}"
-                                          SharedSizeGroup="KeyWithSymbol">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                </controls:Key.Value>
-                            </controls:Key>
-                        </Setter.Value>
-                    </Setter>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Source={x:Static properties:Settings.Default}, Path=ConversationOnlyMode}" Value="True">
-                            <Setter Property="Content">
-                                <Setter.Value>
-                                    <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
-                                                  Text="{x:Static resx:Resources.QUIT}"
-                                                  SharedSizeGroup="KeyWithSymbol">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Quit}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
-                                </Setter.Value>
-                            </Setter>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ContentControl.Style>
-        </ContentControl>
-        <controls:Key Grid.Row="5" Grid.Column="17" Grid.ColumnSpan="2"
-                      SymbolGeometry="{StaticResource CalibrateIcon}"
-                      Text="{x:Static resx:Resources.RE_CALIBRATE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Calibrate}" />
-            </controls:Key.Value>
-        </controls:Key>
-        <controls:Key Grid.Row="5" Grid.Column="19" />
-    </Grid>
+    <controls:Key Grid.Row="4" Grid.Column="0" />
+    <controls:Key Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Case="None"
+                  Text="'"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="'" />
+    <controls:Key Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2" Case="None"
+                  Text="&quot;"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="&quot;" />
+    <controls:Key Grid.Row="4" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
+                  Text="¢"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="¢" />
+    <controls:Key Grid.Row="4" Grid.Column="7" Grid.ColumnSpan="2" Case="None"
+                  Text="$"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="$" />
+    <controls:Key Grid.Row="4" Grid.Column="9" Grid.ColumnSpan="2" Case="None"
+                  Text="€"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="€" />
+    <controls:Key Grid.Row="4" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
+                  Text="£"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="£" />
+    <controls:Key Grid.Row="4" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
+                  Text="¥"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="¥" />
+    <controls:Key Grid.Row="4" Grid.Column="15" Grid.ColumnSpan="2"
+                  SymbolGeometry="{StaticResource BackOneIcon}"
+                  Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
+                  SharedSizeGroup="KeyWithSymbol"
+                  Value="{x:Static enums:FunctionKeys.BackOne}" />
+    <controls:Key Grid.Row="4" Grid.Column="17" Grid.ColumnSpan="2"
+                  SymbolGeometry="{StaticResource BackManyIcon}"
+                  Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
+                  SharedSizeGroup="KeyWithSymbol"
+                  Value="{x:Static enums:FunctionKeys.BackMany}" />
+    <controls:Key Grid.Row="4" Grid.Column="19" />
+
+    <controls:Key Grid.Row="5" Grid.Column="0" />
+    <controls:Key Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
+                  SymbolGeometry="{StaticResource ShiftIcon}"
+                  Text="{x:Static resx:Resources.SHIFT}"
+                  SharedSizeGroup="KeyWithSymbol"
+                  Value="{x:Static enums:FunctionKeys.LeftShift}" />
+    <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
+                  SymbolGeometry="{StaticResource AlphaIcon}"
+                  Text="{x:Static resx:Resources.ALPHA}"
+                  SharedSizeGroup="KeyWithSymbol"
+                  Value="{x:Static enums:FunctionKeys.ConversationAlphaKeyboard}" />
+    <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
+                  Text=","
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="," />
+    <controls:Key Grid.Row="5" Grid.Column="7" Grid.ColumnSpan="4"
+                  SymbolGeometry="{StaticResource SpaceIcon}"
+                  Text="{x:Static resx:Resources.SPACE}"
+                  WidthSpan="2"
+                  SharedSizeGroup="KeyWithSymbol"
+                  Value=" " />
+    <controls:Key Grid.Row="5" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
+                  Text="."
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="." />
+    <controls:Key Grid.Row="5" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
+                  Text="+"
+                  SharedSizeGroup="KeyWithSingleLetter"
+                  Value="+" />
+    <ContentControl Grid.Row="5" Grid.Column="15" Grid.ColumnSpan="2">
+      <ContentControl.Style>
+        <Style TargetType="{x:Type ContentControl}">
+          <Setter Property="Content">
+            <Setter.Value>
+              <controls:Key SymbolGeometry="{StaticResource BackIcon}"
+                            Text="{x:Static resx:Resources.BACK}"
+                            SharedSizeGroup="KeyWithSymbol"
+                            Value="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
+            </Setter.Value>
+          </Setter>
+          <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static properties:Settings.Default}, Path=ConversationOnlyMode}" Value="True">
+              <Setter Property="Content">
+                <Setter.Value>
+                  <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
+                                Text="{x:Static resx:Resources.QUIT}"
+                                SharedSizeGroup="KeyWithSymbol"
+                                Value="{x:Static enums:FunctionKeys.Quit}" />
+                </Setter.Value>
+              </Setter>
+            </DataTrigger>
+          </Style.Triggers>
+        </Style>
+      </ContentControl.Style>
+    </ContentControl>
+    <controls:Key Grid.Row="5" Grid.Column="17" Grid.ColumnSpan="2"
+                  SymbolGeometry="{StaticResource CalibrateIcon}"
+                  Text="{x:Static resx:Resources.RE_CALIBRATE}"
+                  SharedSizeGroup="KeyWithSymbol"
+                  Value="{x:Static enums:FunctionKeys.Calibrate}" />
+    <controls:Key Grid.Row="5" Grid.Column="19" />
+  </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/ConversationNumericAndSymbols.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/ConversationNumericAndSymbols.xaml
@@ -4,9 +4,9 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d"
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -166,12 +166,12 @@
                   SymbolGeometry="{StaticResource BackOneIcon}"
                   Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                   SharedSizeGroup="KeyWithSymbol"
-                  Value="{x:Static enums:FunctionKeys.BackOne}" />
+                  Value="{x:Static models:KeyValues.BackOneKey}" />
     <controls:Key Grid.Row="4" Grid.Column="17" Grid.ColumnSpan="2"
                   SymbolGeometry="{StaticResource BackManyIcon}"
                   Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                   SharedSizeGroup="KeyWithSymbol"
-                  Value="{x:Static enums:FunctionKeys.BackMany}" />
+                  Value="{x:Static models:KeyValues.BackManyKey}" />
     <controls:Key Grid.Row="4" Grid.Column="19" />
 
     <controls:Key Grid.Row="5" Grid.Column="0" />
@@ -179,12 +179,12 @@
                   SymbolGeometry="{StaticResource ShiftIcon}"
                   Text="{x:Static resx:Resources.SHIFT}"
                   SharedSizeGroup="KeyWithSymbol"
-                  Value="{x:Static enums:FunctionKeys.LeftShift}" />
+                  Value="{x:Static models:KeyValues.LeftShiftKey}" />
     <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                   SymbolGeometry="{StaticResource AlphaIcon}"
                   Text="{x:Static resx:Resources.ALPHA}"
                   SharedSizeGroup="KeyWithSymbol"
-                  Value="{x:Static enums:FunctionKeys.ConversationAlphaKeyboard}" />
+                  Value="{x:Static models:KeyValues.ConversationAlphaKeyboardKey}" />
     <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
                   Text=","
                   SharedSizeGroup="KeyWithSingleLetter"
@@ -211,7 +211,7 @@
               <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                             Text="{x:Static resx:Resources.BACK}"
                             SharedSizeGroup="KeyWithSymbol"
-                            Value="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
+                            Value="{x:Static models:KeyValues.BackFromKeyboardKey}" />
             </Setter.Value>
           </Setter>
           <Style.Triggers>
@@ -221,7 +221,7 @@
                   <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                 Text="{x:Static resx:Resources.QUIT}"
                                 SharedSizeGroup="KeyWithSymbol"
-                                Value="{x:Static enums:FunctionKeys.Quit}" />
+                                Value="{x:Static models:KeyValues.QuitKey}" />
                 </Setter.Value>
               </Setter>
             </DataTrigger>
@@ -233,7 +233,7 @@
                   SymbolGeometry="{StaticResource CalibrateIcon}"
                   Text="{x:Static resx:Resources.RE_CALIBRATE}"
                   SharedSizeGroup="KeyWithSymbol"
-                  Value="{x:Static enums:FunctionKeys.Calibrate}" />
+                  Value="{x:Static models:KeyValues.CalibrateKey}" />
     <controls:Key Grid.Row="5" Grid.Column="19" />
   </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies1.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Currencies1"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Currencies1"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -6,6 +6,7 @@
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -100,12 +101,12 @@
                       SymbolGeometry="{StaticResource 1of2Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies2Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies2KeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="₠"
@@ -151,18 +152,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}" />
         
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
+                      Value="{x:Static models:KeyValues.LeftShiftKey}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="₦"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -195,36 +196,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}" />
+                      Value="{x:Static models:KeyValues.BackOneKey}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}" />
+                      Value="{x:Static models:KeyValues.BackManyKey}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}" />
         
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
+                      Value="{x:Static models:KeyValues.LeftWinKey}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
+                      Value="{x:Static models:KeyValues.LeftAltKey}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="₨"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -253,11 +254,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies1.xaml
@@ -4,16 +4,15 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
-    
+
     <UserControl.Resources>
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
     </UserControl.Resources>
-    
+
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <Grid.RowDefinitions>
@@ -54,348 +53,211 @@
         <controls:Output Grid.Row="0" Grid.Column="0"
                          Grid.RowSpan="2" Grid.ColumnSpan="24" 
                          ScratchpadWidthInKeys="8"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="¤"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¤" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¤" />
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="₳"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₳" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₳" />
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="฿"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="฿" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="฿" />
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="₵"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₵" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₵" />
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="¢"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¢" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¢" />
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="₡"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₡" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₡" />
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="₢"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₢" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₢" />
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="$"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="$" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="$" />
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="₫"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₫" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₫" />
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="₯"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₯" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₯" />
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 1of2Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Currencies2Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies2Keyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="₠"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₠" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₠" />
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="€"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="€" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="€" />
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="ƒ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ƒ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ƒ" />
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="₣"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₣" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₣" />
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="₲"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₲" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₲" />
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="₴"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₴" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₴" />
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="₭"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₭" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₭" />
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="₺"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₺" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₺" />
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="ℳ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ℳ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ℳ" />
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="₥"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₥" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₥" />
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
-
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
+        
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="₦"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₦" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₦" />
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="₧"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₧" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₧" />
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="₱"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₱" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₱" />
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="₰"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₰" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₰" />
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="£"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="£" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="£" />
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="៛"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="៛" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="៛" />
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="₹"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₹" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₹" />
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
-
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
+        
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="₨"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₨" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₨" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" " />
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="₪"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₪" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₪" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="৳"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="৳" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="৳" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies2.xaml
@@ -1,11 +1,11 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Currencies2"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Currencies2"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -99,12 +99,12 @@
                       SymbolGeometry="{StaticResource 2of2Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}" />
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" />
@@ -120,18 +120,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
+                      Value="{x:Static models:KeyValues.LeftShiftKey}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2" />
@@ -143,36 +143,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}" />
+                      Value="{x:Static models:KeyValues.BackOneKey}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}" />
+                      Value="{x:Static models:KeyValues.BackManyKey}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}" />
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
+                      Value="{x:Static models:KeyValues.LeftWinKey}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
+                      Value="{x:Static models:KeyValues.LeftAltKey}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
@@ -192,11 +192,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Currencies2.xaml
@@ -4,7 +4,6 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -58,90 +57,54 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="₸"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₸" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₸" />
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="₮"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₮" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₮" />
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="₩"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="₩" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="₩" />
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="¥"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¥" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¥" />
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="ман"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ман" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ман" />
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="лв"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="лв" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="лв" />
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="﷼"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="﷼" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="﷼" />
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="ден"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ден" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ден" />
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="zł"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="zł" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="zł" />
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="Дин."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="Дин." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="Дин." />
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 2of2Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Currencies1Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" />
@@ -156,28 +119,19 @@
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2" />
@@ -188,94 +142,61 @@
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" " />
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics1.xaml
@@ -4,7 +4,6 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -13,7 +12,7 @@
     <UserControl.Resources>
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
     </UserControl.Resources>
-    
+
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <Grid.RowDefinitions>
@@ -54,348 +53,211 @@
         <controls:Output Grid.Row="0" Grid.Column="0"
                          Grid.RowSpan="2" Grid.ColumnSpan="24" 
                          ScratchpadWidthInKeys="8"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
-        
+                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ă" ShiftDownText="Ă"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ă" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ă" />
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ą" ShiftDownText="Ą"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ą" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ą" />
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ã" ShiftDownText="Ã"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ã" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ã" />
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ä" ShiftDownText="Ä"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ä" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ä" />
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="å" ShiftDownText="Å"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="å" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="å" />
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="æ" ShiftDownText="Æ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="æ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="æ" />
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ā" ShiftDownText="Ā"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ā" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ā" />
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="à" ShiftDownText="À"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="à" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="à" />
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="á" ShiftDownText="Á"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="á" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="á" />
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="â" ShiftDownText="Â"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="â" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="â" />
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic2Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic2Keyboard}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="č" ShiftDownText="Č"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="č" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="č" />
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ç" ShiftDownText="Ç"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ç" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ç" />
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ć" ShiftDownText="Ć"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ć" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ć" />
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="đ" ShiftDownText="Đ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="đ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="đ" />
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ð" ShiftDownText="Ð"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ð" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ð" />
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ď" ShiftDownText="Ď"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ď" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ď" />
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ə" ShiftDownText="Ə"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ə" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ə" />
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ę" ShiftDownText="Ę"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ę" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ę" />
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ě" ShiftDownText="Ě"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ě" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ě" />
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ê" ShiftDownText="Ê"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ê" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ê" />
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ë" ShiftDownText="Ë"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ë" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ë" />
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ē" ShiftDownText="Ē"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ē" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ē" />
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ė" ShiftDownText="Ė"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ė" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ė" />
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="è" ShiftDownText="È"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="è" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="è" />
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="é" ShiftDownText="É"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="é" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="é" />
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ĝ" ShiftDownText="Ĝ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĝ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĝ" />
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ğ" ShiftDownText="Ğ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ğ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ğ" />
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ģ" ShiftDownText="Ģ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ģ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ģ" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" " />
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ħ" ShiftDownText="Ħ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ħ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ħ" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ĥ" ShiftDownText="Ĥ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĥ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĥ" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics1.xaml
@@ -1,11 +1,11 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Diacritics1"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Diacritics1"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -100,12 +100,12 @@
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic2Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic2KeyboardKey}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}" />
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="č" ShiftDownText="Č"
@@ -151,18 +151,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
+                      Value="{x:Static models:KeyValues.LeftShiftKey}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ë" ShiftDownText="Ë"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -195,36 +195,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}" />
+                      Value="{x:Static models:KeyValues.BackOneKey}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}" />
+                      Value="{x:Static models:KeyValues.BackManyKey}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}" />
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
+                      Value="{x:Static models:KeyValues.LeftWinKey}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
+                      Value="{x:Static models:KeyValues.LeftAltKey}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ģ" ShiftDownText="Ģ"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -253,11 +253,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics2.xaml
@@ -1,11 +1,11 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Diacritics2"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Diacritics2"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -100,12 +100,12 @@
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic3Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic3KeyboardKey}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}" />
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ļ" ShiftDownText="Ļ"
@@ -151,18 +151,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
+                      Value="{x:Static models:KeyValues.LeftShiftKey}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ø" ShiftDownText="Ø"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -195,36 +195,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}" />
+                      Value="{x:Static models:KeyValues.BackOneKey}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}" />
+                      Value="{x:Static models:KeyValues.BackManyKey}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}" />
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
+                      Value="{x:Static models:KeyValues.LeftWinKey}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
+                      Value="{x:Static models:KeyValues.LeftAltKey}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ř" ShiftDownText="Ř"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -253,11 +253,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics2.xaml
@@ -4,7 +4,6 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -13,7 +12,7 @@
     <UserControl.Resources>
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
     </UserControl.Resources>
-    
+
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <Grid.RowDefinitions>
@@ -54,348 +53,211 @@
         <controls:Output Grid.Row="0" Grid.Column="0"
                          Grid.RowSpan="2" Grid.ColumnSpan="24" 
                          ScratchpadWidthInKeys="8"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
-        
+                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ị" ShiftDownText="Ị"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ị" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ị" />
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="į" ShiftDownText="Į"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="į" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="į" />
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ī" ShiftDownText="Ī"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ī" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ī" />
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ï" ShiftDownText="Ï"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ï" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ï" />
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="î" ShiftDownText="Î"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="î" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="î" />
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="í" ShiftDownText="Í"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="í" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="í" />
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ì" ShiftDownText="Ì"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ì" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ì" />
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ķ" ShiftDownText="Ķ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ķ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ķ" />
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ł" ShiftDownText="Ł"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ł" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ł" />
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ľ" ShiftDownText="Ľ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ľ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ľ" />
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic3Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic3Keyboard}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ļ" ShiftDownText="Ļ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ļ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ļ" />
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ĺ" ShiftDownText="Ĺ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĺ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĺ" />
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ň" ShiftDownText="Ň"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ň" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ň" />
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ņ" ShiftDownText="Ņ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ņ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ņ" />
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ń" ShiftDownText="Ń"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ń" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ń" />
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ñ" ShiftDownText="Ñ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ñ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ñ" />
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ơ" ShiftDownText="Ơ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ơ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ơ" />
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="œ" ShiftDownText="Œ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="œ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="œ" />
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ő" ShiftDownText="Ő"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ő" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ő" />
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ō" ShiftDownText="Ō"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ō" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ō" />
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}" />
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ø" ShiftDownText="Ø"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ø" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ø" />
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ö" ShiftDownText="Ö"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ö" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ö" />
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="õ" ShiftDownText="Õ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="õ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="õ" />
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ô" ShiftDownText="Ô"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ô" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ô" />
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ó" ShiftDownText="Ó"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ó" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ó" />
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ò" ShiftDownText="Ò"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ò" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ò" />
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ŕ" ShiftDownText="Ŕ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŕ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŕ" />
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}" />
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}" />
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}" />
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}" />
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}" />
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ř" ShiftDownText="Ř"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ř" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ř" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" " />
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ş" ShiftDownText="Ş"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ş" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ş" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="š" ShiftDownText="Š"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="š" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="š" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}" />
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics3.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Diacritics3"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Diacritics3"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -100,12 +100,12 @@
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ų" ShiftDownText="Ų"
@@ -151,18 +151,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ÿ" ShiftDownText="Ÿ"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -189,36 +189,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
@@ -238,11 +238,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Diacritics3.xaml
@@ -58,314 +58,191 @@
         
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ș" ShiftDownText="Ș"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ș" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ș"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ß" ShiftDownText="ß"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ß" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ß"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ś" ShiftDownText="Ś"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ś" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ś"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ŝ" ShiftDownText="Ŝ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŝ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŝ"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ť" ShiftDownText="Ť"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ť" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ť"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ț" ShiftDownText="Ț"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ț" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ț"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ţ" ShiftDownText="Ţ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ţ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ţ"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="þ" ShiftDownText="Þ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="þ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="þ"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ụ" ShiftDownText="Ụ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ụ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ụ"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ư" ShiftDownText="Ư"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ư" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ư"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic1Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ų" ShiftDownText="Ų"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ų" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ų"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ű" ShiftDownText="Ű"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ű" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ű"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ů" ShiftDownText="Ů"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ů" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ů"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ū" ShiftDownText="Ū"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ū" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ū"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ü" ShiftDownText="Ü"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ü" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ü"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="û" ShiftDownText="Û"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="û" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="û"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ú" ShiftDownText="Ú"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ú" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ú"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ù" ShiftDownText="Ù"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ù" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ù"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ŵ" ShiftDownText="Ŵ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŵ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŵ"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ŷ" ShiftDownText="Ŷ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŷ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŷ"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ÿ" ShiftDownText="Ÿ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ÿ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ÿ"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ý" ShiftDownText="Ý"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ý" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ý"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ź" ShiftDownText="Ź"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ź" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ź"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ż" ShiftDownText="Ż"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ż" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ż"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ž" ShiftDownText="Ž"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ž" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ž"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Language.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Language.xaml
@@ -4,10 +4,8 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
-                       xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -43,47 +41,29 @@
                             </Grid.ColumnDefinitions>
                             <controls:Key Grid.Row="0" Grid.Column="0"
                                           Text="{x:Static resx:Resources.ENGLISH_CANADA}"
-                                          SharedSizeGroup="KeyWithText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.EnglishCanada}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithText"
+                                          Value="{x:Static enums:FunctionKeys.EnglishCanada}"/>
                             <controls:Key Grid.Row="0" Grid.Column="1"
                                           Text="{x:Static resx:Resources.ENGLISH_UK}"
-                                          SharedSizeGroup="KeyWithText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.EnglishUK}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithText"
+                                          Value="{x:Static enums:FunctionKeys.EnglishUK}"/>
                             <controls:Key Grid.Row="0" Grid.Column="2"
                                           Text="{x:Static resx:Resources.ENGLISH_US}"
-                                          SharedSizeGroup="KeyWithText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.EnglishUS}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithText"
+                                          Value="{x:Static enums:FunctionKeys.EnglishUS}"/>
                             
                             <controls:Key Grid.Row="1" Grid.Column="0"
                                           Text="{x:Static resx:Resources.FRENCH_FRANCE_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.FrenchFrance}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithText"
+                                          Value="{x:Static enums:FunctionKeys.FrenchFrance}"/>
                             <controls:Key Grid.Row="1" Grid.Column="1"
                                           Text="{x:Static resx:Resources.GERMAN_GERMANY_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.GermanGermany}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithText"
+                                          Value="{x:Static enums:FunctionKeys.GermanGermany}"/>
                             <controls:Key Grid.Row="1" Grid.Column="2"
                                           Text="{x:Static resx:Resources.RUSSIAN_RUSSIA_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.RussianRussia}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithText"
+                                          Value="{x:Static enums:FunctionKeys.RussianRussia}"/>
                         </Grid>
                     </Setter.Value>
                 </Setter>
@@ -112,47 +92,29 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:Key Grid.Row="0" Grid.Column="0"
                                                   Text="{x:Static resx:Resources.ENGLISH_CANADA}"
-                                                  SharedSizeGroup="KeyWithText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.EnglishCanada}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithText"
+                                                  Value="{x:Static enums:FunctionKeys.EnglishCanada}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="0"
                                                   Text="{x:Static resx:Resources.ENGLISH_UK}"
-                                                  SharedSizeGroup="KeyWithText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.EnglishUK}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithText"
+                                                  Value="{x:Static enums:FunctionKeys.EnglishUK}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="0"
                                                   Text="{x:Static resx:Resources.ENGLISH_US}"
-                                                  SharedSizeGroup="KeyWithText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.EnglishUS}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithText"
+                                                  Value="{x:Static enums:FunctionKeys.EnglishUS}"/>
 
                                     <controls:Key Grid.Row="0" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.FRENCH_FRANCE_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.FrenchFrance}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithText"
+                                                  Value="{x:Static enums:FunctionKeys.FrenchFrance}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.GERMAN_GERMANY_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.GermanGermany}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithText"
+                                                  Value="{x:Static enums:FunctionKeys.GermanGermany}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.RUSSIAN_RUSSIA_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.RussianRussia}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithText"
+                                                  Value="{x:Static enums:FunctionKeys.RussianRussia}"/>
                                 </Grid>
                             </Setter.Value>
                         </Setter>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Language.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Language.xaml
@@ -1,12 +1,12 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Language"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Language"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -42,28 +42,28 @@
                             <controls:Key Grid.Row="0" Grid.Column="0"
                                           Text="{x:Static resx:Resources.ENGLISH_CANADA}"
                                           SharedSizeGroup="KeyWithText"
-                                          Value="{x:Static enums:FunctionKeys.EnglishCanada}"/>
+                                          Value="{x:Static models:KeyValues.EnglishCanadaKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="1"
                                           Text="{x:Static resx:Resources.ENGLISH_UK}"
                                           SharedSizeGroup="KeyWithText"
-                                          Value="{x:Static enums:FunctionKeys.EnglishUK}"/>
+                                          Value="{x:Static models:KeyValues.EnglishUKKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="2"
                                           Text="{x:Static resx:Resources.ENGLISH_US}"
                                           SharedSizeGroup="KeyWithText"
-                                          Value="{x:Static enums:FunctionKeys.EnglishUS}"/>
+                                          Value="{x:Static models:KeyValues.EnglishUSKey}"/>
                             
                             <controls:Key Grid.Row="1" Grid.Column="0"
                                           Text="{x:Static resx:Resources.FRENCH_FRANCE_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithText"
-                                          Value="{x:Static enums:FunctionKeys.FrenchFrance}"/>
+                                          Value="{x:Static models:KeyValues.FrenchFranceKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="1"
                                           Text="{x:Static resx:Resources.GERMAN_GERMANY_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithText"
-                                          Value="{x:Static enums:FunctionKeys.GermanGermany}"/>
+                                          Value="{x:Static models:KeyValues.GermanGermanyKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="2"
                                           Text="{x:Static resx:Resources.RUSSIAN_RUSSIA_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithText"
-                                          Value="{x:Static enums:FunctionKeys.RussianRussia}"/>
+                                          Value="{x:Static models:KeyValues.RussianRussiaKey}"/>
                         </Grid>
                     </Setter.Value>
                 </Setter>
@@ -93,28 +93,28 @@
                                     <controls:Key Grid.Row="0" Grid.Column="0"
                                                   Text="{x:Static resx:Resources.ENGLISH_CANADA}"
                                                   SharedSizeGroup="KeyWithText"
-                                                  Value="{x:Static enums:FunctionKeys.EnglishCanada}"/>
+                                                  Value="{x:Static models:KeyValues.EnglishCanadaKey}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="0"
                                                   Text="{x:Static resx:Resources.ENGLISH_UK}"
                                                   SharedSizeGroup="KeyWithText"
-                                                  Value="{x:Static enums:FunctionKeys.EnglishUK}"/>
+                                                  Value="{x:Static models:KeyValues.EnglishUKKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="0"
                                                   Text="{x:Static resx:Resources.ENGLISH_US}"
                                                   SharedSizeGroup="KeyWithText"
-                                                  Value="{x:Static enums:FunctionKeys.EnglishUS}"/>
+                                                  Value="{x:Static models:KeyValues.EnglishUSKey}"/>
 
                                     <controls:Key Grid.Row="0" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.FRENCH_FRANCE_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithText"
-                                                  Value="{x:Static enums:FunctionKeys.FrenchFrance}"/>
+                                                  Value="{x:Static models:KeyValues.FrenchFranceKey}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.GERMAN_GERMANY_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithText"
-                                                  Value="{x:Static enums:FunctionKeys.GermanGermany}"/>
+                                                  Value="{x:Static models:KeyValues.GermanGermanyKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.RUSSIAN_RUSSIA_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithText"
-                                                  Value="{x:Static enums:FunctionKeys.RussianRussia}"/>
+                                                  Value="{x:Static models:KeyValues.RussianRussiaKey}"/>
                                 </Grid>
                             </Setter.Value>
                         </Setter>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Menu.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Menu.xaml
@@ -41,121 +41,80 @@
         <controls:Key Grid.Row="0" Grid.Column="0"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="0" Grid.Column="1"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUMBERS_AND_SYMBOLS}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="0" Grid.Column="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
         <controls:Key Grid.Row="0" Grid.Column="3"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
         <controls:Key Grid.Row="1" Grid.Column="0"
                       SymbolGeometry="{StaticResource ConversationIcon}"
                       Text="{x:Static resx:Resources.CONVERSATION}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ConversationAlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.ConversationAlphaKeyboard}"/>
         <controls:Key Grid.Row="1" Grid.Column="1"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="1" Grid.Column="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
         <controls:Key Grid.Row="1" Grid.Column="3"
                       SymbolGeometry="{StaticResource SleepIcon}"
                       Text="{x:Static resx:Resources.SLEEP}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Sleep}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Sleep}"/>
 
         <controls:Key Grid.Row="2" Grid.Column="0"
                       SymbolGeometry="{StaticResource DecreaseOpacityIcon}"
                       Text="{x:Static resx:Resources.DECREASE_OPACITY_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.DecreaseOpacity}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.DecreaseOpacity}"/>
         <controls:Key Grid.Row="2" Grid.Column="1"
                       SymbolGeometry="{StaticResource IncreaseOpacityIcon}"
                       Text="{x:Static resx:Resources.INCREASE_OPACITY_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.IncreaseOpacity}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.IncreaseOpacity}"/>
         <controls:Key Grid.Row="2" Grid.Column="2"
                       SymbolGeometry="{StaticResource LanguageIcon}"
                       Text="{x:Static resx:Resources.LANGUAGE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Language}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Language}"/>
         <controls:Key Grid.Row="2" Grid.Column="3"
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Calibrate}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0"
                       SymbolGeometry="{StaticResource QuitIcon}"
                       Text="{x:Static resx:Resources.QUIT}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Quit}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Quit}"/>
         <controls:Key Grid.Row="3" Grid.Column="1"
                       SymbolGeometry="{StaticResource SizeAndPositionIcon}"
                       Text="{x:Static resx:Resources.SIZE_AND_POSITION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.SizeAndPositionKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.SizeAndPositionKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="2"
                       SymbolGeometry="{StaticResource MinimiseIcon}"
                       Text="{x:Static resx:Resources.MINIMISE}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.Minimise}">
             <controls:Key.SymbolOrientation>
                 <MultiBinding Converter="{StaticResource MinimiseAndDockPositionToSymbolOrientation}">
                     <MultiBinding.Bindings>
@@ -164,17 +123,11 @@
                     </MultiBinding.Bindings>
                 </MultiBinding>
             </controls:Key.SymbolOrientation>
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Minimise}" />
-            </controls:Key.Value>
         </controls:Key>
         <controls:Key Grid.Row="3" Grid.Column="3"
                       SymbolGeometry="{StaticResource BackIcon}"
                       Text="{x:Static resx:Resources.BACK}"
-                      SharedSizeGroup="KeyWithSymbolAndText">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbolAndText"
+                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Menu.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Menu.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Menu"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Menu"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
@@ -42,79 +41,79 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="0" Grid.Column="1"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUMBERS_AND_SYMBOLS}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="0" Grid.Column="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
         <controls:Key Grid.Row="0" Grid.Column="3"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
         <controls:Key Grid.Row="1" Grid.Column="0"
                       SymbolGeometry="{StaticResource ConversationIcon}"
                       Text="{x:Static resx:Resources.CONVERSATION}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.ConversationAlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.ConversationAlphaKeyboardKey}"/>
         <controls:Key Grid.Row="1" Grid.Column="1"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="1" Grid.Column="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
         <controls:Key Grid.Row="1" Grid.Column="3"
                       SymbolGeometry="{StaticResource SleepIcon}"
                       Text="{x:Static resx:Resources.SLEEP}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Sleep}"/>
+                      Value="{x:Static models:KeyValues.SleepKey}"/>
 
         <controls:Key Grid.Row="2" Grid.Column="0"
                       SymbolGeometry="{StaticResource DecreaseOpacityIcon}"
                       Text="{x:Static resx:Resources.DECREASE_OPACITY_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.DecreaseOpacity}"/>
+                      Value="{x:Static models:KeyValues.DecreaseOpacityKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="1"
                       SymbolGeometry="{StaticResource IncreaseOpacityIcon}"
                       Text="{x:Static resx:Resources.INCREASE_OPACITY_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.IncreaseOpacity}"/>
+                      Value="{x:Static models:KeyValues.IncreaseOpacityKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="2"
                       SymbolGeometry="{StaticResource LanguageIcon}"
                       Text="{x:Static resx:Resources.LANGUAGE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Language}"/>
+                      Value="{x:Static models:KeyValues.LanguageKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="3"
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
+                      Value="{x:Static models:KeyValues.CalibrateKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0"
                       SymbolGeometry="{StaticResource QuitIcon}"
                       Text="{x:Static resx:Resources.QUIT}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Quit}"/>
+                      Value="{x:Static models:KeyValues.QuitKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="1"
                       SymbolGeometry="{StaticResource SizeAndPositionIcon}"
                       Text="{x:Static resx:Resources.SIZE_AND_POSITION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.SizeAndPositionKeyboard}"/>
+                      Value="{x:Static models:KeyValues.SizeAndPositionKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="2"
                       SymbolGeometry="{StaticResource MinimiseIcon}"
                       Text="{x:Static resx:Resources.MINIMISE}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.Minimise}">
+                      Value="{x:Static models:KeyValues.MinimiseKey}">
             <controls:Key.SymbolOrientation>
                 <MultiBinding Converter="{StaticResource MinimiseAndDockPositionToSymbolOrientation}">
                     <MultiBinding.Bindings>
@@ -128,6 +127,6 @@
                       SymbolGeometry="{StaticResource BackIcon}"
                       Text="{x:Static resx:Resources.BACK}"
                       SharedSizeGroup="KeyWithSymbolAndText"
-                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                      Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Minimised.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Minimised.xaml
@@ -1,10 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Minimised"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Minimised"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -15,6 +15,6 @@
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <controls:Key SymbolGeometry="{StaticResource ApplicationIcon}"
-                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                      Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Minimised.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Minimised.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -15,10 +14,7 @@
 
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
-        <controls:Key SymbolGeometry="{StaticResource ApplicationIcon}">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+        <controls:Key SymbolGeometry="{StaticResource ApplicationIcon}"
+                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Mouse.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Mouse.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
@@ -65,216 +64,139 @@
                                                               Text="{x:Static resx:Resources.DO_AT_CURRENT_LOCATION}"
                                                               SharedSizeGroup="KeyWithText" />
                                                 <controls:Key Grid.Row="1" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
-                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseMoveAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.MOVE_BY}}">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAmountInPixels}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseMoveAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.MOVE_BY}}"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAmountInPixels}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMoveToIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_TO_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveTo}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveTo}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseLeftClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseLeftClick}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                               Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMiddleClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMiddleClick}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                               Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseRightClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseRightClick}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseLeftDoubleClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseLeftDoubleClick}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="0" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToTop}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToTop}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="1" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToBottom}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToBottom}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="2" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToLeft}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToLeft}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToRight}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToRight}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftDownUpIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_DOWN_UP_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseLeftDownUp}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseLeftDownUp}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMiddleDownUpIcon}"
                                                               Text="{x:Static resx:Resources.MIDDLE_DOWN_UP_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMiddleDownUp}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMiddleDownUp}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseRightDownUpIcon}"
                                                               Text="{x:Static resx:Resources.RIGHT_UP_DOWN_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseRightDownUp}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseRightDownUp}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMagneticCursorIcon}"
                                                               Text="{x:Static resx:Resources.MAGNETIC_CURSOR_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMagneticCursor}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMagneticCursor}"/>
                                                 <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="8"
                                                               Text="{x:Static resx:Resources.DO_AT_POINT}"
                                                               SharedSizeGroup="KeyWithText" />
                                                 <controls:Key Grid.Row="6" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
-                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseScrollAmountInClicks, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.SCROLL_BY}}">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseScrollAmountInClicks}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseScrollAmountInClicks, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.SCROLL_BY}}"
+                                                              Value="{x:Static enums:FunctionKeys.MouseScrollAmountInClicks}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseDragIcon}"
                                                               Text="{x:Static resx:Resources.CLICK_AND_DRAG_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseDrag}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseDrag}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                               Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndMiddleClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndMiddleClick}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                               Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="0" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="1" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="2" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToLeftIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_LEFT_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToLeft}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToLeft}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToRightIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToRight}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToRight}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                               Text="{x:Static resx:Resources.MAGNIFIER}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMagnifier}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                               Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.RepeatLastMouseAction}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource CollapseDockIcon}"
                                                               Text="{x:Static resx:Resources.COLLAPSE_DOCK_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.CollapseDock}">
                                                     <controls:Key.SymbolOrientation>
                                                         <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                             <MultiBinding.Bindings>
@@ -283,18 +205,12 @@
                                                             </MultiBinding.Bindings>
                                                         </MultiBinding>
                                                     </controls:Key.SymbolOrientation>
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.CollapseDock}" />
-                                                    </controls:Key.Value>
                                                 </controls:Key>
                                                 <controls:Key Grid.Row="8" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource BackIcon}"
                                                               Text="{x:Static resx:Resources.BACK}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                    <controls:Key.Value>
-                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                                    </controls:Key.Value>
-                                                </controls:Key>
+                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                              Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                                             </Grid>
                                         </Setter.Value>
                                     </Setter>
@@ -325,63 +241,43 @@
                                                         <controls:Key Grid.Row="0" Grid.Column="0"
                                                                       SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="1"
                                                                       SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="3"
                                                                       SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="4"
                                                                       SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="5"
                                                                       SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                                       Text="{x:Static resx:Resources.MAGNIFIER}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMagnifier}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="6"
                                                                       SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                                       Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.RepeatLastMouseAction}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="7"
                                                                       SymbolGeometry="{StaticResource ExpandDockIcon}"
                                                                       Text="{x:Static resx:Resources.EXPAND_DOCK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.ExpandDock}">
                                                             <controls:Key.SymbolOrientation>
                                                                 <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                     <MultiBinding.Bindings>
@@ -390,18 +286,12 @@
                                                                     </MultiBinding.Bindings>
                                                                 </MultiBinding>
                                                             </controls:Key.SymbolOrientation>
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandDock}" />
-                                                            </controls:Key.Value>
                                                         </controls:Key>
                                                         <controls:Key Grid.Row="0" Grid.Column="8"
                                                                       SymbolGeometry="{StaticResource BackIcon}"
                                                                       Text="{x:Static resx:Resources.BACK}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                                                     </Grid>
                                                 </Setter.Value>
                                             </Setter>
@@ -410,7 +300,7 @@
                                 </Style>
                             </ContentControl.Style>
                         </ContentControl>
-                    </Setter.Value>    
+                    </Setter.Value>
                 </Setter>
                 <Style.Triggers>
                     <DataTrigger Value="False">
@@ -462,216 +352,139 @@
                                                                       Text="{x:Static resx:Resources.DO_AT_CURRENT_LOCATION}"
                                                                       SharedSizeGroup="KeyWithText" />
                                                         <controls:Key Grid.Row="1" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
-                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseMoveAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.MOVE_BY}}">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAmountInPixels}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseMoveAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.MOVE_BY}}"
+                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAmountInPixels}"/>
                                                         <controls:Key Grid.Row="1" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMoveToIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_TO_SPLIT_WITH_NEWLINE}"
-                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveTo}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveTo}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToTop}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToTop}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToBottom}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToBottom}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToLeft}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToLeft}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveToRight}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToRight}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseLeftClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseLeftClick}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                                       Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMiddleClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMiddleClick}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseRightClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseRightClick}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseLeftDoubleClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseLeftDoubleClick}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDownUpIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOWN_UP_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseLeftDownUp}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseLeftDownUp}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMiddleDownUpIcon}"
                                                                       Text="{x:Static resx:Resources.MIDDLE_DOWN_UP_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMiddleDownUp}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMiddleDownUp}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseRightDownUpIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_UP_DOWN_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseRightDownUp}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseRightDownUp}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMagneticCursorIcon}"
                                                                       Text="{x:Static resx:Resources.MAGNETIC_CURSOR_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMagneticCursor}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMagneticCursor}"/>
                                                         <controls:Key Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="4"
                                                                       Text="{x:Static resx:Resources.DO_AT_POINT}"
                                                                       SharedSizeGroup="KeyWithText" />
                                                         <controls:Key Grid.Row="10" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
-                                                              Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseScrollAmountInClicks, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.SCROLL_BY}}">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseScrollAmountInClicks}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseScrollAmountInClicks, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.SCROLL_BY}}"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseScrollAmountInClicks}"/>
                                                         <controls:Key Grid.Row="10" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseDragIcon}"
                                                                       Text="{x:Static resx:Resources.CLICK_AND_DRAG_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseDrag}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseDrag}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToLeftIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_LEFT_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToLeft}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToLeft}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToRightIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToRight}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToRight}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                                       Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndMiddleClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndMiddleClick}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
                                                         <controls:Key Grid.Row="16" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                                       Text="{x:Static resx:Resources.MAGNIFIER}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMagnifier}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
                                                         <controls:Key Grid.Row="16" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                                       Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.RepeatLastMouseAction}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
                                                         <controls:Key Grid.Row="16" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource CollapseDockIcon}"
                                                                       Text="{x:Static resx:Resources.COLLAPSE_DOCK_SPLIT_WITH_NEWLINE}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.CollapseDock}">
                                                             <controls:Key.SymbolOrientation>
                                                                 <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                     <MultiBinding.Bindings>
@@ -680,18 +493,12 @@
                                                                     </MultiBinding.Bindings>
                                                                 </MultiBinding>
                                                             </controls:Key.SymbolOrientation>
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.CollapseDock}" />
-                                                            </controls:Key.Value>
                                                         </controls:Key>
                                                         <controls:Key Grid.Row="16" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource BackIcon}"
                                                                       Text="{x:Static resx:Resources.BACK}"
-                                                                      SharedSizeGroup="KeyWithSymbolAndText">
-                                                            <controls:Key.Value>
-                                                                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                                            </controls:Key.Value>
-                                                        </controls:Key>
+                                                                      SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                                                     </Grid>
                                                 </Setter.Value>
                                             </Setter>
@@ -722,63 +529,43 @@
                                                                 <controls:Key Grid.Row="0" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                               Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
                                                                 <controls:Key Grid.Row="1" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                               Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
                                                                 <controls:Key Grid.Row="2" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                               Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
                                                                 <controls:Key Grid.Row="3" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                                               Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
                                                                 <controls:Key Grid.Row="4" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                                               Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
                                                                 <controls:Key Grid.Row="5" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                                               Text="{x:Static resx:Resources.MAGNIFIER}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseMagnifier}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
                                                                 <controls:Key Grid.Row="6" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                                               Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.RepeatLastMouseAction}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
                                                                 <controls:Key Grid.Row="7" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource ExpandDockIcon}"
                                                                               Text="{x:Static resx:Resources.EXPAND_DOCK_SPLIT_WITH_NEWLINE}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.ExpandDock}">
                                                                     <controls:Key.SymbolOrientation>
                                                                         <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                             <MultiBinding.Bindings>
@@ -787,18 +574,12 @@
                                                                             </MultiBinding.Bindings>
                                                                         </MultiBinding>
                                                                     </controls:Key.SymbolOrientation>
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandDock}" />
-                                                                    </controls:Key.Value>
                                                                 </controls:Key>
                                                                 <controls:Key Grid.Row="8" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource BackIcon}"
                                                                               Text="{x:Static resx:Resources.BACK}"
-                                                                              SharedSizeGroup="KeyWithSymbolAndText">
-                                                                    <controls:Key.Value>
-                                                                        <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                                                    </controls:Key.Value>
-                                                                </controls:Key>
+                                                                              SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                                                             </Grid>
                                                         </Setter.Value>
                                                     </Setter>
@@ -807,7 +588,7 @@
                                         </Style>
                                     </ContentControl.Style>
                                 </ContentControl>
-                            </Setter.Value>    
+                            </Setter.Value>
                         </Setter>
                     </DataTrigger>
                 </Style.Triggers>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Mouse.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/Mouse.xaml
@@ -1,13 +1,13 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Mouse"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.Mouse"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -65,138 +65,138 @@
                                                               SharedSizeGroup="KeyWithText" />
                                                 <controls:Key Grid.Row="1" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
                                                               Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseMoveAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.MOVE_BY}}"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAmountInPixels}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAmountInPixelsKey}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMoveToIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_TO_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveTo}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveToKey}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseLeftClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseLeftClickKey}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                               Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMiddleClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMiddleClickKey}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                               Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseRightClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseRightClickKey}"/>
                                                 <controls:Key Grid.Row="1" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseLeftDoubleClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseLeftDoubleClickKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="0" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToTop}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveToTopKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="1" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToBottom}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveToBottomKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="2" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToLeft}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveToLeftKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                               Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveToRight}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveToRightKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftDownUpIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_DOWN_UP_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseLeftDownUp}"/>
+                                                              Value="{x:Static models:KeyValues.MouseLeftDownUpKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMiddleDownUpIcon}"
                                                               Text="{x:Static resx:Resources.MIDDLE_DOWN_UP_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMiddleDownUp}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMiddleDownUpKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseRightDownUpIcon}"
                                                               Text="{x:Static resx:Resources.RIGHT_UP_DOWN_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseRightDownUp}"/>
+                                                              Value="{x:Static models:KeyValues.MouseRightDownUpKey}"/>
                                                 <controls:Key Grid.Row="3" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMagneticCursorIcon}"
                                                               Text="{x:Static resx:Resources.MAGNETIC_CURSOR_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMagneticCursor}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMagneticCursorKey}"/>
                                                 <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="8"
                                                               Text="{x:Static resx:Resources.DO_AT_POINT}"
                                                               SharedSizeGroup="KeyWithText" />
                                                 <controls:Key Grid.Row="6" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
                                                               Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseScrollAmountInClicks, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.SCROLL_BY}}"
-                                                              Value="{x:Static enums:FunctionKeys.MouseScrollAmountInClicks}"/>
+                                                              Value="{x:Static models:KeyValues.MouseScrollAmountInClicksKey}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseDragIcon}"
                                                               Text="{x:Static resx:Resources.CLICK_AND_DRAG_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseDrag}"/>
+                                                              Value="{x:Static models:KeyValues.MouseDragKey}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndLeftClickKey}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                               Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndMiddleClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndMiddleClickKey}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                               Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndRightClickKey}"/>
                                                 <controls:Key Grid.Row="6" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                               Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndLeftDoubleClickKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="0" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndScrollToTopKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="1" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndScrollToBottomKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="2" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToLeftIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_LEFT_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToLeft}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndScrollToLeftKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="3" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseScrollToRightIcon}"
                                                               Text="{x:Static resx:Resources.SCROLL_RIGHT_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToRight}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAndScrollToRightKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="4" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                               Text="{x:Static resx:Resources.MAGNIFIER}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMagnifierKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="5" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                               Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
+                                                              Value="{x:Static models:KeyValues.RepeatLastMouseActionKey}"/>
                                                 <controls:Key Grid.Row="8" Grid.Column="6" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource CollapseDockIcon}"
                                                               Text="{x:Static resx:Resources.COLLAPSE_DOCK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.CollapseDock}">
+                                                              Value="{x:Static models:KeyValues.CollapseDockKey}">
                                                     <controls:Key.SymbolOrientation>
                                                         <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                             <MultiBinding.Bindings>
@@ -210,7 +210,7 @@
                                                               SymbolGeometry="{StaticResource BackIcon}"
                                                               Text="{x:Static resx:Resources.BACK}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                              Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                                              Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                                             </Grid>
                                         </Setter.Value>
                                     </Setter>
@@ -242,42 +242,42 @@
                                                                       SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndLeftClickKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="1"
                                                                       SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndRightClickKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndLeftDoubleClickKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="3"
                                                                       SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndScrollToTopKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="4"
                                                                       SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndScrollToBottomKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="5"
                                                                       SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                                       Text="{x:Static resx:Resources.MAGNIFIER}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMagnifierKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="6"
                                                                       SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                                       Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
+                                                                      Value="{x:Static models:KeyValues.RepeatLastMouseActionKey}"/>
                                                         <controls:Key Grid.Row="0" Grid.Column="7"
                                                                       SymbolGeometry="{StaticResource ExpandDockIcon}"
                                                                       Text="{x:Static resx:Resources.EXPAND_DOCK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.ExpandDock}">
+                                                                      Value="{x:Static models:KeyValues.ExpandDockKey}">
                                                             <controls:Key.SymbolOrientation>
                                                                 <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                     <MultiBinding.Bindings>
@@ -291,7 +291,7 @@
                                                                       SymbolGeometry="{StaticResource BackIcon}"
                                                                       Text="{x:Static resx:Resources.BACK}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                                                      Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                                                     </Grid>
                                                 </Setter.Value>
                                             </Setter>
@@ -353,138 +353,138 @@
                                                                       SharedSizeGroup="KeyWithText" />
                                                         <controls:Key Grid.Row="1" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
                                                               Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseMoveAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.MOVE_BY}}"
-                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAmountInPixels}"/>
+                                                              Value="{x:Static models:KeyValues.MouseMoveAmountInPixelsKey}"/>
                                                         <controls:Key Grid.Row="1" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMoveToIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_TO_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveTo}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveToKey}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToTop}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveToTopKey}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToBottom}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveToBottomKey}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToLeft}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveToLeftKey}"/>
                                                         <controls:Key Grid.Row="3" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                                       Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveToRight}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveToRightKey}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseLeftClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseLeftClickKey}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                                       Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMiddleClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMiddleClickKey}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseRightClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseRightClickKey}"/>
                                                         <controls:Key Grid.Row="5" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseLeftDoubleClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseLeftDoubleClickKey}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDownUpIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOWN_UP_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseLeftDownUp}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseLeftDownUpKey}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMiddleDownUpIcon}"
                                                                       Text="{x:Static resx:Resources.MIDDLE_DOWN_UP_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMiddleDownUp}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMiddleDownUpKey}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseRightDownUpIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_UP_DOWN_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseRightDownUp}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseRightDownUpKey}"/>
                                                         <controls:Key Grid.Row="7" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMagneticCursorIcon}"
                                                                       Text="{x:Static resx:Resources.MAGNETIC_CURSOR_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMagneticCursor}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMagneticCursorKey}"/>
                                                         <controls:Key Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="4"
                                                                       Text="{x:Static resx:Resources.DO_AT_POINT}"
                                                                       SharedSizeGroup="KeyWithText" />
                                                         <controls:Key Grid.Row="10" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="3"
                                                                       Text="{Binding Source={x:Static properties:Settings.Default}, Path=MouseScrollAmountInClicks, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.SCROLL_BY}}"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseScrollAmountInClicks}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseScrollAmountInClicksKey}"/>
                                                         <controls:Key Grid.Row="10" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseDragIcon}"
                                                                       Text="{x:Static resx:Resources.CLICK_AND_DRAG_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseDrag}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseDragKey}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndScrollToTopKey}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndScrollToBottomKey}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToLeftIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_LEFT_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToLeft}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndScrollToLeftKey}"/>
                                                         <controls:Key Grid.Row="12" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseScrollToRightIcon}"
                                                                       Text="{x:Static resx:Resources.SCROLL_RIGHT_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToRight}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndScrollToRightKey}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndLeftClickKey}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMiddleClickIcon}"
                                                                       Text="{x:Static resx:Resources.MIDDLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndMiddleClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndMiddleClickKey}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                       Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndRightClickKey}"/>
                                                         <controls:Key Grid.Row="14" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                       Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMoveAndLeftDoubleClickKey}"/>
                                                         <controls:Key Grid.Row="16" Grid.Column="0" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                                       Text="{x:Static resx:Resources.MAGNIFIER}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
+                                                                      Value="{x:Static models:KeyValues.MouseMagnifierKey}"/>
                                                         <controls:Key Grid.Row="16" Grid.Column="1" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                                       Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
+                                                                      Value="{x:Static models:KeyValues.RepeatLastMouseActionKey}"/>
                                                         <controls:Key Grid.Row="16" Grid.Column="2" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource CollapseDockIcon}"
                                                                       Text="{x:Static resx:Resources.COLLAPSE_DOCK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.CollapseDock}">
+                                                                      Value="{x:Static models:KeyValues.CollapseDockKey}">
                                                             <controls:Key.SymbolOrientation>
                                                                 <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                     <MultiBinding.Bindings>
@@ -498,7 +498,7 @@
                                                                       SymbolGeometry="{StaticResource BackIcon}"
                                                                       Text="{x:Static resx:Resources.BACK}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
-                                                                      Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                                                      Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                                                     </Grid>
                                                 </Setter.Value>
                                             </Setter>
@@ -530,42 +530,42 @@
                                                                               SymbolGeometry="{StaticResource MouseLeftClickIcon}"
                                                                               Text="{x:Static resx:Resources.LEFT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftClick}"/>
+                                                                              Value="{x:Static models:KeyValues.MouseMoveAndLeftClickKey}"/>
                                                                 <controls:Key Grid.Row="1" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseRightClickIcon}"
                                                                               Text="{x:Static resx:Resources.RIGHT_CLICK_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndRightClick}"/>
+                                                                              Value="{x:Static models:KeyValues.MouseMoveAndRightClickKey}"/>
                                                                 <controls:Key Grid.Row="2" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseLeftDoubleClickIcon}"
                                                                               Text="{x:Static resx:Resources.LEFT_DOUBLE_CLICK_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndLeftDoubleClick}"/>
+                                                                              Value="{x:Static models:KeyValues.MouseMoveAndLeftDoubleClickKey}"/>
                                                                 <controls:Key Grid.Row="3" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseScrollToTopIcon}"
                                                                               Text="{x:Static resx:Resources.SCROLL_UP_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToTop}"/>
+                                                                              Value="{x:Static models:KeyValues.MouseMoveAndScrollToTopKey}"/>
                                                                 <controls:Key Grid.Row="4" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseScrollToBottomIcon}"
                                                                               Text="{x:Static resx:Resources.SCROLL_DOWN_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.MouseMoveAndScrollToBottom}"/>
+                                                                              Value="{x:Static models:KeyValues.MouseMoveAndScrollToBottomKey}"/>
                                                                 <controls:Key Grid.Row="5" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource MouseMagnifierIcon}"
                                                                               Text="{x:Static resx:Resources.MAGNIFIER}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.MouseMagnifier}"/>
+                                                                              Value="{x:Static models:KeyValues.MouseMagnifierKey}"/>
                                                                 <controls:Key Grid.Row="6" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource ReplayLastMouseActionIcon}"
                                                                               Text="{x:Static resx:Resources.REPEAT_LAST_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.RepeatLastMouseAction}"/>
+                                                                              Value="{x:Static models:KeyValues.RepeatLastMouseActionKey}"/>
                                                                 <controls:Key Grid.Row="7" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource ExpandDockIcon}"
                                                                               Text="{x:Static resx:Resources.EXPAND_DOCK_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.ExpandDock}">
+                                                                              Value="{x:Static models:KeyValues.ExpandDockKey}">
                                                                     <controls:Key.SymbolOrientation>
                                                                         <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                             <MultiBinding.Bindings>
@@ -579,7 +579,7 @@
                                                                               SymbolGeometry="{StaticResource BackIcon}"
                                                                               Text="{x:Static resx:Resources.BACK}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
-                                                                              Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                                                              Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                                                             </Grid>
                                                         </Setter.Value>
                                                     </Setter>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols1.xaml
@@ -4,7 +4,6 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -58,344 +57,206 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="1"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="1" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="1"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="2"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="2" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="2"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="3"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="3" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="3"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="4"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="4" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="4"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="5"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="5" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="5"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="6"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="6" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="6"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="7"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="7" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="7"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="8"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="8" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="8"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="9"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="9" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="9"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="0"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="0" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="0"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="NumericAndSymbols2Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols2Keyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="+"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="+" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="+"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="-"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="-" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="-"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="*"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="*" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="*"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="/"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="/" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="/"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="_"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="_" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="_"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="%"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="%" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="%"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="("
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="(" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="("/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text=")"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String=")" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=")"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text=":"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String=":" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=":"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text=";"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String=";" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=";"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="#"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="#" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="#"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="@"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="@" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="@"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="&amp;"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="&amp;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="&amp;"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="="
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="=" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="="/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="'"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="'" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="'"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="&quot;"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="&quot;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="&quot;"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="!"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="!" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="!"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="?"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="?" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="?"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols1.xaml
@@ -1,11 +1,11 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.NumericAndSymbols1"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.NumericAndSymbols1"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -99,12 +99,12 @@
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols2Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols2KeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="+"
@@ -150,18 +150,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="#"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -194,36 +194,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -252,11 +252,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols2.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.NumericAndSymbols2"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.NumericAndSymbols2"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -13,7 +13,7 @@
     <UserControl.Resources>
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
     </UserControl.Resources>
-    
+
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <Grid.RowDefinitions>
@@ -54,348 +54,212 @@
         <controls:Output Grid.Row="0" Grid.Column="0"
                          Grid.RowSpan="2" Grid.ColumnSpan="24" 
                          ScratchpadWidthInKeys="8"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="·"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="·" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="·"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="•"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="•" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="•"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="°"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="°" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="°"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="~"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="~" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="~"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="^"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="^" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="^"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="±"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="±" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="±"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="«"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="«" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="«"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="»"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="»" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="»"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="{}{"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="{}{" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="{}{"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="{}}"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="{}}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="{}}"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="NumericAndSymbols3Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols3Keyboard}"/>
+
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="µ" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="µ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="µ"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="©"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="©" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="©"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="®"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="®" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="®"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="\"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="\" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="\"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="|"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="|" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="|"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="¦"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¦" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¦"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="["
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="[" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="["/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="]"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="]" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="]"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="&lt;"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="&lt;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="&lt;"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="&gt;"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="&gt;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="&gt;"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="℗"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="℗" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="℗"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="™"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="™" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="™"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="℠"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="℠" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="℠"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="℡"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="℡" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="℡"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="`"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="`" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="`"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="π"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="π" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="π"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="¡"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¡" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¡"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="∴"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∴" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∴"/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="∵"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∵" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∵"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="¿"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¿" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¿"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols2.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -101,13 +100,13 @@
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols3Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols3KeyboardKey}"/>
 
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="µ" 
@@ -153,18 +152,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="℗"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -197,36 +196,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="∴"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -255,11 +254,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols3.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.NumericAndSymbols3"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.NumericAndSymbols3"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -58,344 +58,207 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="†"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="†" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="†"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="‡"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="‡" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="‡"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="№"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="№" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="№"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="÷"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="÷" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="÷"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="‰"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="‰" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="‰"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="‱"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="‱" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="‱"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="¶"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¶" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¶"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="§"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="§" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="§"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="⇒"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⇒" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⇒"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="→"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="→" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="→"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="NumericAndSymbols1Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+        
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="⊃"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊃" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊃"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="⇔"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⇔" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⇔"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="↔"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="↔" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="↔"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="¬"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="¬" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="¬"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="∧"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∧" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∧"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="∨"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∨" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∨"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="⊕"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊕" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊕"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="⊻"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊻" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊻"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="⊤"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊤" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊤"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="⊥"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊥" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊥"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="∑"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∑" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∑"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text="∀"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∀" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∀"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="∃"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∃" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∃"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2" Case="None"
                       Text="∄"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="∄" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="∄"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2" Case="None"
                       Text="≡"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="≡" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="≡"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="⊢"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊢" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊢"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="⊨"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊨" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊨"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="⋆"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⋆" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⋆"/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="⊬"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊬" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊬"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="⊭"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="⊭" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="⊭"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/NumericAndSymbols3.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -100,13 +99,13 @@
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Case="None"
                       Text="⊃"
@@ -152,18 +151,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2" Case="None"
                       Text="∑"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -196,36 +195,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text="⋆"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -254,11 +253,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/PhysicalKeys.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/PhysicalKeys.xaml
@@ -59,327 +59,198 @@
         <controls:Key Grid.Row="2" Grid.Column="0" />
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Case="None"
                       Text="F1"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F1}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F1}"/>
         <controls:Key Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="2" Case="None"
                       Text="F2"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F2}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F2}"/>
         <controls:Key Grid.Row="2" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
                       Text="F3"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F3}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F3}"/>
         <controls:Key Grid.Row="2" Grid.Column="7" Grid.ColumnSpan="2" Case="None"
                       Text="F4"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F4}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F4}"/>
         <controls:Key Grid.Row="2" Grid.Column="9" Grid.ColumnSpan="2" Case="None"
                       Text="F5"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F5}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F5}"/>
         <controls:Key Grid.Row="2" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
                       Text="F6"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F6}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F6}"/>
         <controls:Key Grid.Row="2" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
                       Text="F7"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F7}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F7}"/>
         <controls:Key Grid.Row="2" Grid.Column="15" Grid.ColumnSpan="2" Case="None"
                       Text="F8"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F8}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F8}"/>
         <controls:Key Grid.Row="2" Grid.Column="17" Grid.ColumnSpan="2" Case="None"
                       Text="F9"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F9}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F9}"/>
         <controls:Key Grid.Row="2" Grid.Column="19" Grid.ColumnSpan="2" Case="None"
                       Text="F10"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F10}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F10}"/>
         <controls:Key Grid.Row="2" Grid.Column="21" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="23" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ESC}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Escape}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.Escape}"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.BREAK}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Break}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.Break}"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.DEL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Delete}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.Delete}"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.INS}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Insert}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.Insert}"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.PG_UP_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PgUp}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.PgUp}"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource UpArrowKeyIcon}"
                       Text="{x:Static resx:Resources.UP_ARROW_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ArrowUp}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ArrowUp}"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.PG_DN_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PgDn}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.PgDn}"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.HOME}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Home}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.Home}"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="F11"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F11}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F11}"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="F12"
-                      SharedSizeGroup="FunctionKey">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.F12}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="FunctionKey"
+                      Value="{x:Static enums:FunctionKeys.F12}"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.PRNT_SCR_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PrintScreen}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.PrintScreen}"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.NUM_LK_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumberLock}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.NumberLock}"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.SCRN_LK_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ScrollLock}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.ScrollLock}"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource LeftArrowKeyIcon}"
                       Text="{x:Static resx:Resources.LEFT_ARROW_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ArrowLeft}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ArrowLeft}"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DownArrowKeyIcon}"
                       Text="{x:Static resx:Resources.DOWN_ARROW_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ArrowDown}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ArrowDown}"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource RightArrowKeyIcon}"
                       Text="{x:Static resx:Resources.RIGHT_ARROW_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ArrowRight}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ArrowRight}"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.END}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.End}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.End}"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="8"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="4" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                           Text="{x:Static resx:Resources.CONTEXTUAL_MENU_KEY}"
-                          SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Menu}" />
-            </controls:Key.Value>
-        </controls:Key>
+                          SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.Menu}"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/PhysicalKeys.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/PhysicalKeys.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.PhysicalKeys"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.PhysicalKeys"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -60,172 +59,172 @@
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Case="None"
                       Text="F1"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F1}"/>
+                      Value="{x:Static models:KeyValues.F1Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="2" Case="None"
                       Text="F2"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F2}"/>
+                      Value="{x:Static models:KeyValues.F2Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
                       Text="F3"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F3}"/>
+                      Value="{x:Static models:KeyValues.F3Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="7" Grid.ColumnSpan="2" Case="None"
                       Text="F4"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F4}"/>
+                      Value="{x:Static models:KeyValues.F4Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="9" Grid.ColumnSpan="2" Case="None"
                       Text="F5"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F5}"/>
+                      Value="{x:Static models:KeyValues.F5Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
                       Text="F6"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F6}"/>
+                      Value="{x:Static models:KeyValues.F6Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="13" Grid.ColumnSpan="2" Case="None"
                       Text="F7"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F7}"/>
+                      Value="{x:Static models:KeyValues.F7Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="15" Grid.ColumnSpan="2" Case="None"
                       Text="F8"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F8}"/>
+                      Value="{x:Static models:KeyValues.F8Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="17" Grid.ColumnSpan="2" Case="None"
                       Text="F9"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F9}"/>
+                      Value="{x:Static models:KeyValues.F9Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="19" Grid.ColumnSpan="2" Case="None"
                       Text="F10"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F10}"/>
+                      Value="{x:Static models:KeyValues.F10Key}"/>
         <controls:Key Grid.Row="2" Grid.Column="21" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="23" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ESC}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.Escape}"/>
+                      Value="{x:Static models:KeyValues.EscapeKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.BREAK}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.Break}"/>
+                      Value="{x:Static models:KeyValues.BreakKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.DEL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.Delete}"/>
+                      Value="{x:Static models:KeyValues.DeleteKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.INS}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.Insert}"/>
+                      Value="{x:Static models:KeyValues.InsertKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.PG_UP_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.PgUp}"/>
+                      Value="{x:Static models:KeyValues.PgUpKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource UpArrowKeyIcon}"
                       Text="{x:Static resx:Resources.UP_ARROW_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ArrowUp}"/>
+                      Value="{x:Static models:KeyValues.ArrowUpKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.PG_DN_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.PgDn}"/>
+                      Value="{x:Static models:KeyValues.PgDnKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.HOME}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.Home}"/>
+                      Value="{x:Static models:KeyValues.HomeKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="F11"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F11}"/>
+                      Value="{x:Static models:KeyValues.F11Key}"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2" Case="None"
                       Text="F12"
                       SharedSizeGroup="FunctionKey"
-                      Value="{x:Static enums:FunctionKeys.F12}"/>
+                      Value="{x:Static models:KeyValues.F12Key}"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.PRNT_SCR_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.PrintScreen}"/>
+                      Value="{x:Static models:KeyValues.PrintScreenKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.NUM_LK_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.NumberLock}"/>
+                      Value="{x:Static models:KeyValues.NumberLockKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.SCRN_LK_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.ScrollLock}"/>
+                      Value="{x:Static models:KeyValues.ScrollLockKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource LeftArrowKeyIcon}"
                       Text="{x:Static resx:Resources.LEFT_ARROW_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ArrowLeft}"/>
+                      Value="{x:Static models:KeyValues.ArrowLeftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DownArrowKeyIcon}"
                       Text="{x:Static resx:Resources.DOWN_ARROW_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ArrowDown}"/>
+                      Value="{x:Static models:KeyValues.ArrowDownKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource RightArrowKeyIcon}"
                       Text="{x:Static resx:Resources.RIGHT_ARROW_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ArrowRight}"/>
+                      Value="{x:Static models:KeyValues.ArrowRightKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.END}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.End}"/>
+                      Value="{x:Static models:KeyValues.EndKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="8"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
@@ -235,7 +234,7 @@
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                           Text="{x:Static resx:Resources.CONTEXTUAL_MENU_KEY}"
                           SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.Menu}"/>
+                      Value="{x:Static models:KeyValues.MenuKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
@@ -246,11 +245,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/SizeAndPosition.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/SizeAndPosition.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
@@ -59,286 +58,184 @@
                             <controls:Key Grid.Row="0" Grid.Column="0"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToTopAndLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToTopAndLeft}"/>
                             <controls:Key Grid.Row="0" Grid.Column="1"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_UP_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToTop}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToTop}"/>
                             <controls:Key Grid.Row="0" Grid.Column="2"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToTopAndRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToTopAndRight}"/>
                             <controls:Key Grid.Row="0" Grid.Column="4"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromTopAndLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndLeft}"/>
                             <controls:Key Grid.Row="0" Grid.Column="5"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_DOWN_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromTop}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromTop}"/>
                             <controls:Key Grid.Row="0" Grid.Column="6"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromTopAndRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndRight}"/>
                             <controls:Key Grid.Row="0" Grid.Column="8"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                           Text="{x:Static resx:Resources.MOVE_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndLeft}"/>
                             <controls:Key Grid.Row="0" Grid.Column="9" 
                                           SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                           Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTop}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToTop}"/>
                             <controls:Key Grid.Row="0" Grid.Column="10"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                           Text="{x:Static resx:Resources.MOVE_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndRight}"/>
                             <controls:Key Grid.Row="0" Grid.Column="12"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndLeftBoundaries}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndLeftBoundaries}"/>
                             <controls:Key Grid.Row="0" Grid.Column="13"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_UP_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopBoundary}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToTopBoundary}"/>
                             <controls:Key Grid.Row="0" Grid.Column="14"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndRightBoundaries}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndRightBoundaries}"/>
                             <controls:Key Grid.Row="1" Grid.Column="0"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToLeft}"/>
                             <controls:Key Grid.Row="1" Grid.Column="1"
                                           Text="{x:Static resx:Resources.EXPAND}"
                                           SharedSizeGroup="KeyWithText" />
                             <controls:Key Grid.Row="1" Grid.Column="2"
                                           SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToRight}"/>
                             <controls:Key Grid.Row="1" Grid.Column="4"
                                           SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromLeft}"/>
                             <controls:Key Grid.Row="1" Grid.Column="5"
                                           Text="{x:Static resx:Resources.SHRINK}"
                                           SharedSizeGroup="KeyWithText" />
                             <controls:Key Grid.Row="1" Grid.Column="6"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromRight}"/>
                             <controls:Key Grid.Row="1" Grid.Column="8"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                           Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToLeft}"/>
                             <controls:Key Grid.Row="1" Grid.Column="9"
                                           Text="{x:Static resx:Resources.MOVE}"
                                           SharedSizeGroup="KeyWithText" />
                             <controls:Key Grid.Row="1" Grid.Column="10"
                                           SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                           Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToRight}"/>
                             <controls:Key Grid.Row="1" Grid.Column="12"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToLeftBoundary}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToLeftBoundary}"/>
                             <controls:Key Grid.Row="1" Grid.Column="13"
                                           Text="{x:Static resx:Resources.JUMP}"
                                           SharedSizeGroup="KeyWithText" />
                             <controls:Key Grid.Row="1" Grid.Column="14"
                                           SymbolGeometry="{StaticResource ArrowPointingToRightBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToRightBoundary}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToRightBoundary}"/>
 
                             <controls:Key Grid.Row="2" Grid.Column="0"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToBottomAndLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToBottomAndLeft}"/>
                             <controls:Key Grid.Row="2" Grid.Column="1"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_DOWN_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToBottom}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToBottom}"/>
                             <controls:Key Grid.Row="2" Grid.Column="2"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToBottomAndRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ExpandToBottomAndRight}"/>
                             <controls:Key Grid.Row="2" Grid.Column="4"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromBottomAndLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndLeft}"/>
                             <controls:Key Grid.Row="2" Grid.Column="5"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_UP_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromBottom}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromBottom}"/>
                             <controls:Key Grid.Row="2" Grid.Column="6"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromBottomAndRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndRight}"/>
                             <controls:Key Grid.Row="2" Grid.Column="8"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                           Text="{x:Static resx:Resources.MOVE_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndLeft}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeft}"/>
                             <controls:Key Grid.Row="2" Grid.Column="9"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                           Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottom}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToBottom}"/>
                             <controls:Key Grid.Row="2" Grid.Column="10"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                           Text="{x:Static resx:Resources.MOVE_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndRight}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndRight}"/>
                             <controls:Key Grid.Row="2" Grid.Column="12"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndLeftBoundaries}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeftBoundaries}"/>
                             <controls:Key Grid.Row="2" Grid.Column="13"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_DOWN_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomBoundary}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToBottomBoundary}"/>
                             <controls:Key Grid.Row="2" Grid.Column="14"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndRightBoundaries}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndRightBoundaries}"/>
                             <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="11"
-                                          Text="{Binding Source={x:Static properties:Settings.Default}, Path=MoveAndResizeAdjustmentAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.ADJUST_BY}}">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveAndResizeAdjustmentAmount}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          Text="{Binding Source={x:Static properties:Settings.Default}, Path=MoveAndResizeAdjustmentAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.ADJUST_BY}}"
+                                          Value="{x:Static enums:FunctionKeys.MoveAndResizeAdjustmentAmount}"/>
                             <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="3"
                                           SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbolAndText"
+                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                         </Grid>
                     </Setter.Value>
                 </Setter>
@@ -379,285 +276,183 @@
                                     <controls:Key Grid.Row="0" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToTopAndLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToTopAndLeft}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="1"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_UP_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToTop}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToTop}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToTopAndRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToTopAndRight}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromTopAndLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndLeft}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_DOWN_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromTop}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromTop}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromTopAndRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndRight}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToLeft}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.EXPAND}"
                                                   SharedSizeGroup="KeyWithText" />
                                     <controls:Key Grid.Row="1" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToRight}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromLeft}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="5"
                                                   Text="{x:Static resx:Resources.SHRINK}"
                                                   SharedSizeGroup="KeyWithText" />
                                     <controls:Key Grid.Row="1" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromRight}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToBottomAndLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToBottomAndLeft}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="1"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_DOWN_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToBottom}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToBottom}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ExpandToBottomAndRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ExpandToBottomAndRight}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromBottomAndLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndLeft}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_UP_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromBottom}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromBottom}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ShrinkFromBottomAndRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndRight}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndLeft}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="1" 
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTop}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToTop}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndRight}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndLeftBoundaries}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndLeftBoundaries}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_UP_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopBoundary}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToTopBoundary}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToTopAndRightBoundaries}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndRightBoundaries}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToLeft}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.MOVE}"
                                                   SharedSizeGroup="KeyWithText" />
                                     <controls:Key Grid.Row="5" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToRight}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToLeftBoundary}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToLeftBoundary}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="5"
                                                   Text="{x:Static resx:Resources.JUMP}"
                                                   SharedSizeGroup="KeyWithText" />
                                     <controls:Key Grid.Row="5" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToRightBoundary}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToRightBoundary}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndLeft}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeft}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="1"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottom}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToBottom}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndRight}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndRight}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndLeftBoundaries}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeftBoundaries}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_DOWN_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomBoundary}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomBoundary}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
-                                                  SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveToBottomAndRightBoundaries}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndRightBoundaries}"/>
                                     <controls:Key Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="3"
-                                                  Text="{Binding Source={x:Static properties:Settings.Default}, Path=MoveAndResizeAdjustmentAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.ADJUST_BY}}">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MoveAndResizeAdjustmentAmount}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  Text="{Binding Source={x:Static properties:Settings.Default}, Path=MoveAndResizeAdjustmentAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.ADJUST_BY}}"
+                                                  Value="{x:Static enums:FunctionKeys.MoveAndResizeAdjustmentAmount}"/>
                                     <controls:Key Grid.Row="8" Grid.Column="4" Grid.ColumnSpan="3"
                                                   SymbolGeometry="{StaticResource BackIcon}"
                                                   Text="{x:Static resx:Resources.BACK}"
-                                          SharedSizeGroup="KeyWithSymbolAndText">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbolAndText"
+                                                  Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                                 </Grid>
                             </Setter.Value>
                         </Setter>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/SizeAndPosition.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/SizeAndPosition.xaml
@@ -1,13 +1,13 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.SizeAndPosition"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.SizeAndPosition"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -59,67 +59,67 @@
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToTopAndLeft}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToTopAndLeftKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="1"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_UP_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToTop}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToTopKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="2"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToTopAndRight}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToTopAndRightKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="4"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndLeft}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromTopAndLeftKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="5"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_DOWN_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromTop}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromTopKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="6"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndRight}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromTopAndRightKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="8"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                           Text="{x:Static resx:Resources.MOVE_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndLeft}"/>
+                                          Value="{x:Static models:KeyValues.MoveToTopAndLeftKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="9" 
                                           SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                           Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToTop}"/>
+                                          Value="{x:Static models:KeyValues.MoveToTopKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="10"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                           Text="{x:Static resx:Resources.MOVE_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndRight}"/>
+                                          Value="{x:Static models:KeyValues.MoveToTopAndRightKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="12"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndLeftBoundaries}"/>
+                                          Value="{x:Static models:KeyValues.MoveToTopAndLeftBoundariesKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="13"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_UP_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToTopBoundary}"/>
+                                          Value="{x:Static models:KeyValues.MoveToTopBoundaryKey}"/>
                             <controls:Key Grid.Row="0" Grid.Column="14"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToTopAndRightBoundaries}"/>
+                                          Value="{x:Static models:KeyValues.MoveToTopAndRightBoundariesKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="0"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToLeft}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToLeftKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="1"
                                           Text="{x:Static resx:Resources.EXPAND}"
                                           SharedSizeGroup="KeyWithText" />
@@ -127,12 +127,12 @@
                                           SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToRight}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToRightKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="4"
                                           SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromLeft}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromLeftKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="5"
                                           Text="{x:Static resx:Resources.SHRINK}"
                                           SharedSizeGroup="KeyWithText" />
@@ -140,12 +140,12 @@
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromRight}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromRightKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="8"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                           Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToLeft}"/>
+                                          Value="{x:Static models:KeyValues.MoveToLeftKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="9"
                                           Text="{x:Static resx:Resources.MOVE}"
                                           SharedSizeGroup="KeyWithText" />
@@ -153,12 +153,12 @@
                                           SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                           Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToRight}"/>
+                                          Value="{x:Static models:KeyValues.MoveToRightKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="12"
                                           SymbolGeometry="{StaticResource ArrowPointingToLeftBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToLeftBoundary}"/>
+                                          Value="{x:Static models:KeyValues.MoveToLeftBoundaryKey}"/>
                             <controls:Key Grid.Row="1" Grid.Column="13"
                                           Text="{x:Static resx:Resources.JUMP}"
                                           SharedSizeGroup="KeyWithText" />
@@ -166,76 +166,76 @@
                                           SymbolGeometry="{StaticResource ArrowPointingToRightBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToRightBoundary}"/>
+                                          Value="{x:Static models:KeyValues.MoveToRightBoundaryKey}"/>
 
                             <controls:Key Grid.Row="2" Grid.Column="0"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToBottomAndLeft}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToBottomAndLeftKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="1"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_DOWN_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToBottom}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToBottomKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="2"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                           Text="{x:Static resx:Resources.EXPAND_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ExpandToBottomAndRight}"/>
+                                          Value="{x:Static models:KeyValues.ExpandToBottomAndRightKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="4"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndLeft}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromBottomAndLeftKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="5"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_UP_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromBottom}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromBottomKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="6"
                                           SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                           Text="{x:Static resx:Resources.SHRINK_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndRight}"/>
+                                          Value="{x:Static models:KeyValues.ShrinkFromBottomAndRightKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="8"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                           Text="{x:Static resx:Resources.MOVE_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeft}"/>
+                                          Value="{x:Static models:KeyValues.MoveToBottomAndLeftKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="9"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                           Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToBottom}"/>
+                                          Value="{x:Static models:KeyValues.MoveToBottomKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="10"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                           Text="{x:Static resx:Resources.MOVE_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndRight}"/>
+                                          Value="{x:Static models:KeyValues.MoveToBottomAndRightKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="12"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomLeftBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeftBoundaries}"/>
+                                          Value="{x:Static models:KeyValues.MoveToBottomAndLeftBoundariesKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="13"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_DOWN_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToBottomBoundary}"/>
+                                          Value="{x:Static models:KeyValues.MoveToBottomBoundaryKey}"/>
                             <controls:Key Grid.Row="2" Grid.Column="14"
                                           SymbolGeometry="{StaticResource ArrowPointingToBottomRightBoundaryIcon}"
                                           Text="{x:Static resx:Resources.JUMP_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.MoveToBottomAndRightBoundaries}"/>
+                                          Value="{x:Static models:KeyValues.MoveToBottomAndRightBoundariesKey}"/>
                             <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="11"
                                           Text="{Binding Source={x:Static properties:Settings.Default}, Path=MoveAndResizeAdjustmentAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.ADJUST_BY}}"
-                                          Value="{x:Static enums:FunctionKeys.MoveAndResizeAdjustmentAmount}"/>
+                                          Value="{x:Static models:KeyValues.MoveAndResizeAdjustmentAmountKey}"/>
                             <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="3"
                                           SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
                                           SharedSizeGroup="KeyWithSymbolAndText"
-                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                          Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                         </Grid>
                     </Setter.Value>
                 </Setter>
@@ -277,37 +277,37 @@
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToTopAndLeft}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToTopAndLeftKey}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="1"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_UP_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToTop}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToTopKey}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToTopAndRight}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToTopAndRightKey}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndLeft}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromTopAndLeftKey}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_DOWN_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromTop}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromTopKey}"/>
                                     <controls:Key Grid.Row="0" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromTopAndRight}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromTopAndRightKey}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToLeft}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToLeftKey}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.EXPAND}"
                                                   SharedSizeGroup="KeyWithText" />
@@ -315,12 +315,12 @@
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToRight}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToRightKey}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromLeft}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromLeftKey}"/>
                                     <controls:Key Grid.Row="1" Grid.Column="5"
                                                   Text="{x:Static resx:Resources.SHRINK}"
                                                   SharedSizeGroup="KeyWithText" />
@@ -328,72 +328,72 @@
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromRight}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromRightKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToBottomAndLeft}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToBottomAndLeftKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="1"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_DOWN_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToBottom}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToBottomKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                                   Text="{x:Static resx:Resources.EXPAND_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ExpandToBottomAndRight}"/>
+                                                  Value="{x:Static models:KeyValues.ExpandToBottomAndRightKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndLeft}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromBottomAndLeftKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_UP_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromBottom}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromBottomKey}"/>
                                     <controls:Key Grid.Row="2" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                                   Text="{x:Static resx:Resources.SHRINK_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.ShrinkFromBottomAndRight}"/>
+                                                  Value="{x:Static models:KeyValues.ShrinkFromBottomAndRightKey}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndLeft}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToTopAndLeftKey}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="1" 
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_UP_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToTop}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToTopKey}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndRight}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToTopAndRightKey}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopLeftBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_UP_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndLeftBoundaries}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToTopAndLeftBoundariesKey}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_UP_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToTopBoundary}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToTopBoundaryKey}"/>
                                     <controls:Key Grid.Row="4" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToTopRightBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_UP_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToTopAndRightBoundaries}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToTopAndRightBoundariesKey}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToLeft}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToLeftKey}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="1"
                                                   Text="{x:Static resx:Resources.MOVE}"
                                                   SharedSizeGroup="KeyWithText" />
@@ -401,12 +401,12 @@
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToRight}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToRightKey}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToLeftBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToLeftBoundary}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToLeftBoundaryKey}"/>
                                     <controls:Key Grid.Row="5" Grid.Column="5"
                                                   Text="{x:Static resx:Resources.JUMP}"
                                                   SharedSizeGroup="KeyWithText" />
@@ -414,45 +414,45 @@
                                                   SymbolGeometry="{StaticResource ArrowPointingToRightBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToRightBoundary}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToRightBoundaryKey}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="0"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeft}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToBottomAndLeftKey}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="1"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_DOWN_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToBottom}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToBottomKey}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="2"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightIcon}"
                                                   Text="{x:Static resx:Resources.MOVE_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndRight}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToBottomAndRightKey}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="4"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomLeftBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_DOWN_AND_LEFT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndLeftBoundaries}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToBottomAndLeftBoundariesKey}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="5"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_DOWN_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomBoundary}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToBottomBoundaryKey}"/>
                                     <controls:Key Grid.Row="6" Grid.Column="6"
                                                   SymbolGeometry="{StaticResource ArrowPointingToBottomRightBoundaryIcon}"
                                                   Text="{x:Static resx:Resources.JUMP_DOWN_AND_RIGHT_SPLIT_WITH_NEWLINE}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.MoveToBottomAndRightBoundaries}"/>
+                                                  Value="{x:Static models:KeyValues.MoveToBottomAndRightBoundariesKey}"/>
                                     <controls:Key Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="3"
                                                   Text="{Binding Source={x:Static properties:Settings.Default}, Path=MoveAndResizeAdjustmentAmountInPixels, Converter={StaticResource IntToSingularPluralStringFormatter}, ConverterParameter={x:Static resx:Resources.ADJUST_BY}}"
-                                                  Value="{x:Static enums:FunctionKeys.MoveAndResizeAdjustmentAmount}"/>
+                                                  Value="{x:Static models:KeyValues.MoveAndResizeAdjustmentAmountKey}"/>
                                     <controls:Key Grid.Row="8" Grid.Column="4" Grid.ColumnSpan="3"
                                                   SymbolGeometry="{StaticResource BackIcon}"
                                                   Text="{x:Static resx:Resources.BACK}"
                                                   SharedSizeGroup="KeyWithSymbolAndText"
-                                                  Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                                  Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                                 </Grid>
                             </Setter.Value>
                         </Setter>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/YesNoQuestion.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/YesNoQuestion.xaml
@@ -4,15 +4,15 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
     <UserControl.Resources>
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
     </UserControl.Resources>
-    
+
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <Grid.RowDefinitions>
@@ -53,25 +53,19 @@
         <controls:QuestionText Grid.Row="0" Grid.Column="0" 
                            Grid.RowSpan="3" Grid.ColumnSpan="22"
                            Text="{Binding Text, Mode=OneWay}" />
-        
+
         <controls:Key Grid.Row="4" Grid.Column="4" 
                       Grid.RowSpan="3" Grid.ColumnSpan="6"
                       SymbolGeometry="{StaticResource YesIcon}"
                       Text="{x:Static resx:Resources.YES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="YesQuestionResult" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.YesQuestionResult}" />
 
         <controls:Key Grid.Row="4" Grid.Column="14" 
                       Grid.RowSpan="3" Grid.ColumnSpan="6"
                       SymbolGeometry="{StaticResource NoIcon}"
                       Text="{x:Static resx:Resources.NO}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="NoQuestionResult" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NoQuestionResult}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/YesNoQuestion.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/YesNoQuestion.xaml
@@ -1,11 +1,11 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.YesNoQuestion"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.YesNoQuestion"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -59,13 +59,13 @@
                       SymbolGeometry="{StaticResource YesIcon}"
                       Text="{x:Static resx:Resources.YES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.YesQuestionResult}" />
+                      Value="{x:Static models:KeyValues.YesQuestionResultKey}" />
 
         <controls:Key Grid.Row="4" Grid.Column="14" 
                       Grid.RowSpan="3" Grid.ColumnSpan="6"
                       SymbolGeometry="{StaticResource NoIcon}"
                       Text="{x:Static resx:Resources.NO}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NoQuestionResult}" />
+                      Value="{x:Static models:KeyValues.NoQuestionResultKey}" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/Alpha.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.English.Alpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.English.Alpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -102,7 +101,7 @@
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="23" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
@@ -150,18 +149,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -194,36 +193,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -242,7 +241,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
@@ -253,11 +252,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/Alpha.xaml
@@ -13,7 +13,7 @@
     <UserControl.Resources>
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
     </UserControl.Resources>
-    
+
     <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
           Grid.IsSharedSizeScope="True">
         <Grid.RowDefinitions>
@@ -54,344 +54,210 @@
         <controls:Output Grid.Row="0" Grid.Column="0"
                          Grid.RowSpan="2" Grid.ColumnSpan="24" 
                          ScratchpadWidthInKeys="8"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
-        
+                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+
         <controls:Key Grid.Row="2" Grid.Column="0" />
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="q" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="q"/>
         <controls:Key Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="w" ShiftDownText="W"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="w" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="w"/>
         <controls:Key Grid.Row="2" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="e" ShiftDownText="E" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="e" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="e"/>
         <controls:Key Grid.Row="2" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="r" ShiftDownText="R"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="r" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="r"/>
         <controls:Key Grid.Row="2" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="t" ShiftDownText="T"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="t" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="t"/>
         <controls:Key Grid.Row="2" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="y" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="y"/>
         <controls:Key Grid.Row="2" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="u" ShiftDownText="U"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="u" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="u"/>
         <controls:Key Grid.Row="2" Grid.Column="15" Grid.ColumnSpan="2"
                       ShiftUpText="i" ShiftDownText="I"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="i" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="i"/>
         <controls:Key Grid.Row="2" Grid.Column="17" Grid.ColumnSpan="2"
                       ShiftUpText="o" ShiftDownText="O"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="o" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="o"/>
         <controls:Key Grid.Row="2" Grid.Column="19" Grid.ColumnSpan="2"
                       ShiftUpText="p" ShiftDownText="P"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="p" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="p"/>
         <controls:Key Grid.Row="2" Grid.Column="21" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="23" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource TabIcon}" 
                       Text="{x:Static resx:Resources.TAB}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x09;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="&#x09;"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="a" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="a"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="s" ShiftDownText="S"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="s" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="s"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="d" ShiftDownText="D"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="d" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="d"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="f" ShiftDownText="F"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="f" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="f"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="g" ShiftDownText="G"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="g" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="g"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="h" ShiftDownText="H"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="h" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="h"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="j" ShiftDownText="J"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="j" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="j"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="k" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="k"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="l" ShiftDownText="L"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="l" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="l"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="z" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="z"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="x" ShiftDownText="X"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="x" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="x"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="c" ShiftDownText="C"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="c" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="c"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="v" ShiftDownText="V"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="v" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="v"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="b" ShiftDownText="B"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="b" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="b"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="n" ShiftDownText="N"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="n" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="n"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="m" ShiftDownText="M"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="m" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="m"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" Case="None"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="MultiKeySelectionIsOn" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/ConversationAlpha.xaml
@@ -55,257 +55,155 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="q" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="q"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="w" ShiftDownText="W"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="w" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="w"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="e" ShiftDownText="E" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="e" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="e"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="r" ShiftDownText="R"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="r" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="r"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="t" ShiftDownText="T"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="t" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="t"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="y" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="y"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="u" ShiftDownText="U"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="u" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="u"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="i" ShiftDownText="I"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="i" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="i"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="o" ShiftDownText="O"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="o" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="o"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="p" ShiftDownText="P"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="p" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="p"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" />
         <controls:Key Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="a" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="a"/>
         <controls:Key Grid.Row="3" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="s" ShiftDownText="S"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="s" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="s"/>
         <controls:Key Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="d" ShiftDownText="D"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="d" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="d"/>
         <controls:Key Grid.Row="3" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="f" ShiftDownText="F"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="f" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="f"/>
         <controls:Key Grid.Row="3" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="g" ShiftDownText="G"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="g" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="g"/>
         <controls:Key Grid.Row="3" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="h" ShiftDownText="H"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="h" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="h"/>
         <controls:Key Grid.Row="3" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="j" ShiftDownText="J"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="j" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="j"/>
         <controls:Key Grid.Row="3" Grid.Column="15" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="k" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="k"/>
         <controls:Key Grid.Row="3" Grid.Column="17" Grid.ColumnSpan="2"
                       ShiftUpText="l" ShiftDownText="L"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="l" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="l"/>
         <controls:Key Grid.Row="3" Grid.Column="19" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" />
         <controls:Key Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="z" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="z"/>
         <controls:Key Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="x" ShiftDownText="X"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="x" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="x"/>
         <controls:Key Grid.Row="4" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="c" ShiftDownText="C"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="c" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="c"/>
         <controls:Key Grid.Row="4" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="v" ShiftDownText="V"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="v" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="v"/>
         <controls:Key Grid.Row="4" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="b" ShiftDownText="B"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="b" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="b"/>
         <controls:Key Grid.Row="4" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="n" ShiftDownText="N"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="n" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="n"/>
         <controls:Key Grid.Row="4" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="m" ShiftDownText="M"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="m" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="m"/>
         <controls:Key Grid.Row="4" Grid.Column="15" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="17" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="19" />
         
         <controls:Key Grid.Row="5" Grid.Column="0" />
         <controls:Key Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="7" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="11" Grid.ColumnSpan="2" Case="None"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="13" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
         <ContentControl Grid.Row="5" Grid.Column="15" Grid.ColumnSpan="2">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -313,11 +211,8 @@
                         <Setter.Value>
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
-                                          SharedSizeGroup="KeyWithSymbol">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbol"
+                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -326,11 +221,8 @@
                                 <Setter.Value>
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
-                                                  SharedSizeGroup="KeyWithSymbol">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Quit}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbol"
+                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -341,10 +233,7 @@
         <controls:Key Grid.Row="5" Grid.Column="17"  Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Calibrate}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/ConversationAlpha.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.English.ConversationAlpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.English.ConversationAlpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -166,12 +165,12 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="17" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="19" />
         
         <controls:Key Grid.Row="5" Grid.Column="0" />
@@ -179,12 +178,12 @@
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
+                      Value="{x:Static models:KeyValues.ConversationNumericAndSymbolsKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2" Case="None"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -203,7 +202,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}"/>
         <ContentControl Grid.Row="5" Grid.Column="15" Grid.ColumnSpan="2">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -212,7 +211,7 @@
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
                                           SharedSizeGroup="KeyWithSymbol"
-                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                          Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -222,7 +221,7 @@
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
                                                   SharedSizeGroup="KeyWithSymbol"
-                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
+                                                  Value="{x:Static models:KeyValues.QuitKey}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -234,6 +233,6 @@
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
+                      Value="{x:Static models:KeyValues.CalibrateKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Alpha.xaml
@@ -63,375 +63,224 @@
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="à" ShiftDownText="À"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="à" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="à"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="a" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="a"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="z" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="z"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="e" ShiftDownText="E" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="e" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="e"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="r" ShiftDownText="R"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="r" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="r"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="t" ShiftDownText="T"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="t" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="t"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="y" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="y"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="u" ShiftDownText="U"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="u" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="u"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="i" ShiftDownText="I"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="i" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="i"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="o" ShiftDownText="O"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="o" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="o"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       ShiftUpText="p" ShiftDownText="P"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="p" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="p"/>
         <controls:Key Grid.Row="2" Grid.Column="24" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="2" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
         
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource TabIcon}" 
                       Text="{x:Static resx:Resources.TAB}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x09;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="&#x09;"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ç" ShiftDownText="Ç"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ç" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ç"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="q" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="q"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="s" ShiftDownText="S"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="s" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="s"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="d" ShiftDownText="D"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="d" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="d"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="f" ShiftDownText="F"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="f" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="f"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="g" ShiftDownText="G"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="g" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="g"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="h" ShiftDownText="H"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="h" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="h"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="j" ShiftDownText="J"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="j" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="j"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="k" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="k"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="l" ShiftDownText="L"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="l" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="l"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       ShiftUpText="m" ShiftDownText="M"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="m" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="m"/>
         <controls:Key Grid.Row="3" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="é" ShiftDownText="É"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="é" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="é"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="è" ShiftDownText="È"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="è" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="è"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="w" ShiftDownText="W"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="w" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="w"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="x" ShiftDownText="X"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="x" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="x"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="c" ShiftDownText="C"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="c" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="c"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="v" ShiftDownText="V"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="v" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="v"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="b" ShiftDownText="B"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="b" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="b"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="n" ShiftDownText="N"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="n" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="n"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ù" ShiftDownText="Ù"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ù" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ù"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
         
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="8"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="4" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="2" Case="None"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="MultiKeySelectionIsOn" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" />
-                <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Alpha.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Alpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Alpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -110,7 +109,7 @@
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
         
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource TabIcon}" 
@@ -165,18 +164,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="é" ShiftDownText="É"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -217,36 +216,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
         
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" Case="None"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -265,7 +264,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}" />
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
@@ -276,11 +275,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/ConversationAlpha.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.ConversationAlpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.ConversationAlpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -186,23 +185,23 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
+                      Value="{x:Static models:KeyValues.ConversationNumericAndSymbolsKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -221,7 +220,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}"/>
         <ContentControl Grid.Row="5" Grid.Column="18" Grid.ColumnSpan="2">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -230,7 +229,7 @@
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
                                           SharedSizeGroup="KeyWithSymbol"
-                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                          Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -240,7 +239,7 @@
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
                                                   SharedSizeGroup="KeyWithSymbol"
-                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
+                                                  Value="{x:Static models:KeyValues.QuitKey}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -252,6 +251,6 @@
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
+                      Value="{x:Static models:KeyValues.CalibrateKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/ConversationAlpha.xaml
@@ -53,291 +53,175 @@
         <controls:Output Grid.Row="0" Grid.Column="0"
                          Grid.RowSpan="2" Grid.ColumnSpan="22" 
                          ScratchpadWidthInKeys="6"
-                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" /> <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+                         NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="à" ShiftDownText="À"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="à" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="à"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="a" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="a"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="z" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="z"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="e" ShiftDownText="E" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="e" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="e"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="r" ShiftDownText="R"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="r" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="r"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="t" ShiftDownText="T"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="t" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="t"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="y" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="y"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="u" ShiftDownText="U"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="u" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="u"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="i" ShiftDownText="I"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="i" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="i"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="o" ShiftDownText="O"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="o" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="o"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="p" ShiftDownText="P"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="p" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="p"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ç" ShiftDownText="Ç"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ç" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ç"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="q" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="q"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="s" ShiftDownText="S"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="s" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="s"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="d" ShiftDownText="D"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="d" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="d"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="f" ShiftDownText="F"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="f" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="f"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="g" ShiftDownText="G"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="g" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="g"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="h" ShiftDownText="H"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="h" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="h"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="j" ShiftDownText="J"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="j" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="j"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="k" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="k"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="l" ShiftDownText="L"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="l" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="l"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="m" ShiftDownText="M"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="m" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="m"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="é" ShiftDownText="É"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="é" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="é"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="è" ShiftDownText="È"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="è" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="è"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="w" ShiftDownText="W"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="w" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="w"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="x" ShiftDownText="X"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="x" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="x"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="c" ShiftDownText="C"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="c" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="c"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="v" ShiftDownText="V"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="v" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="v"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="b" ShiftDownText="B"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="b" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="b"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="n" ShiftDownText="N"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="n" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="n"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ù" ShiftDownText="Ù"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ù" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ù"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2" Case="None"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="8"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="4" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" Case="None"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
         <ContentControl Grid.Row="5" Grid.Column="18" Grid.ColumnSpan="2">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -345,11 +229,8 @@
                         <Setter.Value>
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
-                                          SharedSizeGroup="KeyWithSymbol">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbol"
+                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -358,11 +239,8 @@
                                 <Setter.Value>
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
-                                                  SharedSizeGroup="KeyWithSymbol">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Quit}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbol"
+                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -373,10 +251,7 @@
         <controls:Key Grid.Row="5" Grid.Column="20"  Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Calibrate}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics1.xaml
@@ -58,339 +58,203 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="æ" ShiftDownText="Æ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="æ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="æ"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="à" ShiftDownText="À"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="à" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="à"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="â" ShiftDownText="Â"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="â" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="â"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ç" ShiftDownText="Ç"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ç" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ç"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ë" ShiftDownText="Ë"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ë" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ë"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ê" ShiftDownText="Ê"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ê" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ê"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="è" ShiftDownText="È"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="è" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="è"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="é" ShiftDownText="É"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="é" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="é"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ï" ShiftDownText="Ï"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ï" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ï"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="î" ShiftDownText="Î"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="î" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="î"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic2Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic2Keyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="œ" ShiftDownText="Œ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="œ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="œ"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ô" ShiftDownText="Ô"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ô" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ô"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ü" ShiftDownText="Ü"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ü" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ü"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="û" ShiftDownText="Û"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="û" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="û"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ù" ShiftDownText="Ù"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ù" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ù"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ÿ" ShiftDownText="Ÿ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ÿ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ÿ"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ă" ShiftDownText="Ă"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ă" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ă"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ą" ShiftDownText="Ą"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ą" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ą"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ã" ShiftDownText="Ã"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ã" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ã"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ä" ShiftDownText="Ä"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ä" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ä"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="å" ShiftDownText="Å"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="å" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="å"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ā" ShiftDownText="Ā"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ā" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ā"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="á" ShiftDownText="Á"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="á" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="á"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="č" ShiftDownText="Č"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="č" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="č"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ć" ShiftDownText="Ć"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ć" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ć"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="đ" ShiftDownText="Đ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="đ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="đ"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ð" ShiftDownText="Ð"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ð" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ð"/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ď" ShiftDownText="Ď"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ď" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ď"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ə" ShiftDownText="Ə"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ə" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ə"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" />
-                <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>  
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>  
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics1.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Diacritics1"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Diacritics1"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -100,12 +99,12 @@
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic2Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic2KeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="œ" ShiftDownText="Œ"
@@ -148,18 +147,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ä" ShiftDownText="Ä"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -192,36 +191,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ð" ShiftDownText="Ð"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -250,11 +249,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>  
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>  
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics2.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -100,13 +99,13 @@
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic3Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic3KeyboardKey}"/>
         
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="į" ShiftDownText="Į"
@@ -152,18 +151,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ņ" ShiftDownText="Ņ"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -197,36 +196,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ö" ShiftDownText="Ö"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -255,11 +254,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics2.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Diacritics2"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Diacritics2"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -58,345 +58,208 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ę" ShiftDownText="Ę"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ę" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ę"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ě" ShiftDownText="Ě"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ě" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ě"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ē" ShiftDownText="Ē"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ē" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ē"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ė" ShiftDownText="Ė"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ė" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ė"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ĝ" ShiftDownText="Ĝ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĝ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĝ"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ğ" ShiftDownText="Ğ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ğ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ğ"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ģ" ShiftDownText="Ģ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ģ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ģ"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ħ" ShiftDownText="Ħ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ħ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ħ"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ĥ" ShiftDownText="Ĥ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĥ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĥ"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ị" ShiftDownText="Ị"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ị" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ị"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic3Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic3Keyboard}"/>
+        
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="į" ShiftDownText="Į"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="į" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="į"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ī" ShiftDownText="Ī"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ī" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ī"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="í" ShiftDownText="Í"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="í" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="í"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ì" ShiftDownText="Ì"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ì" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ì"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ķ" ShiftDownText="Ķ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ķ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ķ"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ł" ShiftDownText="Ł"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ł" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ł"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ľ" ShiftDownText="Ľ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ľ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ľ"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ļ" ShiftDownText="Ļ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ļ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ļ"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ĺ" ShiftDownText="Ĺ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĺ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĺ"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ň" ShiftDownText="Ň"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ň" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ň"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ņ" ShiftDownText="Ņ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ņ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ņ"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ń" ShiftDownText="Ń"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ń" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ń"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ñ" ShiftDownText="Ñ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ñ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ñ"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ơ" ShiftDownText="Ơ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ơ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ơ"/>
 
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ő" ShiftDownText="Ő"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ő" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ő"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ō" ShiftDownText="Ō"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ō" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ō"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ø" ShiftDownText="Ø"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ø" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ø"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ö" ShiftDownText="Ö"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ö" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ö"/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="õ" ShiftDownText="Õ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="õ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="õ"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ó" ShiftDownText="Ó"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ó" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ó"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics3.xaml
@@ -4,8 +4,8 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -99,12 +99,12 @@
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ț" ShiftDownText="Ț"
@@ -150,18 +150,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ŵ" ShiftDownText="Ŵ"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -191,36 +191,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
@@ -240,11 +240,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/French/Diacritics3.xaml
@@ -1,10 +1,9 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Diacritics3"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.French.Diacritics3"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -58,320 +57,194 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ò" ShiftDownText="Ò"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ò" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ò"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ŕ" ShiftDownText="Ŕ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŕ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŕ"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ř" ShiftDownText="Ř"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ř" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ř"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ş" ShiftDownText="Ş"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ş" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ş"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="š" ShiftDownText="Š"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="š" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="š"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ș" ShiftDownText="Ș"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ș" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ș"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ß" ShiftDownText="ß"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ß" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ß"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ś" ShiftDownText="Ś"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ś" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ś"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ŝ" ShiftDownText="Ŝ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŝ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŝ"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ť" ShiftDownText="Ť"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ť" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ť"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic1Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ț" ShiftDownText="Ț"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ț" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ț"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ţ" ShiftDownText="Ţ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ţ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ţ"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="þ" ShiftDownText="Þ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="þ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="þ"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ụ" ShiftDownText="Ụ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ụ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ụ"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ư" ShiftDownText="Ư"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ư" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ư"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ų" ShiftDownText="Ų"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ų" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ų"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ű" ShiftDownText="Ű"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ű" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ű"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ů" ShiftDownText="Ů"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ů" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ů"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ū" ShiftDownText="Ū"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ū" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ū"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ú" ShiftDownText="Ú"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ú" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ú"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ŵ" ShiftDownText="Ŵ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŵ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŵ"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ŷ" ShiftDownText="Ŷ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŷ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŷ"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ý" ShiftDownText="Ý"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ý" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ý"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ź" ShiftDownText="Ź"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ź" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ź"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ż" ShiftDownText="Ż"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ż" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ż"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ž" ShiftDownText="Ž"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ž" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ž"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Alpha.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Alpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Alpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -107,7 +106,7 @@
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="25" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
@@ -159,18 +158,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -207,36 +206,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       Text="," Case="None"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -255,7 +254,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}">
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}">
         </controls:Key>
         <controls:Key Grid.Row="5" Grid.Column="18" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
@@ -267,11 +266,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Alpha.xaml
@@ -61,360 +61,217 @@
         <controls:Key Grid.Row="2" Grid.Column="0" />
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="q" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="q"/>
         <controls:Key Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="w" ShiftDownText="W"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="w" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="w"/>
         <controls:Key Grid.Row="2" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="e" ShiftDownText="E" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="e" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="e"/>
         <controls:Key Grid.Row="2" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="r" ShiftDownText="R"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="r" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="r"/>
         <controls:Key Grid.Row="2" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="t" ShiftDownText="T"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="t" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="t"/>
         <controls:Key Grid.Row="2" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="z" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="z"/>
         <controls:Key Grid.Row="2" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="u" ShiftDownText="U"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="u" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="u"/>
         <controls:Key Grid.Row="2" Grid.Column="15" Grid.ColumnSpan="2"
                       ShiftUpText="i" ShiftDownText="I"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="i" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="i"/>
         <controls:Key Grid.Row="2" Grid.Column="17" Grid.ColumnSpan="2"
                       ShiftUpText="o" ShiftDownText="O"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="o" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="o"/>
         <controls:Key Grid.Row="2" Grid.Column="19" Grid.ColumnSpan="2"
                       ShiftUpText="p" ShiftDownText="P"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="p" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="p"/>
         <controls:Key Grid.Row="2" Grid.Column="21" Grid.ColumnSpan="2"
                       ShiftUpText="ü" ShiftDownText="Ü"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ü" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ü"/>
         <controls:Key Grid.Row="2" Grid.Column="23" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="25" />
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource TabIcon}" 
                       Text="{x:Static resx:Resources.TAB}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x09;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="&#x09;"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="a" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="a"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="s" ShiftDownText="S"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="s" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="s"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="d" ShiftDownText="D"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="d" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="d"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="f" ShiftDownText="F"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="f" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="f"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="g" ShiftDownText="G"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="g" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="g"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="h" ShiftDownText="H"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="h" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="h"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="j" ShiftDownText="J"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="j" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="j"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="k" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="k"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="l" ShiftDownText="L"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="l" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="l"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="ö" ShiftDownText="Ö"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ö" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ö"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="y" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="y"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="x" ShiftDownText="X"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="x" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="x"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="c" ShiftDownText="C"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="c" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="c"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="v" ShiftDownText="V"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="v" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="v"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="b" ShiftDownText="B"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="b" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="b"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="n" ShiftDownText="N"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="n" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="n"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="m" ShiftDownText="M"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="m" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="m"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ä" ShiftDownText="Ä"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ä" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ä"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       Text="," Case="None"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="6"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="3" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       Text="." Case="None"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="MultiKeySelectionIsOn" />
-            </controls:Key.Value>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}">
         </controls:Key>
         <controls:Key Grid.Row="5" Grid.Column="18" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/ConversationAlpha.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.ConversationAlpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.ConversationAlpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -57,278 +57,167 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="q" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="q"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="w" ShiftDownText="W"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="w" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="w"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="e" ShiftDownText="E" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="e" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="e"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="r" ShiftDownText="R"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="r" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="r"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="t" ShiftDownText="T"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="t" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="t"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="z" ShiftDownText="Z"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="z" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="z"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="u" ShiftDownText="U"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="u" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="u"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="i" ShiftDownText="I"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="i" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="i"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="o" ShiftDownText="O"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="o" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="o"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="p" ShiftDownText="P"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="p" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="p"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="ü" ShiftDownText="Ü"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ü" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ü"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" />
         <controls:Key Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="a" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="a"/>
         <controls:Key Grid.Row="3" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="s" ShiftDownText="S"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="s" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="s"/>
         <controls:Key Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="d" ShiftDownText="D"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="d" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="d"/>
         <controls:Key Grid.Row="3" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="f" ShiftDownText="F"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="f" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="f"/>
         <controls:Key Grid.Row="3" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="g" ShiftDownText="G"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="g" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="g"/>
         <controls:Key Grid.Row="3" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="h" ShiftDownText="H"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="h" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="h"/>
         <controls:Key Grid.Row="3" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="j" ShiftDownText="J"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="j" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="j"/>
         <controls:Key Grid.Row="3" Grid.Column="15" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="k" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="k"/>
         <controls:Key Grid.Row="3" Grid.Column="17" Grid.ColumnSpan="2"
                       ShiftUpText="l" ShiftDownText="L"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="l" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="l"/>
         <controls:Key Grid.Row="3" Grid.Column="19" Grid.ColumnSpan="2"
                       ShiftUpText="ö" ShiftDownText="Ö"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ö" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ö"/>
         <controls:Key Grid.Row="3" Grid.Column="21" />
 
         <controls:Key Grid.Row="4" Grid.Column="0" />
         <controls:Key Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="y" ShiftDownText="Y"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="y" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="y"/>
         <controls:Key Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="x" ShiftDownText="X"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="x" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="x"/>
         <controls:Key Grid.Row="4" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="c" ShiftDownText="C"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="c" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="c"/>
         <controls:Key Grid.Row="4" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="v" ShiftDownText="V"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="v" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="v"/>
         <controls:Key Grid.Row="4" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="b" ShiftDownText="B"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="b" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="b"/>
         <controls:Key Grid.Row="4" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="n" ShiftDownText="N"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="n" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="n"/>
         <controls:Key Grid.Row="4" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="m" ShiftDownText="M"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="m" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="m"/>
         <controls:Key Grid.Row="4" Grid.Column="15" Grid.ColumnSpan="2"
                       ShiftUpText="ä" ShiftDownText="Ä"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ä" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ä"/>
         <controls:Key Grid.Row="4" Grid.Column="17" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="19" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="21" />
         
         <controls:Key Grid.Row="5" Grid.Column="0" />
         <controls:Key Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2"
                       Text="," Case="None"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="7" Grid.ColumnSpan="6"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="3" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="13" Grid.ColumnSpan="2"
                       Text="." Case="None"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="15" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
         <ContentControl Grid.Row="5" Grid.Column="17" Grid.ColumnSpan="2">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -336,11 +225,8 @@
                         <Setter.Value>
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
-                                          SharedSizeGroup="KeyWithSymbol">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbol"
+                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -349,11 +235,8 @@
                                 <Setter.Value>
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
-                                                  SharedSizeGroup="KeyWithSymbol">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Quit}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbol"
+                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -364,11 +247,8 @@
         <controls:Key Grid.Row="5" Grid.Column="19"  Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Calibrate}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
         <controls:Key Grid.Row="5" Grid.Column="21" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/ConversationAlpha.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
@@ -180,12 +179,12 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="19" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="21" />
         
         <controls:Key Grid.Row="5" Grid.Column="0" />
@@ -193,12 +192,12 @@
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="3" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
+                      Value="{x:Static models:KeyValues.ConversationNumericAndSymbolsKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="5" Grid.ColumnSpan="2"
                       Text="," Case="None"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -217,7 +216,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}"/>
         <ContentControl Grid.Row="5" Grid.Column="17" Grid.ColumnSpan="2">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -226,7 +225,7 @@
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
                                           SharedSizeGroup="KeyWithSymbol"
-                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                          Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -236,7 +235,7 @@
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
                                                   SharedSizeGroup="KeyWithSymbol"
-                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
+                                                  Value="{x:Static models:KeyValues.QuitKey}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -248,7 +247,7 @@
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
+                      Value="{x:Static models:KeyValues.CalibrateKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="21" />
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics1.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Diacritics1"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Diacritics1"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -97,13 +96,13 @@
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic2Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic2KeyboardKey}"/>
         
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ā" ShiftDownText="Ā"
@@ -149,18 +148,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ə" ShiftDownText="Ə"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -193,36 +192,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="è" ShiftDownText="È"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -251,11 +250,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics1.xaml
@@ -58,338 +58,204 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ä" ShiftDownText="Ä"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ä" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ä"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ö" ShiftDownText="Ö"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ö" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ö"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ü" ShiftDownText="Ü"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ü" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ü"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ß" ShiftDownText="ß"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ß" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ß"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ă" ShiftDownText="Ă"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ă" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ă"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ą" ShiftDownText="Ą"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ą" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ą"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ã" ShiftDownText="Ã"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ã" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ã"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="å" ShiftDownText="Å"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="å" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="å"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="æ" ShiftDownText="Æ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="æ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="æ"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 1of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic2Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic2Keyboard}"/>
+        
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ā" ShiftDownText="Ā"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ā" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ā"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="à" ShiftDownText="À"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="à" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="à"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="á" ShiftDownText="Á"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="á" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="á"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="â" ShiftDownText="Â"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="â" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="â"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="č" ShiftDownText="Č"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="č" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="č"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ç" ShiftDownText="Ç"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ç" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ç"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ć" ShiftDownText="Ć"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ć" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ć"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="đ" ShiftDownText="Đ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="đ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="đ"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ð" ShiftDownText="Ð"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ð" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ð"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ď" ShiftDownText="Ď"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ď" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ď"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ə" ShiftDownText="Ə"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ə" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ə"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ę" ShiftDownText="Ę"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ę" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ę"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ě" ShiftDownText="Ě"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ě" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ě"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ê" ShiftDownText="Ê"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ê" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ê"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ë" ShiftDownText="Ë"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ë" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ë"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ē" ShiftDownText="Ē"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ē" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ē"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ė" ShiftDownText="Ė"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ė" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ė"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="è" ShiftDownText="È"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="è" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="è"/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="é" ShiftDownText="É"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="é" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="é"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ĝ" ShiftDownText="Ĝ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĝ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĝ"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics2.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -100,12 +99,12 @@
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic3Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic3KeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ì" ShiftDownText="Ì"
@@ -151,18 +150,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ơ" ShiftDownText="Ơ"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -195,36 +194,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ó" ShiftDownText="Ó"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -253,11 +252,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics2.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics2.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Diacritics2"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Diacritics2"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -58,344 +58,206 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ğ" ShiftDownText="Ğ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ğ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ğ"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ģ" ShiftDownText="Ģ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ģ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ģ"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ħ" ShiftDownText="Ħ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ħ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ħ"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ĥ" ShiftDownText="Ĥ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĥ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĥ"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ị" ShiftDownText="Ị"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ị" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ị"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="į" ShiftDownText="Į"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="į" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="į"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ī" ShiftDownText="Ī"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ī" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ī"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ï" ShiftDownText="Ï"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ï" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ï"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="î" ShiftDownText="Î"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="î" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="î"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="í" ShiftDownText="Í"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="í" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="í"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 2of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic3Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic3Keyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ì" ShiftDownText="Ì"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ì" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ì"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ķ" ShiftDownText="Ķ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ķ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ķ"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ł" ShiftDownText="Ł"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ł" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ł"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ľ" ShiftDownText="Ľ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ľ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ľ"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ļ" ShiftDownText="Ļ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ļ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ļ"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ĺ" ShiftDownText="Ĺ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ĺ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ĺ"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ň" ShiftDownText="Ň"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ň" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ň"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ņ" ShiftDownText="Ņ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ņ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ņ"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ń" ShiftDownText="Ń"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ń" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ń"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ñ" ShiftDownText="Ñ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ñ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ñ"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ơ" ShiftDownText="Ơ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ơ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ơ"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="œ" ShiftDownText="Œ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="œ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="œ"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ő" ShiftDownText="Ő"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ő" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ő"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ō" ShiftDownText="Ō"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ō" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ō"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ø" ShiftDownText="Ø"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ø" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ø"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="õ" ShiftDownText="Õ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="õ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="õ"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ô" ShiftDownText="Ô"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ô" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ô"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ó" ShiftDownText="Ó"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ó" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ó"/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ò" ShiftDownText="Ò"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ò" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ò"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ŕ" ShiftDownText="Ŕ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŕ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŕ"/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics3.xaml
@@ -5,7 +5,6 @@
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -100,12 +99,12 @@
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ụ" ShiftDownText="Ụ"
@@ -152,18 +151,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ŷ" ShiftDownText="Ŷ"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -193,36 +192,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
@@ -242,11 +241,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics3.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/German/Diacritics3.xaml
@@ -1,4 +1,4 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Diacritics3"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.German.Diacritics3"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -58,321 +58,195 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ř" ShiftDownText="Ř"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ř" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ř"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ş" ShiftDownText="Ş"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ş" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ş"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="š" ShiftDownText="Š"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="š" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="š"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ș" ShiftDownText="Ș"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ș" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ș"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ś" ShiftDownText="Ś"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ś" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ś"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ŝ" ShiftDownText="Ŝ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŝ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŝ"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ť" ShiftDownText="Ť"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ť" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ť"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ț" ShiftDownText="Ț"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ț" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ț"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ţ" ShiftDownText="Ţ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ţ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ţ"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="þ" ShiftDownText="Þ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="þ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="þ"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource 3of3Icon}"
                       Text="{x:Static resx:Resources.NEXT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="Diacritic1Keyboard" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ụ" ShiftDownText="Ụ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ụ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ụ"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ư" ShiftDownText="Ư"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ư" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ư"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ų" ShiftDownText="Ų"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ų" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ų"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ű" ShiftDownText="Ű"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ű" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ű"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ů" ShiftDownText="Ů"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ů" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ů"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ū" ShiftDownText="Ū"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ū" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ū"/>
 
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="û" ShiftDownText="Û"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="û" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="û"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ú" ShiftDownText="Ú"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ú" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ú"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ù" ShiftDownText="Ù"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ù" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ù"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ŵ" ShiftDownText="Ŵ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŵ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŵ"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ŷ" ShiftDownText="Ŷ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ŷ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ŷ"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ÿ" ShiftDownText="Ÿ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ÿ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ÿ"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="ý" ShiftDownText="Ý"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ý" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ý"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="ź" ShiftDownText="Ź"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ź" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ź"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="ż" ShiftDownText="Ż"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ż" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ż"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ž" ShiftDownText="Ž"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ž" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ž"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2" />
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" /> <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /> <!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/Alpha.xaml
@@ -63,389 +63,233 @@
         <controls:Key Grid.Row="2" Grid.Column="0" />
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="й" ShiftDownText="Й"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="й" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="й"/>
         <controls:Key Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="2"
                       ShiftUpText="ц" ShiftDownText="Ц"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ц" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ц"/>
         <controls:Key Grid.Row="2" Grid.Column="5" Grid.ColumnSpan="2"
                       ShiftUpText="у" ShiftDownText="У" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="у" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="у"/>
         <controls:Key Grid.Row="2" Grid.Column="7" Grid.ColumnSpan="2"
                       ShiftUpText="к" ShiftDownText="К"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="к" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="к"/>
         <controls:Key Grid.Row="2" Grid.Column="9" Grid.ColumnSpan="2"
                       ShiftUpText="е" ShiftDownText="Е"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="е" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="е"/>
         <controls:Key Grid.Row="2" Grid.Column="11" Grid.ColumnSpan="2"
                       ShiftUpText="н" ShiftDownText="Н"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="н" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="н"/>
         <controls:Key Grid.Row="2" Grid.Column="13" Grid.ColumnSpan="2"
                       ShiftUpText="г" ShiftDownText="Г"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="г" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="г"/>
         <controls:Key Grid.Row="2" Grid.Column="15" Grid.ColumnSpan="2"
                       ShiftUpText="ш" ShiftDownText="Ш"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ш" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ш"/>
         <controls:Key Grid.Row="2" Grid.Column="17" Grid.ColumnSpan="2"
                       ShiftUpText="щ" ShiftDownText="Щ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="щ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="щ"/>
         <controls:Key Grid.Row="2" Grid.Column="19" Grid.ColumnSpan="2"
                       ShiftUpText="з" ShiftDownText="З"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="з" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="з"/>
         <controls:Key Grid.Row="2" Grid.Column="21" Grid.ColumnSpan="2"
                      ShiftUpText="х" ShiftDownText="Х"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="х" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="х"/>
         <controls:Key Grid.Row="2" Grid.Column="23" Grid.ColumnSpan="2"
                       ShiftUpText="ъ" ShiftDownText="Ъ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ъ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ъ"/>
         <controls:Key Grid.Row="2" Grid.Column="25" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MenuKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
         <controls:Key Grid.Row="2" Grid.Column="27" />
         
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource TabIcon}" 
                       Text="{x:Static resx:Resources.TAB}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x09;" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="&#x09;"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ф" ShiftDownText="Ф"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ф" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ф"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ы" ShiftDownText="Ы"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ы" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ы"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="в" ShiftDownText="В"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="в" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="в"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="а" ShiftDownText="А"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="а" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="а"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="п" ShiftDownText="П"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="п" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="п"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="р" ShiftDownText="Р"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="р" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="р"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="о" ShiftDownText="О"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="о" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="о"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="л" ShiftDownText="Л"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="л" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="л"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="д" ShiftDownText="Д"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="д" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="д"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="ж" ShiftDownText="Ж"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ж" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ж"/>
         <controls:Key Grid.Row="3" Grid.Column="22" Grid.ColumnSpan="2"
                       ShiftUpText="э" ShiftDownText="Э"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="э" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="э"/>
         <controls:Key Grid.Row="3" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.AlphaKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
         <controls:Key Grid.Row="3" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Diacritic1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="я" ShiftDownText="Я"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="я" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="я"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="ч" ShiftDownText="Ч"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ч" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ч"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="с" ShiftDownText="С"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="с" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="с"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="м" ShiftDownText="М"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="м" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="м"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="и" ShiftDownText="И"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="и" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="и"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="т" ShiftDownText="Т"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="т" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="т"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ь" ShiftDownText="Ь"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ь" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ь"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                        ShiftUpText="б" ShiftDownText="Б"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="б" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="б"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ю" ShiftDownText="Ю"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ю" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ю"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
         <controls:Key Grid.Row="4" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
         <controls:Key Grid.Row="4" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Currencies1Keyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftCtrl}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftWin}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
-                      SharedSizeGroup="KeyWithDescription">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftAlt}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithDescription"
+                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="8" Grid.ColumnSpan="6"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"                     
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="3">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="3"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ё" ShiftDownText="Ё"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ё" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ё"/>
         <controls:Key Grid.Row="5" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="MultiKeySelectionIsOn" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
+        
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
                       Text="{x:Static resx:Resources.ENTER}"
                       SharedSizeGroup="KeyWithSymbol"
-                      WidthSpan="2">
-            <controls:Key.Value>
-                <models:KeyValue String="&#x0a;" />
-                <!--Hex for "\n"-->
-            </controls:Key.Value>
-        </controls:Key>
+                      WidthSpan="2"
+                      Value="&#x0a;" /><!--Hex for "\n"-->
         <controls:Key Grid.Row="5" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MouseKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/Alpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/Alpha.xaml
@@ -1,11 +1,10 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Russian.Alpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Russian.Alpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
                        xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
@@ -113,7 +112,7 @@
                       SymbolGeometry="{StaticResource MenuIcon}"
                       Text="{x:Static resx:Resources.MENU}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MenuKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MenuKeyboardKey}"/>
         <controls:Key Grid.Row="2" Grid.Column="27" />
         
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
@@ -169,18 +168,18 @@
                       SymbolGeometry="{StaticResource AlphaIcon}"
                       Text="{x:Static resx:Resources.ALPHA}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.AlphaKeyboard}"/>
+                      Value="{x:Static models:KeyValues.AlphaKeyboardKey}"/>
         <controls:Key Grid.Row="3" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource DiacriticsIcon}"
                       Text="{x:Static resx:Resources.DIACRITICS}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Diacritic1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Diacritic1KeyboardKey}"/>
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="я" ShiftDownText="Я"
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -221,36 +220,36 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="22" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="24" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.NumericAndSymbols1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.NumericAndSymbols1KeyboardKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CurrenciesIcon}"
                       Text="{x:Static resx:Resources.CURRENCIES}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Currencies1Keyboard}"/>
+                      Value="{x:Static models:KeyValues.Currencies1KeyboardKey}"/>
 
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.CTRL}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftCtrl}"/>
+                      Value="{x:Static models:KeyValues.LeftCtrlKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource WinIcon}"
                       Text="{x:Static resx:Resources.WIN}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftWin}"/>
+                      Value="{x:Static models:KeyValues.LeftWinKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text="{x:Static resx:Resources.ALT}"
                       SharedSizeGroup="KeyWithDescription"
-                      Value="{x:Static enums:FunctionKeys.LeftAlt}"/>
+                      Value="{x:Static models:KeyValues.LeftAltKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="2"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -273,7 +272,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}"/>
         
         <controls:Key Grid.Row="5" Grid.Column="20" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource EnterIcon}"
@@ -285,11 +284,11 @@
                       SymbolGeometry="{StaticResource MouseIcon}"
                       Text="{x:Static resx:Resources.MOUSE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MouseKeyboard}"/>
+                      Value="{x:Static models:KeyValues.MouseKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="26" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource PhysicalKeysIcon}"
                       Text="{x:Static resx:Resources.PHYSICAL_KEYS_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.PhysicalKeysKeyboard}"/>
+                      Value="{x:Static models:KeyValues.PhysicalKeysKeyboardKey}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/ConversationAlpha.xaml
@@ -1,10 +1,9 @@
-﻿<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Russian.ConversationAlpha"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Russian.ConversationAlpha"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
@@ -57,295 +56,175 @@
 
         <controls:Key Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="й" ShiftDownText="Й"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="й" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="й"/>
         <controls:Key Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ц" ShiftDownText="Ц"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ц" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ц"/>
         <controls:Key Grid.Row="2" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="у" ShiftDownText="У" 
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="у" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="у"/>
         <controls:Key Grid.Row="2" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="к" ShiftDownText="К"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="к" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="к"/>
         <controls:Key Grid.Row="2" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="е" ShiftDownText="Е"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="е" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="е"/>
         <controls:Key Grid.Row="2" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="н" ShiftDownText="Н"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="н" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="н"/>
         <controls:Key Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="г" ShiftDownText="Г"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="г" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="г"/>
         <controls:Key Grid.Row="2" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="ш" ShiftDownText="Ш"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ш" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ш"/>
         <controls:Key Grid.Row="2" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="щ" ShiftDownText="Щ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="щ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="щ"/>
         <controls:Key Grid.Row="2" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="з" ShiftDownText="З"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="з" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="з"/>
         <controls:Key Grid.Row="2" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="ъ" ShiftDownText="Ъ"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ъ" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ъ"/>
 
         <controls:Key Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="ф" ShiftDownText="Ф"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ф" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ф"/>
         <controls:Key Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ы" ShiftDownText="Ы"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ы" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ы"/>
         <controls:Key Grid.Row="3" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="в" ShiftDownText="В"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="в" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="в"/>
         <controls:Key Grid.Row="3" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="а" ShiftDownText="А"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="а" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="а"/>
         <controls:Key Grid.Row="3" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="п" ShiftDownText="П"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="п" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="п"/>
         <controls:Key Grid.Row="3" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="р" ShiftDownText="Р"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="р" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="р"/>
         <controls:Key Grid.Row="3" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="о" ShiftDownText="О"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="о" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="о"/>
         <controls:Key Grid.Row="3" Grid.Column="14" Grid.ColumnSpan="2"
                       ShiftUpText="л" ShiftDownText="Л"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="л" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="л"/>
         <controls:Key Grid.Row="3" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="д" ShiftDownText="Д"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="д" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="д"/>
         <controls:Key Grid.Row="3" Grid.Column="18" Grid.ColumnSpan="2"
                       ShiftUpText="ж" ShiftDownText="Ж"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ж" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ж"/>
         <controls:Key Grid.Row="3" Grid.Column="20" Grid.ColumnSpan="2"
                       ShiftUpText="э" ShiftDownText="Э"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="э" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="э"/>
 
 
         <controls:Key Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                       ShiftUpText="я" ShiftDownText="Я"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="я" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="я"/>
         <controls:Key Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2"
                       ShiftUpText="ч" ShiftDownText="Ч"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ч" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ч"/>
         <controls:Key Grid.Row="4" Grid.Column="4" Grid.ColumnSpan="2"
                       ShiftUpText="с" ShiftDownText="С"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="с" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="с"/>
         <controls:Key Grid.Row="4" Grid.Column="6" Grid.ColumnSpan="2"
                       ShiftUpText="м" ShiftDownText="М"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="м" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="м"/>
         <controls:Key Grid.Row="4" Grid.Column="8" Grid.ColumnSpan="2"
                       ShiftUpText="и" ShiftDownText="И"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="и" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="и"/>
         <controls:Key Grid.Row="4" Grid.Column="10" Grid.ColumnSpan="2"
                       ShiftUpText="т" ShiftDownText="Т"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="т" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="т"/>
         <controls:Key Grid.Row="4" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ь" ShiftDownText="Ь"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ь" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ь"/>
         <controls:Key Grid.Row="4" Grid.Column="14" Grid.ColumnSpan="2"
                        ShiftUpText="б" ShiftDownText="Б"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="б" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="б"/>
         <controls:Key Grid.Row="4" Grid.Column="16" Grid.ColumnSpan="2"
                       ShiftUpText="ю" ShiftDownText="Ю"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ю" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ю"/>
         <controls:Key Grid.Row="4" Grid.Column="18" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackOne}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackMany}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
        
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.LeftShift}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text=","
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="," />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value=","/>
         <controls:Key Grid.Row="5" Grid.Column="6" Grid.ColumnSpan="4"
                       SymbolGeometry="{StaticResource SpaceIcon}"
                       Text="{x:Static resx:Resources.SPACE}"
                       WidthSpan="2" 
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue String=" " />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value=" "/>
         <controls:Key Grid.Row="5" Grid.Column="10" Grid.ColumnSpan="2"
                       Text="."
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="." />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="."/>
         <controls:Key Grid.Row="5" Grid.Column="12" Grid.ColumnSpan="2"
                       ShiftUpText="ё" ShiftDownText="Ё"
-                      SharedSizeGroup="KeyWithSingleLetter">
-            <controls:Key.Value>
-                <models:KeyValue String="ё" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSingleLetter"
+                      Value="ё"/>
         <controls:Key Grid.Row="5" Grid.Column="14" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
         <ContentControl Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -354,11 +233,8 @@
                             <controls:Key SymbolGeometry="{StaticResource BackIcon}"
                                           Text="{x:Static resx:Resources.BACK}"
                                            WidthSpan="2"
-                                          SharedSizeGroup="KeyWithSymbol">
-                                <controls:Key.Value>
-                                    <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.BackFromKeyboard}" />
-                                </controls:Key.Value>
-                            </controls:Key>
+                                          SharedSizeGroup="KeyWithSymbol"
+                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -367,11 +243,8 @@
                                 <Setter.Value>
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
-                                                  SharedSizeGroup="KeyWithSymbol">
-                                        <controls:Key.Value>
-                                            <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Quit}" />
-                                        </controls:Key.Value>
-                                    </controls:Key>
+                                                  SharedSizeGroup="KeyWithSymbol"
+                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -382,10 +255,7 @@
         <controls:Key Grid.Row="5" Grid.Column="20"  Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
-                      SharedSizeGroup="KeyWithSymbol">
-            <controls:Key.Value>
-                <models:KeyValue FunctionKey="{x:Static enums:FunctionKeys.Calibrate}" />
-            </controls:Key.Value>
-        </controls:Key>
+                      SharedSizeGroup="KeyWithSymbol"
+                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
     </Grid>
 </controls:KeyboardView>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/ConversationAlpha.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Russian/ConversationAlpha.xaml
@@ -4,9 +4,9 @@
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                        xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
-                       xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+                       xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
                        mc:Ignorable="d" 
                        d:DesignHeight="300" d:DesignWidth="300">
 
@@ -185,23 +185,23 @@
                       SymbolGeometry="{StaticResource BackOneIcon}"
                       Text="{x:Static resx:Resources.BACK_ONE_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackOne}"/>
+                      Value="{x:Static models:KeyValues.BackOneKey}"/>
         <controls:Key Grid.Row="4" Grid.Column="20" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource BackManyIcon}"
                       Text="{x:Static resx:Resources.BACK_WORD_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.BackMany}"/>
+                      Value="{x:Static models:KeyValues.BackManyKey}"/>
        
         <controls:Key Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource ShiftIcon}"
                       Text="{x:Static resx:Resources.SHIFT}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.LeftShift}"/>
+                      Value="{x:Static models:KeyValues.LeftShiftKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2"
                       SymbolGeometry="{StaticResource NumericAndSymbolsIcon}"
                       Text="{x:Static resx:Resources.NUM_SYM_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.ConversationNumericAndSymbolsKeyboard}"/>
+                      Value="{x:Static models:KeyValues.ConversationNumericAndSymbolsKeyboardKey}"/>
         <controls:Key Grid.Row="5" Grid.Column="4" Grid.ColumnSpan="2"
                       Text=","
                       SharedSizeGroup="KeyWithSingleLetter"
@@ -224,7 +224,7 @@
                       SymbolGeometry="{StaticResource MultiKeySelectionIcon}"
                       Text="{x:Static resx:Resources.MULTI_KEY_SELECTION_SPLIT_WITH_NEWLINE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.MultiKeySelectionIsOn}"/>
+                      Value="{x:Static models:KeyValues.MultiKeySelectionIsOnKey}"/>
         <ContentControl Grid.Row="5" Grid.Column="16" Grid.ColumnSpan="4">
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
@@ -234,7 +234,7 @@
                                           Text="{x:Static resx:Resources.BACK}"
                                            WidthSpan="2"
                                           SharedSizeGroup="KeyWithSymbol"
-                                          Value="{x:Static enums:FunctionKeys.BackFromKeyboard}"/>
+                                          Value="{x:Static models:KeyValues.BackFromKeyboardKey}"/>
                         </Setter.Value>
                     </Setter>
                     <Style.Triggers>
@@ -244,7 +244,7 @@
                                     <controls:Key SymbolGeometry="{StaticResource QuitIcon}"
                                                   Text="{x:Static resx:Resources.QUIT}"
                                                   SharedSizeGroup="KeyWithSymbol"
-                                                  Value="{x:Static enums:FunctionKeys.Quit}"/>
+                                                  Value="{x:Static models:KeyValues.QuitKey}"/>
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
@@ -256,6 +256,6 @@
                       SymbolGeometry="{StaticResource CalibrateIcon}"
                       Text="{x:Static resx:Resources.RE_CALIBRATE}"
                       SharedSizeGroup="KeyWithSymbol"
-                      Value="{x:Static enums:FunctionKeys.Calibrate}"/>
+                      Value="{x:Static models:KeyValues.CalibrateKey}"/>
     </Grid>
 </controls:KeyboardView>


### PR DESCRIPTION
Making the `KeyValue` _struct_ immutable as per standard guidance*.
This also meant that more static maps needed to be created between `FunctionKeys` and `KeyValue` in the `KeyValues` _class_.

Xaml was updated to use the `KeyValues` instead of `FunctionKeys` directly. _Strings_ use a TypeConverter to map into `KeyValue` types in Xaml.

*References : 
http://stackoverflow.com/questions/3751911/why-are-c-sharp-structs-immutable and https://msdn.microsoft.com/en-us/library/ms229031(v=vs.110).aspx