### PR TITLE
#272: set keyboard back to the origianl keyboard after adding a word to the dictionary

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
@@ -448,10 +448,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     {
                         dictionaryService.AddNewEntryToDictionary(candidate);
                         inputService.RequestSuspend();
-                        nextAction();
 
                         RaiseToastNotification(Resources.ADDED, string.Format(Resources.ENTRY_ADDED_TO_DICTIONARY, candidate),
                             NotificationTypes.Normal, () => { inputService.RequestResume(); });
+
+                        nextAction();
                     },
                     () => nextAction());
             }


### PR DESCRIPTION
Moved the delegate to set the Keyboard back to the original to run at the end of the yes action.  