### PR TITLE
preventing the change of focus when using mouse button key selection

### DIFF
--- a/src/JuliusSweetland.OptiKey/Native/Common/PInvoke.cs
+++ b/src/JuliusSweetland.OptiKey/Native/Common/PInvoke.cs
@@ -48,6 +48,9 @@ namespace JuliusSweetland.OptiKey.Native
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern int RegisterWindowMessage(string msg);
 
+        [DllImport("user32.dll")]
+        public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
         //Wrapper around GetWindowLong32 and GetWindowLong64 based on the current bitness
         public static long GetWindowLong(IntPtr hWnd, int nIndex)
         {

--- a/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
@@ -11,6 +11,7 @@ using JuliusSweetland.OptiKey.Native.Common;
 using JuliusSweetland.OptiKey.Native.Common.Enums;
 using JuliusSweetland.OptiKey.Native.Common.Structs;
 using JuliusSweetland.OptiKey.Static;
+using JuliusSweetland.OptiKey.Properties;
 using log4net;
 
 namespace JuliusSweetland.OptiKey.Services
@@ -112,7 +113,8 @@ namespace JuliusSweetland.OptiKey.Services
             Log.DebugFormat("Screen bounds in Dp: {0}", screenBoundsInDp);
 
             CoerceSavedStateAndApply();
-        
+            PreventWindowActivation();
+
             window.Closed += (_, __) => UnRegisterAppBar();
         }
 
@@ -1267,6 +1269,21 @@ namespace JuliusSweetland.OptiKey.Services
             //Add hook to receive position change messages from Windows
             HwndSource source = HwndSource.FromHwnd(abd.hWnd);
             source.AddHook(AppBarPositionChangeCallback);
+        }
+
+        // If we are using mouse button clicks as a key selection source we should prevent the window from changing focus 
+        // so the target window receives the keyboard input
+        private void PreventWindowActivation()
+        {
+            if (Settings.Default.KeySelectionTriggerSource == TriggerSources.MouseButtonDownUps)
+            {
+                const int WS_EX_APPWINDOW = 0x40000;
+                const int WS_EX_NOACTIVATE = 0x08000000;
+                const int GWL_EXSTYLE = -0x14;
+
+                PInvoke.SetWindowLong(windowHandle, GWL_EXSTYLE, (int)PInvoke.GetWindowLong(windowHandle, GWL_EXSTYLE)
+                    | WS_EX_NOACTIVATE | WS_EX_APPWINDOW);
+            }
         }
 
         private void SetAppBarSizeAndPosition(DockEdges dockPosition, Rect sizeAndPosition, bool isInitialising = false)


### PR DESCRIPTION
This fix should address issue #305. It will prevent the changing of focus when using the mouse button key trigger source. This will allow Optikey to type into the target window even when the user is clicking on it. 

Using this approach, the user will not be able to open the management console using only the on-screen keyboard. Instead, users should open the management console using the context menu or by clicking Optikey in the taskbar to activate the window and then pressing Alt-M. The latter method is similar to how users can activate the window for Microsoft's on-screen keyboard.

This only affects the behavior when using the mouse button key trigger source. Other trigger sources are not affected.