### PR TITLE
Ngrams

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Extensions\DoubleExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\CharExtensionsTests.cs" />
+    <Compile Include="Services\AutoComplete\NGramAutoCompleteTests.cs" />
     <Compile Include="Services\AutoComplete\BasicAutoCompleteTests.cs" />
     <Compile Include="Services\KeyboardOutputServiceTests.cs" />
     <Compile Include="TestBase.cs" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using JuliusSweetland.OptiKey.Services.AutoComplete;
 using NUnit.Framework;
 
@@ -70,26 +71,17 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             }
         };
 
-        private void ExpectEmptyOrRootOnly(string root)
+        private void ExpectEmpty(string root)
         {
-            var suggestions = basicAutoComplete.GetSuggestions(root).ToList();
+            var suggestions = basicAutoComplete.GetSuggestions(root);
 
-            Assert.IsTrue((suggestions.Count == 0) || (suggestions.Count == 1));
-
-            var firstOrDefault = suggestions.FirstOrDefault();
-            Assert.IsTrue((firstOrDefault == null) || (firstOrDefault == root));
+            CollectionAssert.IsEmpty(suggestions);
         }
 
-        private void TestGetSuggestions(string root, string[] expectedSuggestions)
+        private void TestGetSuggestions(string root, IEnumerable<string> expectedSuggestions)
         {
-            var suggestions = basicAutoComplete.GetSuggestions(root).ToList();
+            var suggestions = basicAutoComplete.GetSuggestions(root);
 
-            // The first suggestion can be the original root input.
-            var first = suggestions.First();
-            if ((first == root) && ((expectedSuggestions.Length == 0) || (root != expectedSuggestions[0])))
-            {
-                suggestions.RemoveAt(0);
-            }
             CollectionAssert.AreEqual(expectedSuggestions, suggestions);
         }
 
@@ -101,15 +93,9 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             // try to make this the "t"-word with the highest usage
             basicAutoComplete.AddEntry("these", 101);
 
-            var suggestions = basicAutoComplete.GetSuggestions("t").ToList();
+            var suggestions = basicAutoComplete.GetSuggestions("t");
 
-            var suggestion = suggestions[0];
-            if (suggestion == "t")
-            {
-                suggestion = suggestions[1];
-            }
-
-            Assert.AreNotEqual("these", suggestion);
+            Assert.AreNotEqual("these", suggestions.First());
         }
 
         [Test]
@@ -123,14 +109,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         }
 
         [Test]
-        public void Clear_on_a_configured_provider_removes_all_suggestions_and_may_only_return_root_input()
+        public void Clear_on_a_configured_provider_removes_all_suggestions()
         {
             const string root = "t";
             ConfigureProvider();
 
             basicAutoComplete.Clear();
 
-            ExpectEmptyOrRootOnly(root);
+            ExpectEmpty(root);
         }
 
         [Test]
@@ -150,7 +136,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         }
 
         [Test]
-        public void RemoveEntry_ensures_a_word_is_no_longer_returned_as_a_suggestion_unless_it_is_the_input_root()
+        public void RemoveEntry_ensures_a_word_is_no_longer_returned_as_a_suggestion()
         {
             const string root = "peo";
             ConfigureProvider();
@@ -159,7 +145,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
             // "peo" is not a word, so the list will either be 0 or 1 long, as we've not populated any other words
             // beginning with those letters.
-            ExpectEmptyOrRootOnly(root);
+            ExpectEmpty(root);
         }
 
         [Test]

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
@@ -1,0 +1,196 @@
+﻿using System.Linq;
+using JuliusSweetland.OptiKey.Services.AutoComplete;
+using NUnit.Framework;
+
+namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
+{
+    [TestFixture]
+    public class NGramAutoCompleteTests
+    {
+        #region Setup/Teardown
+
+        [SetUp]
+        public void Arrange()
+        {
+            ngramAutoComplete = new NGramAutoComplete();
+        }
+
+        #endregion
+
+        private NGramAutoComplete ngramAutoComplete;
+
+        /// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
+        private void ConfigureProvider()
+        {
+            var entries = new[] {
+                "the", "be", "to", "of", "and", "a", "in", "that", "have", "I", "it", "for", "not", "on", "with", "he",
+                "as", "you", "do", "at", "this", "but", "his", "by", "from", "they", "we", "say", "her", "she", "or",
+                "an", "will", "my", "one", "all", "would", "there", "their", "what", "so", "up", "out", "if", "about",
+                "who", "get", "which", "go", "me", "when", "make", "can", "like", "time", "no", "just", "him", "know",
+                "take", "people", "into", "year", "your", "good", "some", "could", "them", "see", "other", "than",
+                "then", "now", "look", "only", "come", "its", "over", "think", "also", "back", "after", "use", "two",
+                "how", "our", "work", "first", "well", "way", "even", "new", "want", "because", "any", "these", "give",
+                "day", "most", "us"
+            };
+            for (var index = 0; index < entries.Length; index++)
+            {
+                ngramAutoComplete.AddEntry(entries[index], 100 - index);
+            }
+        }
+
+        private static readonly object[] SuggestionsTestCaseSource = {
+            new object[] {
+                "t",
+                new[] {
+                    "to", "the", "two", "that", "this", "they", "time", "take", "them", "than", "then", "there", "their",
+                    "think", "these"
+                }
+            },
+            new object[] {
+                "th",
+                new[] {
+                    "the", "that", "this", "they", "them", "than", "then", "there", "their", "think", "these", "to",
+                    "two", "with", "time", "take"
+                }
+            },
+            new object[] {
+                "the",
+                new[] {
+                    "the", "they", "them", "then", "there", "their", "these", "that", "this", "than", "think", "to",
+                    "he", "she", "two", "time", "take", "other"
+                }
+            },
+            new object[] {
+                "thes",
+                new[] {
+                    "these", "the", "they", "them", "then", "there", "their", "that", "this", "than", "think", "to",
+                    "two", "time", "take", "other"
+                }
+            },
+            new object[] {
+                "thesa",
+                new[] {
+                    "these", "the", "they", "them", "then", "there", "their", "that", "this", "than", "think", "to",
+                    "two", "time", "take", "other"
+                }
+            },
+            new object[] {
+                "thesau",
+                new[] {
+                    "these", "the", "they", "them", "then", "there", "their", "that", "this", "than", "think", "to",
+                    "two", "time", "take", "other"
+                }
+            },
+            new object[] {
+                "thesaur",
+                new[] {
+                    "these", "the", "they", "them", "then", "there", "their", "that", "this", "than", "think", "to",
+                    "two", "our", "time", "take", "your", "other"
+                }
+            },
+            new object[] {
+                "thesauru",
+                new[] {
+                    "these", "the", "they", "them", "then", "there", "their", "that", "this", "than", "think", "to",
+                    "two", "time", "take", "other"
+                }
+            },
+            new object[] {
+                "thesaurus",
+                new[] {
+                    "these", "the", "they", "them", "then", "there", "their", "that", "this", "than", "think", "to",
+                    "us", "two", "time", "take", "other"
+                }
+            }
+        };
+
+        private void ExpectEmpty(string root)
+        {
+            var suggestions = ngramAutoComplete.GetSuggestions(root).ToList();
+
+            CollectionAssert.IsEmpty(suggestions);
+        }
+
+        private void TestGetSuggestions(string root, string[] expectedSuggestions)
+        {
+            var suggestions = ngramAutoComplete.GetSuggestions(root).ToList();
+
+            CollectionAssert.AreEqual(expectedSuggestions, suggestions);
+        }
+
+        [Test]
+        public void AddEntry_called_with_existing_entry_does_not_update_usage_count()
+        {
+            ConfigureProvider();
+
+            // try to make this the "t"-word with the highest usage
+            ngramAutoComplete.AddEntry("these", 101);
+
+            var suggestions = ngramAutoComplete.GetSuggestions("t");
+
+            Assert.AreNotEqual("these", suggestions.First());
+        }
+
+        [Test]
+        public void After_AddEntry_called_provider_will_return_word_as_suggestion()
+        {
+            ngramAutoComplete.AddEntry("zoo");
+
+            var suggestions = ngramAutoComplete.GetSuggestions("z");
+
+            CollectionAssert.Contains(suggestions, "zoo");
+        }
+
+        [Test]
+        public void Clear_on_a_configured_provider_removes_all_suggestions()
+        {
+            const string root = "t";
+            ConfigureProvider();
+
+            ngramAutoComplete.Clear();
+
+            ExpectEmpty(root);
+        }
+
+        [Test]
+        public void Clear_on_an_empty_provider_succeeds()
+        {
+            ngramAutoComplete.Clear();
+        }
+
+        [Test]
+        [TestCaseSource("SuggestionsTestCaseSource")]
+        public void GetSuggestions_returns_words_containing_matching_trigrams(string root,
+            string[] expectedSuggestions)
+        {
+            ConfigureProvider();
+
+            TestGetSuggestions(root, expectedSuggestions);
+        }
+
+        [Test]
+        public void RemoveEntry_ensures_a_word_is_no_longer_returned_as_a_suggestion()
+        {
+            const string root = "peo";
+            ConfigureProvider();
+
+            ngramAutoComplete.RemoveEntry("people");
+
+            // "peo" is not a word, so the list will either be 0 or 1 long, as we've not populated any other words
+            // beginning with those letters.
+            ExpectEmpty(root);
+        }
+
+        [Test]
+        [TestCaseSource("SuggestionsTestCaseSource")]
+        public void RemoveEntry_on_a_word_not_in_the_provider_succeeds(string root,
+            string[] expectedSuggestions)
+        {
+            ConfigureProvider();
+
+            ngramAutoComplete.RemoveEntry("thesaurus");
+
+            TestGetSuggestions(root, expectedSuggestions);
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey/Models/DictionaryEntry.cs
+++ b/src/JuliusSweetland.OptiKey/Models/DictionaryEntry.cs
@@ -1,5 +1,8 @@
-﻿namespace JuliusSweetland.OptiKey.Models
+﻿using System.Diagnostics;
+
+namespace JuliusSweetland.OptiKey.Models
 {
+    [DebuggerDisplay("'{Entry}' used {UsageCount}")]
     public class DictionaryEntry
     {
         public DictionaryEntry(string entry, int usageCount = 0)

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
@@ -32,26 +32,21 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
 
                 if (!string.IsNullOrWhiteSpace(simplifiedRoot))
                 {
-                    var enumerator =
-                        new List<DictionaryEntry> { new DictionaryEntry(root) } //Include the typed root as first result
-                        .Union(entriesForAutoComplete
-                                .Where(kvp => kvp.Key.StartsWith(simplifiedRoot, StringComparison.Ordinal))
-                                .SelectMany(kvp => kvp.Value)
-                                .Where(de => de.Entry.Length > root.Length)
-                                .Distinct() //Phrases are stored in entriesForAutoComplete with multiple hashes (one the full version of the phrase and one the first letter of each word so you can look them up by either)
-                                .OrderByDescending(de => de.UsageCount)
-                                .ThenBy(de => de.Entry.Length))
-                        .Select(de => de.Entry)
-                        .GetEnumerator();
-
-                    while (enumerator.MoveNext())
-                    {
-                        yield return enumerator.Current;
-                    }
+                    return
+                        entriesForAutoComplete
+                            .Where(kvp => kvp.Key.StartsWith(simplifiedRoot, StringComparison.Ordinal))
+                            .SelectMany(kvp => kvp.Value)
+                            .Where(de => de.Entry.Length >= root.Length)
+                            .Distinct()
+                            // Phrases are stored in entriesForAutoComplete with multiple hashes (one the full version
+                            // of the phrase and one the first letter of each word so you can look them up by either)
+                            .OrderByDescending(de => de.UsageCount)
+                            .ThenBy(de => de.Entry.Length)
+                            .Select(de => de.Entry);
                 }
-
-                yield break; //Not strictly necessary
             }
+
+            return Enumerable.Empty<string>();
         }
 
         public void AddEntry(string entry, int usageCount = 0)

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -16,6 +16,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
     {
         private readonly Dictionary<string, HashSet<EntryMetadata>> entries = new Dictionary<string, HashSet<EntryMetadata>>();
         private readonly Func<string, string> normalize;
+        private readonly int gramCount;
         private readonly string leadingSpaces;
         private readonly string trailingSpaces;
 
@@ -63,6 +64,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             }
 
             normalize = normalizeFunc;
+            this.gramCount = gramCount;
             leadingSpaces = new string(' ', leadingSpaceCount);
             trailingSpaces = new string(' ', trailingSpaceCount);
         }
@@ -134,9 +136,9 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
         private IEnumerable<string> ToNGrams(string word)
         {
             var normalizedWord = leadingSpaces + normalize(word) + trailingSpaces;
-            for (var i = 0; i < normalizedWord.Length-2; i++)
+            for (var i = 0; i < normalizedWord.Length - gramCount + 1; i++)
             {
-                yield return normalizedWord.Substring(i, 3);
+                yield return normalizedWord.Substring(i, gramCount);
             }
         }
 

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -1,6 +1,7 @@
 ﻿using JuliusSweetland.OptiKey.Models;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using log4net;
@@ -142,6 +143,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             }
         }
 
+        [DebuggerDisplay("'{DictionaryEntry.Entry}' used {DictionaryEntry.UsageCount} (ngrams: {NGramCount})")]
         private class EntryMetadata
         {
             public EntryMetadata(DictionaryEntry dictionaryEntry, int nGramCount)

--- a/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
@@ -544,6 +544,13 @@ namespace JuliusSweetland.OptiKey.Services
                         Log.DebugFormat("{0} suggestions generated (possibly capped to {1} by MaxDictionaryMatchesOrSuggestions setting)",
                             suggestions.Count(), Settings.Default.MaxDictionaryMatchesOrSuggestions);
 
+                        // Ensure that the entered word is in the list of suggestions
+                        if (!suggestions.Contains(inProgressWord))
+                        {
+                            suggestions.Insert(0, inProgressWord);
+                            suggestions = suggestions.Take(Settings.Default.MaxDictionaryMatchesOrSuggestions).ToList();
+                        }
+
                         //Correctly case auto complete suggestions
                         var leftShiftIsDown = keyStateService.KeyDownStates[KeyValues.LeftShiftKey].Value == KeyDownStates.Down;
                         var leftShiftIsLockedDown = keyStateService.KeyDownStates[KeyValues.LeftShiftKey].Value == KeyDownStates.LockedDown;


### PR DESCRIPTION
Add unit tests for the NGramAutoComplete class. Also, change the behaviour of `IAutoComplete`'s `GetSuggestions` to not include the root keyword at the head of the list.