### PR TITLE
Remove C# 6.0 syntax

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/Utilities/ColourRgb.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Utilities/ColourRgb.cs
@@ -4,23 +4,18 @@ namespace JuliusSweetland.OptiKey.UI.Utilities
 {
     public struct ColourRgb
     {
-        public byte R { get; }
-        public byte G { get; }
-        public byte B { get; }
+        public byte R { get; private set; }
+        public byte G { get; private set; }
+        public byte B { get; private set; }
 
-        public ColourRgb(byte red, byte green, byte blue)
+        public ColourRgb(byte red, byte green, byte blue) : this()
         {
             R = red;
             G = green;
             B = blue;
         }
 
-        private ColourRgb(Color value)
-        {
-            R = value.R;
-            G = value.G;
-            B = value.B;
-        }
+        private ColourRgb(Color value) : this(value.R, value.G, value.B) { }
 
         public static implicit operator Color(ColourRgb rgb)
         {


### PR DESCRIPTION
I believe at this time we are avoiding c# 6.0 syntax so I removed this.  Also use this constructor to avoid having to declare RGB twice.