### PR TITLE
Consolidate data structure to store in-memory dictionary entries

### DIFF
--- a/src/JuliusSweetland.OptiKey.AutoCompletePerformance/JuliusSweetland.OptiKey.AutoCompletePerformance.csproj
+++ b/src/JuliusSweetland.OptiKey.AutoCompletePerformance/JuliusSweetland.OptiKey.AutoCompletePerformance.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CsvHelper.2.13.5.0\lib\net40-client\CsvHelper.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/JuliusSweetland.OptiKey.AutoCompletePerformance/packages.config
+++ b/src/JuliusSweetland.OptiKey.AutoCompletePerformance/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CsvHelper" version="2.13.5.0" targetFramework="net46" />
+  <package id="CsvHelper" version="2.16.3.0" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -35,32 +35,33 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.1.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.7.63.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.63\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Prism, Version=6.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Prism.Core.6.0.1\lib\net45\Prism.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Prism, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Prism.Core.6.3.0\lib\net45\Prism.dll</HintPath>
     </Reference>
-    <Reference Include="Prism.Wpf, Version=6.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Prism.Wpf.6.0.1\lib\net45\Prism.Wpf.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Prism.Wpf, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Prism.Wpf.6.3.0\lib\net45\Prism.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Prism.Wpf.6.3.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -137,4 +138,3 @@
   </Target>
   -->
 </Project>
-

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
@@ -9,10 +9,9 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
     internal abstract class AutoCompleteTestsBase
     {
         private IManageAutoComplete autoComplete;
+		protected static object[] SuggestionsTestCaseSource { get; private set; }
 
-	protected static object[] SuggestionsTestCaseSource { get; private set; }
-
-	[Test]
+		[Test]
         public void AddEntry_called_with_existing_entry_does_not_update_usage_count()
         {
             ConfigureProvider();
@@ -98,7 +97,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         }
 
         protected abstract IManageAutoComplete CreateAutoComplete();
-	protected abstract object[] GetTestCases();
+		protected abstract object[] GetTestCases();
 
 	/// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
 	private void ConfigureProvider()
@@ -151,10 +150,10 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
         [SetUp]
         public void Arrange()
-	{
+		{
             autoComplete = CreateAutoComplete();
-	    SuggestionsTestCaseSource = GetTestCases();
-	}
+			SuggestionsTestCaseSource = GetTestCases();
+		}
 
         #endregion
     }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
@@ -98,10 +98,10 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         }
 
         protected abstract IManageAutoComplete CreateAutoComplete();
-		protected abstract object[] GetTestCases();
+	protected abstract object[] GetTestCases();
 
-		/// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
-		private void ConfigureProvider()
+	/// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
+	private void ConfigureProvider()
         {
             var entries = new[] {
                 "the", "be", "to", "of", "and", "a", "in", "that", "have", "I", "it", "for", "not", "on", "with", "he",
@@ -151,10 +151,10 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
         [SetUp]
         public void Arrange()
-		{
+	{
             autoComplete = CreateAutoComplete();
-			SuggestionsTestCaseSource = GetTestCases();
-		}
+	    SuggestionsTestCaseSource = GetTestCases();
+	}
 
         #endregion
     }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
@@ -99,8 +99,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         protected abstract IManageAutoComplete CreateAutoComplete();
 		protected abstract object[] GetTestCases();
 
-	/// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
-	private void ConfigureProvider()
+		/// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
+		private void ConfigureProvider()
         {
             var entries = new[] {
                 "the", "be", "to", "of", "and", "a", "in", "that", "have", "I", "it", "for", "not", "on", "with", "he",
@@ -112,6 +112,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
                 "how", "our", "work", "first", "well", "way", "even", "new", "want", "because", "any", "these", "give",
                 "day", "most", "us"
             };
+
             for (var index = 0; index < entries.Length; index++)
             {
                 var word = entries[index];
@@ -125,6 +126,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
                 "how are you", "hay", "hays", "hay's", "hayed", "ha", "haying", "had", "hag", "halfway", "hallway",
                 "ham", "has", "hat", "haywire", "haystack", "hack", "hags", "hail", "hair", "hale"
             };
+
             for (var index = 0; index < entries.Length; index++)
             {
                 var word = entries[index];

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
@@ -9,9 +9,10 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
     internal abstract class AutoCompleteTestsBase
     {
         private IManageAutoComplete autoComplete;
-        protected abstract object[] SuggestionsTestCaseSource { get; }
 
-        [Test]
+		protected static object[] SuggestionsTestCaseSource { get; private set; }
+
+		[Test]
         public void AddEntry_called_with_existing_entry_does_not_update_usage_count()
         {
             ConfigureProvider();
@@ -97,9 +98,10 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         }
 
         protected abstract IManageAutoComplete CreateAutoComplete();
+		protected abstract object[] GetTestCases();
 
-        /// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
-        private void ConfigureProvider()
+		/// <remarks>Top 100 most common words in English: https://en.wikipedia.org/wiki/Most_common_words_in_English. </remarks>
+		private void ConfigureProvider()
         {
             var entries = new[] {
                 "the", "be", "to", "of", "and", "a", "in", "that", "have", "I", "it", "for", "not", "on", "with", "he",
@@ -148,9 +150,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         #region Setup/Teardown
 
         [SetUp]
-        public void Arrange() {
+        public void Arrange()
+		{
             autoComplete = CreateAutoComplete();
-        }
+			SuggestionsTestCaseSource = GetTestCases();
+		}
 
         #endregion
     }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
@@ -10,9 +10,9 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
     {
         private IManageAutoComplete autoComplete;
 
-		protected static object[] SuggestionsTestCaseSource { get; private set; }
+	protected static object[] SuggestionsTestCaseSource { get; private set; }
 
-		[Test]
+	[Test]
         public void AddEntry_called_with_existing_entry_does_not_update_usage_count()
         {
             ConfigureProvider();

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -11,8 +11,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             return new BasicAutoComplete();
         }
 
-        protected override object[] SuggestionsTestCaseSource
-        {
+		protected override object[] GetTestCases()
+		{
+			return SuggestionsTestCases;
+		}
+
+		private object[] SuggestionsTestCases
+		{
             get
             {
                 return new object[] {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -11,13 +11,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             return new BasicAutoComplete();
         }
 
-	protected override object[] GetTestCases()
-	{
-	    return SuggestionsTestCases;
-	}
+		protected override object[] GetTestCases()
+		{
+			return SuggestionsTestCases;
+		}
 
-	private object[] SuggestionsTestCases
-	{
+		private object[] SuggestionsTestCases
+		{
             get
             {
                 return new object[] {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -11,13 +11,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             return new BasicAutoComplete();
         }
 
-		protected override object[] GetTestCases()
-		{
-			return SuggestionsTestCases;
-		}
+	protected override object[] GetTestCases()
+	{
+		return SuggestionsTestCases;
+	}
 
-		private object[] SuggestionsTestCases
-		{
+	private object[] SuggestionsTestCases
+	{
             get
             {
                 return new object[] {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/BasicAutoCompleteTests.cs
@@ -13,7 +13,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
 	protected override object[] GetTestCases()
 	{
-		return SuggestionsTestCases;
+	    return SuggestionsTestCases;
 	}
 
 	private object[] SuggestionsTestCases

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
@@ -11,8 +11,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             return new NGramAutoComplete();
         }
 
-        protected override object[] SuggestionsTestCaseSource
-        {
+		protected override object[] GetTestCases()
+		{
+			return SuggestionsTestCases;
+		}
+
+		private object[] SuggestionsTestCases
+		{
             get
             {
                 return new object[] {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
@@ -11,13 +11,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             return new NGramAutoComplete();
         }
 
-		protected override object[] GetTestCases()
-		{
-			return SuggestionsTestCases;
-		}
+	protected override object[] GetTestCases()
+	{
+		return SuggestionsTestCases;
+	}
 
-		private object[] SuggestionsTestCases
-		{
+	private object[] SuggestionsTestCases
+	{
             get
             {
                 return new object[] {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
@@ -11,13 +11,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
             return new NGramAutoComplete();
         }
 
-	protected override object[] GetTestCases()
-	{
-	    return SuggestionsTestCases;
-	}
+		protected override object[] GetTestCases()
+		{
+			return SuggestionsTestCases;
+		}
 
-	private object[] SuggestionsTestCases
-	{
+		private object[] SuggestionsTestCases
+		{
             get
             {
                 return new object[] {

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/NGramAutoCompleteTests.cs
@@ -13,7 +13,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
 	protected override object[] GetTestCases()
 	{
-		return SuggestionsTestCases;
+	    return SuggestionsTestCases;
 	}
 
 	private object[] SuggestionsTestCases

--- a/src/JuliusSweetland.OptiKey.UnitTests/packages.config
+++ b/src/JuliusSweetland.OptiKey.UnitTests/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.1.0" targetFramework="net46" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net46" />
-  <package id="NUnit" version="2.6.4" targetFramework="net46" />
-  <package id="Prism.Core" version="6.0.1" targetFramework="net46" />
-  <package id="Prism.Wpf" version="6.0.1" targetFramework="net46" />
+  <package id="Moq" version="4.7.63" targetFramework="net46" />
+  <package id="NUnit" version="3.7.1" targetFramework="net46" />
+  <package id="Prism.Core" version="6.3.0" targetFramework="net46" />
+  <package id="Prism.Wpf" version="6.3.0" targetFramework="net46" />
 </packages>

--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -77,12 +77,11 @@
     <Reference Include="EyeXFramework">
       <HintPath>..\..\ext\TobiiEyeXSdk\EyeXFramework.dll</HintPath>
     </Reference>
-    <Reference Include="log4net">
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.1.2.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\MahApps.Metro.1.1.2.0\lib\net45\MahApps.Metro.dll</HintPath>
+    <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MahApps.Metro.1.5.0\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MicrosoftExpressionInteractions.3.0.40218.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
@@ -101,15 +100,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\ext\TheEyeTribe\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Octokit, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Octokit.0.23.0\lib\net45\Octokit.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octokit, Version=0.24.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.0.24.0\lib\net45\Octokit.dll</HintPath>
     </Reference>
-    <Reference Include="Prism">
-      <HintPath>..\..\packages\Prism.Core.6.0.1\lib\net45\Prism.dll</HintPath>
+    <Reference Include="Prism, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Prism.Core.6.3.0\lib\net45\Prism.dll</HintPath>
     </Reference>
-    <Reference Include="Prism.Wpf">
-      <HintPath>..\..\packages\Prism.Wpf.6.0.1\lib\net45\Prism.Wpf.dll</HintPath>
+    <Reference Include="Prism.Wpf, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Prism.Wpf.6.3.0\lib\net45\Prism.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -144,7 +142,7 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MahApps.Metro.1.1.2.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>..\..\packages\Prism.Wpf.6.3.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
@@ -9,7 +9,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
 	public class BasicAutoComplete : IManageAutoComplete
     {
-        private readonly Dictionary<string, HashSet<DictionaryEntry>> entriesForAutoComplete = new Dictionary<string, HashSet<DictionaryEntry>>();
+        private readonly Dictionary<string, HashSet<DictionaryEntry>> entries = new Dictionary<string, HashSet<DictionaryEntry>>();
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -19,21 +19,21 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
         public void Clear()
         {
             Log.Debug("Clear called.");
-            entriesForAutoComplete.Clear();
+            entries.Clear();
         }
 
         public IEnumerable<string> GetSuggestions(string root)
         {
             Log.DebugFormat("GetAutoCompleteSuggestions called with root '{0}'", root);
 
-            if (entriesForAutoComplete != null)
+            if (entries != null)
             {
                 var simplifiedRoot = root.Normalise();
 
                 if (!string.IsNullOrWhiteSpace(simplifiedRoot))
                 {
                     return
-                        entriesForAutoComplete
+                        entries
                             .Where(kvp => kvp.Key.StartsWith(simplifiedRoot, StringComparison.Ordinal))
                             .SelectMany(kvp => kvp.Value)
                             .Where(de => de.Entry.Length >= root.Length)
@@ -67,16 +67,16 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
         { 
             if (!string.IsNullOrWhiteSpace(autoCompleteHash))
             {
-                if (entriesForAutoComplete.ContainsKey(autoCompleteHash))
+                if (entries.ContainsKey(autoCompleteHash))
                 {
-                    if (entriesForAutoComplete[autoCompleteHash].All(nwwuc => nwwuc.Entry != entry))
+                    if (entries[autoCompleteHash].All(nwwuc => nwwuc.Entry != entry))
                     {
-                        entriesForAutoComplete[autoCompleteHash].Add(newEntryWithUsageCount);
+                        entries[autoCompleteHash].Add(newEntryWithUsageCount);
                     }
                 }
                 else
                 {
-                    entriesForAutoComplete.Add(autoCompleteHash, new HashSet<DictionaryEntry> { newEntryWithUsageCount });
+                    entries.Add(autoCompleteHash, new HashSet<DictionaryEntry> { newEntryWithUsageCount });
                 }
             }
         }
@@ -85,21 +85,26 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
         {
             var autoCompleteHash = entry.Normalise(log: false);
             if (!string.IsNullOrWhiteSpace(autoCompleteHash)
-                && entriesForAutoComplete.ContainsKey(autoCompleteHash))
+                && entries.ContainsKey(autoCompleteHash))
             {
-                var foundEntryForAutoComplete = entriesForAutoComplete[autoCompleteHash].FirstOrDefault(ewuc => ewuc.Entry == entry);
+                var foundEntryForAutoComplete = entries[autoCompleteHash].FirstOrDefault(ewuc => ewuc.Entry == entry);
 
                 if (foundEntryForAutoComplete != null)
                 {
-                    entriesForAutoComplete[autoCompleteHash].Remove(foundEntryForAutoComplete);
+                    entries[autoCompleteHash].Remove(foundEntryForAutoComplete);
 
-                    if (!entriesForAutoComplete[autoCompleteHash].Any())
+                    if (!entries[autoCompleteHash].Any())
                     {
-                        entriesForAutoComplete.Remove(autoCompleteHash);
+                        entries.Remove(autoCompleteHash);
                     }
                 }
             }
 
         }
+
+		public Dictionary<string, HashSet<DictionaryEntry>> GetEntries()
+		{
+			return entries;
+		}
     }
 }

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/BasicAutoComplete.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
-    public class BasicAutoComplete : IManageAutoComplete
+	public class BasicAutoComplete : IManageAutoComplete
     {
         private readonly Dictionary<string, HashSet<DictionaryEntry>> entriesForAutoComplete = new Dictionary<string, HashSet<DictionaryEntry>>();
 
@@ -50,24 +50,21 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
         }
 
         public void AddEntry(string entry, DictionaryEntry newEntryWithUsageCount)
-        {
+		{
+			if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
+			{
+				//Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
+				var phraseAutoCompleteHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: false);
+				AddToDictionary(entry, phraseAutoCompleteHash, newEntryWithUsageCount);
+			}
 
-            //Also add to entries for auto complete
-            var autoCompleteHash = entry.Normalise(log: false);
+			//Also add to entries for auto complete
+			var autoCompleteHash = entry.Normalise(log: false);
             AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
-            if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
-            {
-                //Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
-                var phraseAutoCompleteHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: false);
-                AddToDictionary(entry, phraseAutoCompleteHash, newEntryWithUsageCount);
-            }
-
-
         }
 
         private void AddToDictionary (string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)
         { 
-
             if (!string.IsNullOrWhiteSpace(autoCompleteHash))
             {
                 if (entriesForAutoComplete.ContainsKey(autoCompleteHash))

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/IManageAutoComplete.cs
@@ -1,4 +1,5 @@
 ﻿using JuliusSweetland.OptiKey.Models;
+using System.Collections.Generic;
 
 namespace JuliusSweetland.OptiKey.Services.AutoComplete
 {
@@ -17,5 +18,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
         void Clear();
 
         void RemoveEntry(string entry);
-    }
+
+		Dictionary<string, HashSet<DictionaryEntry>> GetEntries();
+	}
 }

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -15,7 +15,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
 	/// </summary>
 	public class NGramAutoComplete : IManageAutoComplete
     {
-        private readonly Dictionary<string, HashSet<EntryMetadata>> entries = new Dictionary<string, HashSet<EntryMetadata>>();
+        private readonly Dictionary<string, HashSet<DictionaryEntry>> entries = new Dictionary<string, HashSet<DictionaryEntry>>();
         private readonly Func<string, string> normalize;
         private readonly int gramCount;
         private readonly string leadingSpaces;
@@ -88,7 +88,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
                 }
                 else
                 {
-                    entries[ngram] = new HashSet<EntryMetadata> { metaData };
+                    entries[ngram] = new HashSet<DictionaryEntry> { metaData };
                 }
             }
         }
@@ -116,7 +116,7 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
                 .Select(x => new
                 {
                     MetaData = x.Key,
-                    Score = CalculateScore(x.Count(), nGramcount, x.Key.NGramCount)
+                    Score = CalculateScore(x.Count(), nGramcount, ((EntryMetadata)x.Key).NGramCount)
                 })
                 .OrderByDescending(x => x.Score)
                 .ThenByDescending(x => x.MetaData.UsageCount)

--- a/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AutoComplete/NGramAutoComplete.cs
@@ -67,8 +67,13 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
             leadingSpaces = new string(' ', leadingSpaceCount);
             trailingSpaces = new string(' ', trailingSpaceCount);
         }
+		
+		public Dictionary<string, HashSet<DictionaryEntry>> GetEntries()
+		{
+			return entries;
+		}
 
-        public void AddEntry(string entry, DictionaryEntry dictionaryEntry)
+		public void AddEntry(string entry, DictionaryEntry dictionaryEntry)
         {
             if (entry.Contains(" "))
             {
@@ -130,7 +135,12 @@ namespace JuliusSweetland.OptiKey.Services.AutoComplete
                 if (entries.ContainsKey(trigram))
                 {
                     entries[trigram].RemoveWhere(x => x.Entry == entry);
-                }
+
+					if (!entries[trigram].Any())
+					{
+						entries.Remove(trigram);
+					}
+				}
             }
         }
         private static double CalculateScore(double numberOfMatches, double numberOfRootNGrams, double numberOfEntryNGrams)

--- a/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
@@ -101,6 +101,8 @@ namespace JuliusSweetland.OptiKey.Services
             try
             {
                 manageAutoComplete = CreateAutoComplete();
+
+				// Create reference to the dictionary entries.
 				entries = manageAutoComplete.GetEntries();
 
                 //Load the user dictionary

--- a/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Extensions;
+using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Services.AutoComplete;
+using log4net;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,16 +12,10 @@ using System.Reactive;
 using System.Text;
 using System.Threading;
 using System.Windows;
-using JuliusSweetland.OptiKey.Enums;
-using JuliusSweetland.OptiKey.Extensions;
-using JuliusSweetland.OptiKey.Models;
-using JuliusSweetland.OptiKey.Properties;
-using JuliusSweetland.OptiKey.Services.AutoComplete;
-using log4net;
 
 namespace JuliusSweetland.OptiKey.Services
 {
-    public class DictionaryService : IDictionaryService
+	public class DictionaryService : IDictionaryService
     {
         #region Constants
 
@@ -30,7 +30,7 @@ namespace JuliusSweetland.OptiKey.Services
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private readonly AutoCompleteMethods autoCompleteMethod;
 
-        private Dictionary<string, List<DictionaryEntry>> entries;
+        private Dictionary<string, HashSet<DictionaryEntry>> entries;
         private IManageAutoComplete manageAutoComplete;
         
         #endregion
@@ -101,7 +101,7 @@ namespace JuliusSweetland.OptiKey.Services
 
             try
             {
-                entries = new Dictionary<string, List<DictionaryEntry>>();
+                entries = new Dictionary<string, HashSet<DictionaryEntry>>();
                 manageAutoComplete = CreateAutoComplete();
 
                 //Load the user dictionary
@@ -275,7 +275,7 @@ namespace JuliusSweetland.OptiKey.Services
                     }
                     else
                     {
-                        entries.Add(hash, new List<DictionaryEntry> { newEntryWithUsageCount });
+                        entries.Add(hash, new HashSet<DictionaryEntry> { newEntryWithUsageCount });
                     }
 
                     //Also add to entries for auto complete

--- a/src/JuliusSweetland.OptiKey/packages.config
+++ b/src/JuliusSweetland.OptiKey/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="MahApps.Metro" version="1.1.2.0" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net46" />
+  <package id="MahApps.Metro" version="1.5.0" targetFramework="net46" />
   <package id="MicrosoftExpressionInteractions" version="3.0.40218.0" targetFramework="net46" />
   <package id="MouseKeyboardActivityMonitor" version="4.0.5150.10665" targetFramework="net45" />
   <package id="NBug" version="1.2.2" targetFramework="net45" />
-  <package id="Octokit" version="0.23.0" targetFramework="net46" />
-  <package id="Prism.Core" version="6.0.1" targetFramework="net45" />
-  <package id="Prism.Wpf" version="6.0.1" targetFramework="net45" />
+  <package id="Octokit" version="0.24.0" targetFramework="net46" />
+  <package id="Prism.Core" version="6.3.0" targetFramework="net46" />
+  <package id="Prism.Wpf" version="6.3.0" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
Related to issue #218 which mentions the dictionary entries are stored at different level and are more or less in duplicates, hence creating maintenance difficulties. This pull request aims to resolve the complexity in the dictionary entries data structure, such that we only use 1 source of truce as where to find the user entries across `DictionaryService ` and the `IAutoComplete` implementations. 

On a side note, VS community seems to render indent a little differently than GitHub, so there're a couple of files that only the indents were updated (and they look ugly in GitHub, but in VSC they look fine).