### PR TITLE
Fixed restoring window to minimised bug

### DIFF
--- a/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
@@ -112,17 +112,23 @@ namespace JuliusSweetland.OptiKey.Services
                 screenBoundsBottomRightInDp.Y - screenBoundsTopLeftInDp.Y);
             Log.DebugFormat("Screen bounds in Dp: {0}", screenBoundsInDp);
 
-            //Force the window state/previous window state to Docked if either is Minimised
-            //This is to avoid restoring the window state to Minimised in certain scenarios
+            //Force the window state/previous window state to non-Minimised/non-Hidden
+            //This is to avoid restoring the window state to Minimised or Hidden in certain scenarios
             var windowState = getWindowState();
             var previousWindowState = getPreviousWindowState();
-            if (windowState == WindowStates.Minimised)
+            if (windowState == WindowStates.Minimised ||
+                windowState == WindowStates.Hidden)
             {
-                saveWindowState(WindowStates.Docked);
-            }
-            if (previousWindowState == WindowStates.Minimised)
-            {
-                savePreviousWindowState(WindowStates.Docked);
+                if (previousWindowState == WindowStates.Minimised ||
+                    previousWindowState == WindowStates.Hidden)
+                {
+                    saveWindowState(WindowStates.Docked);
+                    savePreviousWindowState(WindowStates.Docked);
+                }
+                else
+                {
+                    saveWindowState(previousWindowState);
+                }
             }
 
             CoerceSavedStateAndApply();

--- a/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
@@ -112,25 +112,7 @@ namespace JuliusSweetland.OptiKey.Services
                 screenBoundsBottomRightInDp.Y - screenBoundsTopLeftInDp.Y);
             Log.DebugFormat("Screen bounds in Dp: {0}", screenBoundsInDp);
 
-            //Force the window state/previous window state to non-Minimised/non-Hidden
-            //This is to avoid restoring the window state to Minimised or Hidden in certain scenarios
-            var windowState = getWindowState();
-            var previousWindowState = getPreviousWindowState();
-            if (windowState == WindowStates.Minimised ||
-                windowState == WindowStates.Hidden)
-            {
-                if (previousWindowState == WindowStates.Minimised ||
-                    previousWindowState == WindowStates.Hidden)
-                {
-                    saveWindowState(WindowStates.Docked);
-                    savePreviousWindowState(WindowStates.Docked);
-                }
-                else
-                {
-                    saveWindowState(previousWindowState);
-                }
-            }
-
+            PreventInvalidRestoreState();
             CoerceSavedStateAndApply();
             PreventWindowActivation();
 
@@ -1288,6 +1270,36 @@ namespace JuliusSweetland.OptiKey.Services
             //Add hook to receive position change messages from Windows
             HwndSource source = HwndSource.FromHwnd(abd.hWnd);
             source.AddHook(AppBarPositionChangeCallback);
+        }
+
+        private void PreventInvalidRestoreState()
+        {
+            // We don't want OptiKey to be restored to a Minimised, Hidden,
+            //  or Maximised state, especially if it starts up in Conversation
+            //  mode
+            // Thus we modify the initial window states if necessary
+
+            var windowState = getWindowState();
+            var previousWindowState = getPreviousWindowState();
+            if (windowState != WindowStates.Docked &&
+                windowState != WindowStates.Floating)
+            {
+                if (previousWindowState == WindowStates.Docked ||
+                    previousWindowState == WindowStates.Floating)
+                {
+                    saveWindowState(previousWindowState);
+                }
+                else
+                {
+                    saveWindowState(WindowStates.Docked);
+                }
+            }
+
+            if (previousWindowState != WindowStates.Docked &&
+                previousWindowState != WindowStates.Floating)
+            {
+                savePreviousWindowState(WindowStates.Docked);
+            }
         }
 
         //If we are using mouse button clicks as a key selection source we should prevent 

--- a/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/WindowManipulationService.cs
@@ -112,6 +112,19 @@ namespace JuliusSweetland.OptiKey.Services
                 screenBoundsBottomRightInDp.Y - screenBoundsTopLeftInDp.Y);
             Log.DebugFormat("Screen bounds in Dp: {0}", screenBoundsInDp);
 
+            //Force the window state/previous window state to Docked if either is Minimised
+            //This is to avoid restoring the window state to Minimised in certain scenarios
+            var windowState = getWindowState();
+            var previousWindowState = getPreviousWindowState();
+            if (windowState == WindowStates.Minimised)
+            {
+                saveWindowState(WindowStates.Docked);
+            }
+            if (previousWindowState == WindowStates.Minimised)
+            {
+                savePreviousWindowState(WindowStates.Docked);
+            }
+
             CoerceSavedStateAndApply();
             PreventWindowActivation();
 


### PR DESCRIPTION
## Bug description
A scenario happens where a user starts out in Conversation mode, and when the user tries to go back (to the Menu), the window state goes to Minimised. Thus at this point the OptiKey window is shrunk to the size of the minimised state even though the application is at the Menu, and so the user cannot use the Menu at all since it's too small.

This scenario can be reproduced by making OptiKey start out in Conversation mode, going back to the Menu, minimising OptiKey, and then exiting the application the "unusual" way (say right click on the taskbar icon and close the application from there). Opening OptiKey again and try to go back - it should resize to the minimised window state.

This happens because after minimising OptiKey and unusually closing it, the saved MainWindowState in user.config is Minimised, and this then becomes the MainWindowPreviousState when OptiKey changes the window state to Maximised at start up (due to Conversation mode). At this point, when the user goes back, MainWindowPreviousState = Minimised is restored.

## Solution description
During startup (specifically, at the constructor of WindowManipulationService), the window state or previous window state is forced to Docked if either one is minimised (in user.config).

In my local manual testing, the changes prevent the scenario as described above from happening.