### PR TITLE
Ngrams

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -11,6 +11,9 @@
     <AssemblyName>JuliusSweetland.OptiKey.UnitTests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -71,6 +74,18 @@
       <HintPath>..\..\ext\InputSimulator\WindowsInput.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="Extensions\PointExtensionsTests.cs" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Extensions\DoubleExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\CharExtensionsTests.cs" />
+    <Compile Include="Services\AutoComplete\BasicAutoCompleteTests.cs" />
     <Compile Include="Services\KeyboardOutputServiceTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="UI\ViewModels\MainViewModelSpecifications\MainViewModelTestBase.cs" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -2,7 +2,6 @@
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Services.AutoComplete;
 using NUnit.Framework;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 {
@@ -25,51 +24,20 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         private void ConfigureProvider()
         {
             var entries = new[] {
-                new {Word = "the", Count = 100}, new {Word = "be", Count = 99}, new {Word = "to", Count = 98},
-                new {Word = "of", Count = 97}, new {Word = "and", Count = 96}, new {Word = "a", Count = 95},
-                new {Word = "in", Count = 94}, new {Word = "that", Count = 93}, new {Word = "have", Count = 92},
-                new {Word = "I", Count = 91}, new {Word = "it", Count = 90}, new {Word = "for", Count = 89},
-                new {Word = "not", Count = 88}, new {Word = "on", Count = 87}, new {Word = "with", Count = 86},
-                new {Word = "he", Count = 85}, new {Word = "as", Count = 84}, new {Word = "you", Count = 83},
-                new {Word = "do", Count = 82}, new {Word = "at", Count = 81}, new {Word = "this", Count = 80},
-                new {Word = "but", Count = 79}, new {Word = "his", Count = 78}, new {Word = "by", Count = 77},
-                new {Word = "from", Count = 76}, new {Word = "they", Count = 75}, new {Word = "we", Count = 74},
-                new {Word = "say", Count = 73}, new {Word = "her", Count = 72}, new {Word = "she", Count = 71},
-                new {Word = "or", Count = 70}, new {Word = "an", Count = 69}, new {Word = "will", Count = 68},
-                new {Word = "my", Count = 67}, new {Word = "one", Count = 66}, new {Word = "all", Count = 65},
-                new {Word = "would", Count = 64}, new {Word = "there", Count = 63}, new {Word = "their", Count = 62},
-                new {Word = "what", Count = 61}, new {Word = "so", Count = 60}, new {Word = "up", Count = 59},
-                new {Word = "out", Count = 58}, new {Word = "if", Count = 57}, new {Word = "about", Count = 56},
-                new {Word = "who", Count = 55}, new {Word = "get", Count = 54}, new {Word = "which", Count = 53},
-                new {Word = "go", Count = 52}, new {Word = "me", Count = 51}, new {Word = "when", Count = 50},
-                new {Word = "make", Count = 49}, new {Word = "can", Count = 48}, new {Word = "like", Count = 47},
-                new {Word = "time", Count = 46}, new {Word = "no", Count = 45}, new {Word = "just", Count = 44},
-                new {Word = "him", Count = 43}, new {Word = "know", Count = 42}, new {Word = "take", Count = 41},
-                new {Word = "people", Count = 40}, new {Word = "into", Count = 39}, new {Word = "year", Count = 38},
-                new {Word = "your", Count = 37}, new {Word = "good", Count = 36}, new {Word = "some", Count = 35},
-                new {Word = "could", Count = 34}, new {Word = "them", Count = 33}, new {Word = "see", Count = 32},
-                new {Word = "other", Count = 31}, new {Word = "than", Count = 30}, new {Word = "then", Count = 29},
-                new {Word = "now", Count = 28}, new {Word = "look", Count = 27}, new {Word = "only", Count = 26},
-                new {Word = "come", Count = 25}, new {Word = "its", Count = 24}, new {Word = "over", Count = 23},
-                new {Word = "think", Count = 22}, new {Word = "also", Count = 21}, new {Word = "back", Count = 20},
-                new {Word = "after", Count = 19}, new {Word = "use", Count = 18}, new {Word = "two", Count = 17},
-                new {Word = "how", Count = 16}, new {Word = "our", Count = 15}, new {Word = "work", Count = 14},
-                new {Word = "first", Count = 13}, new {Word = "well", Count = 12}, new {Word = "way", Count = 11},
-                new {Word = "even", Count = 10}, new {Word = "new", Count = 9}, new {Word = "want", Count = 8},
-                new {Word = "because", Count = 7}, new {Word = "any", Count = 6}, new {Word = "these", Count = 5},
-                new {Word = "give", Count = 4}, new {Word = "day", Count = 3}, new {Word = "most", Count = 2},
-                new {Word = "us", Count = 1}
+                "the", "be", "to", "of", "and", "a", "in", "that", "have", "I", "it", "for", "not", "on", "with", "he",
+                "as", "you", "do", "at", "this", "but", "his", "by", "from", "they", "we", "say", "her", "she", "or",
+                "an", "will", "my", "one", "all", "would", "there", "their", "what", "so", "up", "out", "if", "about",
+                "who", "get", "which", "go", "me", "when", "make", "can", "like", "time", "no", "just", "him", "know",
+                "take", "people", "into", "year", "your", "good", "some", "could", "them", "see", "other", "than",
+                "then", "now", "look", "only", "come", "its", "over", "think", "also", "back", "after", "use", "two",
+                "how", "our", "work", "first", "well", "way", "even", "new", "want", "because", "any", "these", "give",
+                "day", "most", "us"
             };
-
-            foreach (var entry in entries)
+            for (var index = 0; index < entries.Length; index++)
             {
-                AddEntry(entry.Word, entry.Count);
+                var word = entries[index];
+                basicAutoComplete.AddEntry(word, new DictionaryEntry(word, 100 - index));
             }
-        }
-
-        private void AddEntry(string entry, int count)
-        {
-            basicAutoComplete.AddEntry(entry, new DictionaryEntry(entry, count));
         }
 
         private static readonly object[] SuggestionsTestCaseSource = {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Services.AutoComplete;
 using NUnit.Framework;
 
@@ -35,8 +34,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             };
             for (var index = 0; index < entries.Length; index++)
             {
-                var word = entries[index];
-                basicAutoComplete.AddEntry(word, new DictionaryEntry(word, 100 - index));
+                basicAutoComplete.AddEntry(entries[index], 100 - index);
             }
         }
 
@@ -101,7 +99,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             ConfigureProvider();
 
             // try to make this the "t"-word with the highest usage
-            basicAutoComplete.AddEntry("these", new DictionaryEntry("these", 101));
+            basicAutoComplete.AddEntry("these", 101);
 
             var suggestions = basicAutoComplete.GetSuggestions("t").ToList();
 
@@ -117,7 +115,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         [Test]
         public void After_AddEntry_called_provider_will_return_word_as_suggestion()
         {
-            basicAutoComplete.AddEntry("zoo", new DictionaryEntry("zoo"));
+            basicAutoComplete.AddEntry("zoo");
 
             var suggestions = basicAutoComplete.GetSuggestions("z");
 

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -1,0 +1,211 @@
+﻿using System.Linq;
+using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Services.AutoComplete;
+using NUnit.Framework;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
+{
+    [TestFixture]
+    public class BasicAutoCompleteTests
+    {
+        #region Setup/Teardown
+
+        [SetUp]
+        public void Arrange()
+        {
+            basicAutoComplete = new BasicAutoComplete();
+        }
+
+        #endregion
+
+        private BasicAutoComplete basicAutoComplete;
+
+        /// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
+        private void ConfigureProvider()
+        {
+            var entries = new[] {
+                new {Word = "the", Count = 100}, new {Word = "be", Count = 99}, new {Word = "to", Count = 98},
+                new {Word = "of", Count = 97}, new {Word = "and", Count = 96}, new {Word = "a", Count = 95},
+                new {Word = "in", Count = 94}, new {Word = "that", Count = 93}, new {Word = "have", Count = 92},
+                new {Word = "I", Count = 91}, new {Word = "it", Count = 90}, new {Word = "for", Count = 89},
+                new {Word = "not", Count = 88}, new {Word = "on", Count = 87}, new {Word = "with", Count = 86},
+                new {Word = "he", Count = 85}, new {Word = "as", Count = 84}, new {Word = "you", Count = 83},
+                new {Word = "do", Count = 82}, new {Word = "at", Count = 81}, new {Word = "this", Count = 80},
+                new {Word = "but", Count = 79}, new {Word = "his", Count = 78}, new {Word = "by", Count = 77},
+                new {Word = "from", Count = 76}, new {Word = "they", Count = 75}, new {Word = "we", Count = 74},
+                new {Word = "say", Count = 73}, new {Word = "her", Count = 72}, new {Word = "she", Count = 71},
+                new {Word = "or", Count = 70}, new {Word = "an", Count = 69}, new {Word = "will", Count = 68},
+                new {Word = "my", Count = 67}, new {Word = "one", Count = 66}, new {Word = "all", Count = 65},
+                new {Word = "would", Count = 64}, new {Word = "there", Count = 63}, new {Word = "their", Count = 62},
+                new {Word = "what", Count = 61}, new {Word = "so", Count = 60}, new {Word = "up", Count = 59},
+                new {Word = "out", Count = 58}, new {Word = "if", Count = 57}, new {Word = "about", Count = 56},
+                new {Word = "who", Count = 55}, new {Word = "get", Count = 54}, new {Word = "which", Count = 53},
+                new {Word = "go", Count = 52}, new {Word = "me", Count = 51}, new {Word = "when", Count = 50},
+                new {Word = "make", Count = 49}, new {Word = "can", Count = 48}, new {Word = "like", Count = 47},
+                new {Word = "time", Count = 46}, new {Word = "no", Count = 45}, new {Word = "just", Count = 44},
+                new {Word = "him", Count = 43}, new {Word = "know", Count = 42}, new {Word = "take", Count = 41},
+                new {Word = "people", Count = 40}, new {Word = "into", Count = 39}, new {Word = "year", Count = 38},
+                new {Word = "your", Count = 37}, new {Word = "good", Count = 36}, new {Word = "some", Count = 35},
+                new {Word = "could", Count = 34}, new {Word = "them", Count = 33}, new {Word = "see", Count = 32},
+                new {Word = "other", Count = 31}, new {Word = "than", Count = 30}, new {Word = "then", Count = 29},
+                new {Word = "now", Count = 28}, new {Word = "look", Count = 27}, new {Word = "only", Count = 26},
+                new {Word = "come", Count = 25}, new {Word = "its", Count = 24}, new {Word = "over", Count = 23},
+                new {Word = "think", Count = 22}, new {Word = "also", Count = 21}, new {Word = "back", Count = 20},
+                new {Word = "after", Count = 19}, new {Word = "use", Count = 18}, new {Word = "two", Count = 17},
+                new {Word = "how", Count = 16}, new {Word = "our", Count = 15}, new {Word = "work", Count = 14},
+                new {Word = "first", Count = 13}, new {Word = "well", Count = 12}, new {Word = "way", Count = 11},
+                new {Word = "even", Count = 10}, new {Word = "new", Count = 9}, new {Word = "want", Count = 8},
+                new {Word = "because", Count = 7}, new {Word = "any", Count = 6}, new {Word = "these", Count = 5},
+                new {Word = "give", Count = 4}, new {Word = "day", Count = 3}, new {Word = "most", Count = 2},
+                new {Word = "us", Count = 1}
+            };
+
+            foreach (var entry in entries)
+            {
+                AddEntry(entry.Word, entry.Count);
+            }
+        }
+
+        private void AddEntry(string entry, int count)
+        {
+            basicAutoComplete.AddEntry(entry, new DictionaryEntry(entry, count));
+        }
+
+        private static readonly object[] SuggestionsTestCaseSource = {
+            new object[] {
+                "t",
+                new[] {
+                    "the", "to", "that", "this", "they", "there", "their", "time", "take", "them", "than", "then",
+                    "think", "two", "these"
+                }
+            },
+            new object[] {
+                "th",
+                new[] {
+                    "the", "that", "this", "they", "there", "their", "them", "than", "then", "think", "these"
+                }
+            },
+            new object[] {
+                "the",
+                new[] {
+                    "the", "they", "there", "their", "them", "then", "these"
+                }
+            },
+            new object[] {
+                "thes",
+                new[] {
+                    "these"
+                }
+            },
+            new object[] {
+                "thesa",
+                new string[] {}
+            }
+        };
+
+        private void ExpectEmptyOrRootOnly(string root)
+        {
+            var suggestions = basicAutoComplete.GetSuggestions(root).ToList();
+
+            Assert.IsTrue((suggestions.Count == 0) || (suggestions.Count == 1));
+
+            var firstOrDefault = suggestions.FirstOrDefault();
+            Assert.IsTrue((firstOrDefault == null) || (firstOrDefault == root));
+        }
+
+        private void TestGetSuggestions(string root, string[] expectedSuggestions)
+        {
+            var suggestions = basicAutoComplete.GetSuggestions(root).ToList();
+
+            // The first suggestion can be the original root input.
+            var first = suggestions.First();
+            if ((first == root) && ((expectedSuggestions.Length == 0) || (root != expectedSuggestions[0])))
+            {
+                suggestions.RemoveAt(0);
+            }
+            CollectionAssert.AreEqual(expectedSuggestions, suggestions);
+        }
+
+        [Test]
+        public void AddEntry_called_with_existing_entry_does_not_update_usage_count()
+        {
+            ConfigureProvider();
+
+            // try to make this the "t"-word with the highest usage
+            basicAutoComplete.AddEntry("these", new DictionaryEntry("these", 101));
+
+            var suggestions = basicAutoComplete.GetSuggestions("t").ToList();
+
+            var suggestion = suggestions[0];
+            if (suggestion == "t")
+            {
+                suggestion = suggestions[1];
+            }
+
+            Assert.AreNotEqual("these", suggestion);
+        }
+
+        [Test]
+        public void After_AddEntry_called_provider_will_return_word_as_suggestion()
+        {
+            basicAutoComplete.AddEntry("zoo", new DictionaryEntry("zoo"));
+
+            var suggestions = basicAutoComplete.GetSuggestions("z");
+
+            CollectionAssert.Contains(suggestions, "zoo");
+        }
+
+        [Test]
+        public void Clear_on_a_configured_provider_removes_all_suggestions_and_may_only_return_root_input()
+        {
+            const string root = "t";
+            ConfigureProvider();
+
+            basicAutoComplete.Clear();
+
+            ExpectEmptyOrRootOnly(root);
+        }
+
+        [Test]
+        public void Clear_on_an_empty_provider_succeeds()
+        {
+            basicAutoComplete.Clear();
+        }
+
+        [Test]
+        [TestCaseSource("SuggestionsTestCaseSource")]
+        public void GetSuggestions_returns_words_matching_the_root_prefix_in_descending_usage_order(string root,
+            string[] expectedSuggestions)
+        {
+            ConfigureProvider();
+
+            TestGetSuggestions(root, expectedSuggestions);
+        }
+
+        [Test]
+        public void RemoveEntry_ensures_a_word_is_no_longer_returned_as_a_suggestion_unless_it_is_the_input_root()
+        {
+            const string root = "peo";
+            ConfigureProvider();
+
+            basicAutoComplete.RemoveEntry("people");
+
+            // "peo" is not a word, so the list will either be 0 or 1 long, as we've not populated any other words
+            // beginning with those letters.
+            ExpectEmptyOrRootOnly(root);
+        }
+
+        [Test]
+        [TestCaseSource("SuggestionsTestCaseSource")]
+        public void RemoveEntry_on_a_word_not_in_the_provider_succeeds(string root,
+            string[] expectedSuggestions)
+        {
+            ConfigureProvider();
+
+            basicAutoComplete.RemoveEntry("thesaurus");
+
+            TestGetSuggestions(root, expectedSuggestions);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
@@ -54,8 +54,9 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             }
         }
 
-        public void AddEntry(string entry, DictionaryEntry newEntryWithUsageCount)
+        public void AddEntry(string entry, int usageCount = 0)
         {
+            var newEntryWithUsageCount = new DictionaryEntry(entry, usageCount);
 
             //Also add to entries for auto complete
             var autoCompleteHash = entry.CreateAutoCompleteDictionaryEntryHash(log: false);

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
@@ -13,6 +13,9 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
+        /// <summary>
+        /// Removes all possible suggestions from the auto complete provider.
+        /// </summary>
         public void Clear()
         {
             Log.Debug("Clear called.");

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
@@ -11,6 +11,9 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
     {
         void AddEntry(string entry, DictionaryEntry metaData);
 
+        /// <summary>
+        /// Removes all possible suggestions from the auto complete provider.
+        /// </summary>
         void Clear();
 
         void RemoveEntry(string entry);

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
@@ -1,6 +1,4 @@
-﻿using JuliusSweetland.OptiKey.Models;
-
-namespace JuliusSweetland.OptiKey.Services.AutoComplete
+﻿namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
     /// <summary>
     ///     Defines a management interface on top of an <see cref="IAutoComplete" /> implementation. It allows dictionary
@@ -9,7 +7,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
     /// <remarks>This class is for management of an underlying provider and so is declared <c>internal</c>.</remarks>
     internal interface IManageAutoComplete : IAutoComplete
     {
-        void AddEntry(string entry, DictionaryEntry metaData);
+        void AddEntry(string entry, int usageCount = 0);
 
         /// <summary>
         /// Removes all possible suggestions from the auto complete provider.

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -85,6 +85,9 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             }
         }
 
+        /// <summary>
+        /// Removes all possible suggestions from the auto complete provider.
+        /// </summary>
         public void Clear()
         {
             Log.Debug("Clear called.");

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -67,9 +67,10 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             trailingSpaces = new string(' ', trailingSpaceCount);
         }
 
-        public void AddEntry(string entry, DictionaryEntry dictionaryEntry)
+        public void AddEntry(string entry, int usageCount = 0)
         {
             var ngrams = ToNGrams(entry).ToList();
+            var dictionaryEntry = new DictionaryEntry(entry, usageCount);
             var metaData = new EntryMetadata(dictionaryEntry, ngrams.Count());
 
             foreach (var ngram in ngrams)

--- a/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
@@ -280,7 +280,7 @@ namespace JuliusSweetland.OptiKey.Services
                     }
 
                     //Also add to entries for auto complete
-                    autoComplete.AddEntry(entry, newEntryWithUsageCount);
+                    autoComplete.AddEntry(entry, usageCount);
                     
                     if (!loadedFromDictionaryFile)
                     {


### PR DESCRIPTION
Added unit tests around the `BasicAutoComplete` class. I also refactored the `IManageAutoComplete` interface slightly to take just the usage count rather than a `DictionaryEntry` - this makes the interface cleaner and means no error handling required for the case when the word in the entry is not the same as the word passed directly as a parameter. As a down-side, this means that the same `DictionaryEntry` is created in two places, but I envisage these two dictionaries being refactored into a single one in the future.