### PR TITLE
Typed word is at the head of the suggestions list

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Services.AutoComplete;
 using NUnit.Framework;
 
@@ -35,7 +36,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             };
             for (var index = 0; index < entries.Length; index++)
             {
-                basicAutoComplete.AddEntry(entries[index], 100 - index);
+                var word = entries[index];
+                basicAutoComplete.AddEntry(word, new DictionaryEntry(word, 100 - index));
             }
         }
 
@@ -91,7 +93,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             ConfigureProvider();
 
             // try to make this the "t"-word with the highest usage
-            basicAutoComplete.AddEntry("these", 101);
+            basicAutoComplete.AddEntry("these", new DictionaryEntry("these", 101));
 
             var suggestions = basicAutoComplete.GetSuggestions("t");
 
@@ -101,7 +103,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         [Test]
         public void After_AddEntry_called_provider_will_return_word_as_suggestion()
         {
-            basicAutoComplete.AddEntry("zoo");
+            basicAutoComplete.AddEntry("zoo", new DictionaryEntry("zoo"));
 
             var suggestions = basicAutoComplete.GetSuggestions("z");
 

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Services.AutoComplete;
 using NUnit.Framework;
 
@@ -34,7 +35,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             };
             for (var index = 0; index < entries.Length; index++)
             {
-                ngramAutoComplete.AddEntry(entries[index], 100 - index);
+                var word = entries[index];
+                ngramAutoComplete.AddEntry(word, new DictionaryEntry(word, 100 - index));
             }
         }
 
@@ -124,7 +126,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             ConfigureProvider();
 
             // try to make this the "t"-word with the highest usage
-            ngramAutoComplete.AddEntry("these", 101);
+            ngramAutoComplete.AddEntry("these", new DictionaryEntry("these", 101));
 
             var suggestions = ngramAutoComplete.GetSuggestions("t");
 
@@ -134,7 +136,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         [Test]
         public void After_AddEntry_called_provider_will_return_word_as_suggestion()
         {
-            ngramAutoComplete.AddEntry("zoo");
+            ngramAutoComplete.AddEntry("zoo", new DictionaryEntry("zoo"));
 
             var suggestions = ngramAutoComplete.GetSuggestions("z");
 

--- a/src/JuliusSweetland.OptiKey/Extensions/ArrayExtensions.cs
+++ b/src/JuliusSweetland.OptiKey/Extensions/ArrayExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+
+namespace JuliusSweetland.OptiKey.Extensions
+{
+    public static class ArrayExtensions
+    {
+        /// <summary>
+        ///     Swaps two elements in an array. No bounds checking is done.
+        /// </summary>
+        /// <param name="list">The list to swap elements in.</param>
+        /// <param name="first">The index of the element to swap to the second index position.</param>
+        /// <param name="second">The index of the element to swap to the first index position.</param>
+        public static void Swap(this IList list, int first, int second)
+        {
+            var temp = list[first];
+            list[first] = list[second];
+            list[second] = temp;
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Enums\PointsSources.cs" />
     <Compile Include="Enums\TriggerSources.cs" />
     <Compile Include="Enums\TriggerStopSignals.cs" />
+    <Compile Include="Extensions\ArrayExtensions.cs" />
     <Compile Include="Extensions\BitmapExtensions.cs" />
     <Compile Include="Extensions\DoubleExtensions.cs" />
     <Compile Include="Extensions\IKeyStateServiceExtensions.cs" />

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
@@ -49,9 +49,8 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             return Enumerable.Empty<string>();
         }
 
-        public void AddEntry(string entry, int usageCount = 0)
+        public void AddEntry(string entry, DictionaryEntry newEntryWithUsageCount)
         {
-            var newEntryWithUsageCount = new DictionaryEntry(entry, usageCount);
 
             //Also add to entries for auto complete
             var autoCompleteHash = entry.CreateAutoCompleteDictionaryEntryHash(log: false);

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
@@ -1,4 +1,6 @@
-﻿namespace JuliusSweetland.OptiKey.Services.AutoComplete
+﻿using JuliusSweetland.OptiKey.Models;
+
+namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
     /// <summary>
     ///     Defines a management interface on top of an <see cref="IAutoComplete" /> implementation. It allows dictionary
@@ -7,7 +9,7 @@
     /// <remarks>This class is for management of an underlying provider and so is declared <c>internal</c>.</remarks>
     internal interface IManageAutoComplete : IAutoComplete
     {
-        void AddEntry(string entry, int usageCount = 0);
+        void AddEntry(string entry, DictionaryEntry metaData);
 
         /// <summary>
         /// Removes all possible suggestions from the auto complete provider.

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -70,10 +70,9 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             trailingSpaces = new string(' ', trailingSpaceCount);
         }
 
-        public void AddEntry(string entry, int usageCount = 0)
+        public void AddEntry(string entry, DictionaryEntry dictionaryEntry)
         {
             var ngrams = ToNGrams(entry).ToList();
-            var dictionaryEntry = new DictionaryEntry(entry, usageCount);
             var metaData = new EntryMetadata(dictionaryEntry, ngrams.Count());
 
             foreach (var ngram in ngrams)

--- a/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
@@ -280,7 +280,7 @@ namespace JuliusSweetland.OptiKey.Services
                     }
 
                     //Also add to entries for auto complete
-                    autoComplete.AddEntry(entry, usageCount);
+                    autoComplete.AddEntry(entry, newEntryWithUsageCount);
                     
                     if (!loadedFromDictionaryFile)
                     {

--- a/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
@@ -544,11 +544,22 @@ namespace JuliusSweetland.OptiKey.Services
                         Log.DebugFormat("{0} suggestions generated (possibly capped to {1} by MaxDictionaryMatchesOrSuggestions setting)",
                             suggestions.Count(), Settings.Default.MaxDictionaryMatchesOrSuggestions);
 
-                        // Ensure that the entered word is in the list of suggestions
-                        if (!suggestions.Contains(inProgressWord))
+                        // Ensure that the entered word is in the list of suggestions...
+                        if (!suggestions.Contains(inProgressWord, StringComparer.CurrentCultureIgnoreCase))
                         {
                             suggestions.Insert(0, inProgressWord);
                             suggestions = suggestions.Take(Settings.Default.MaxDictionaryMatchesOrSuggestions).ToList();
+                        }
+                        else
+                        {
+                            // ...and that it is at the front of the list.
+                            var index =
+                                suggestions.FindIndex(
+                                    s => string.Equals(s, inProgressWord, StringComparison.CurrentCultureIgnoreCase));
+                            if (index > 0)
+                            {
+                                suggestions.Swap(0, index);
+                            }
                         }
 
                         //Correctly case auto complete suggestions


### PR DESCRIPTION
This commit ensures that the typed word always appears at the head of the suggestions list. This functionality has been moved out of the `DictionaryService` into the `KeyboardOutputService`.

Also, revert a previous committing segregating the `DictionaryEntry` objects between the `DictionaryService` and `IAutoComplete` implementations as it broke the usage count update. I've separately raised issue #218 to fix this.