### PR TITLE
Add support for MaryTTS as discussed in #334

### DIFF
--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -160,15 +160,34 @@ namespace JuliusSweetland.OptiKey
                     {
                         StartInfo = new ProcessStartInfo
                         {
-                            FileName = @".\Resources\marytts\bin\marytts-server.bat",
                             UseShellExecute = true,
-                            WindowStyle = ProcessWindowStyle.Minimized, // cannot close it if hidden
+                            WindowStyle = ProcessWindowStyle.Minimized, // cannot close it if set to hidden
                             CreateNoWindow = true
                         }
                     };
-                    proc.Start();
-                    Log.InfoFormat("Started MaryTTS in '{0}' with process name '{1}'.", proc.StartInfo.FileName, proc.ProcessName);
-                    CloseMaryTTSOnApplicationExit(proc);
+                    if (Settings.Default.MaryTTSLocation.EndsWith(@"\bin\marytts-server.bat"))
+                    {
+                        proc.StartInfo.FileName = Settings.Default.MaryTTSLocation;
+                        Log.InfoFormat("Trying to start MaryTTS from '{0}'.", proc.StartInfo.FileName);
+                        try { proc.Start(); }
+                        catch (Exception)
+                        {
+                            Log.InfoFormat("Failed to started MaryTTS. Disabling MaryTTS and using System Voice '{0}' instead.", 
+                                Settings.Default.SpeechVoice);
+                            Settings.Default.MaryTTSEnabled = false;
+                        }
+                        if (Settings.Default.MaryTTSEnabled)
+                        {
+                            Log.InfoFormat("Started MaryTTS.");
+                            CloseMaryTTSOnApplicationExit(proc);
+                        }
+                    }
+                    else
+                    {
+                        Log.InfoFormat("Failed to started MaryTTS. Disabling MaryTTS and using System Voice '{0}' instead.",
+                            Settings.Default.SpeechVoice);
+                        Settings.Default.MaryTTSEnabled = false;
+                    }
                 }
 
                 //Compose UI

--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Diagnostics;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
@@ -151,6 +152,24 @@ namespace JuliusSweetland.OptiKey
 
                 //Release keys on application exit
                 ReleaseKeysOnApplicationExit(keyStateService, publishService);
+
+                if (Settings.Default.MaryTTSEnabled)
+                {
+
+                    Process proc = new Process
+                    {
+                        StartInfo = new ProcessStartInfo
+                        {
+                            FileName = @".\Resources\marytts\bin\marytts-server.bat",
+                            UseShellExecute = true,
+                            WindowStyle = ProcessWindowStyle.Minimized, // cannot close it if hidden
+                            CreateNoWindow = true
+                        }
+                    };
+                    proc.Start();
+                    Log.InfoFormat("Started MaryTTS in '{0}' with process name '{1}'.", proc.StartInfo.FileName, proc.ProcessName);
+                    CloseMaryTTSOnApplicationExit(proc);
+                }
 
                 //Compose UI
                 var mainWindow = new MainWindow(audioService, dictionaryService, inputService, keyStateService);
@@ -803,6 +822,18 @@ namespace JuliusSweetland.OptiKey
                 if (keyStateService.SimulateKeyStrokes)
                 {
                     publishService.ReleaseAllDownKeys();
+                }
+            };
+        }
+
+        private static void CloseMaryTTSOnApplicationExit(Process proc)
+        {
+            Current.Exit += (o, args) =>
+            {
+                if (Settings.Default.MaryTTSEnabled)
+                {
+                    proc.CloseMainWindow();
+                    Log.InfoFormat("MaryTTS has been closed.");
                 }
             };
         }

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -2393,49 +2393,43 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use MaryTTS speech synthesisez?.
+        ///   Looks up a localized string similar to Use MaryTTS speech synthesizer?.
         /// </summary>
         public static string MARYTTS_ENABLED_LABEL {
             get {
                 return ResourceManager.GetString("MARYTTS_ENABLED_LABEL", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ERROR: a valid &apos;marytts-server.bat&apos; file was not selected. Please try again..
         /// </summary>
-        public static string MARYTTS_LOCATION_ERROR_LABEL
-        {
-            get
-            {
+        public static string MARYTTS_LOCATION_ERROR_LABEL {
+            get {
                 return ResourceManager.GetString("MARYTTS_LOCATION_ERROR_LABEL", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Find.
         /// </summary>
-        public static string MARYTTS_LOCATION_FIND_LABEL
-        {
-            get
-            {
+        public static string MARYTTS_LOCATION_FIND_LABEL {
+            get {
                 return ResourceManager.GetString("MARYTTS_LOCATION_FIND_LABEL", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to MaryTTS location (marytts-server.bat):.
         /// </summary>
-        public static string MARYTTS_LOCATION_LABEL
-        {
-            get
-            {
+        public static string MARYTTS_LOCATION_LABEL {
+            get {
                 return ResourceManager.GetString("MARYTTS_LOCATION_LABEL", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to MaryTTS Voice:.
+        ///   Looks up a localized string similar to MaryTTS voice:.
         /// </summary>
         public static string MARYTTS_VOICE_LABEL {
             get {
@@ -4341,7 +4335,7 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("SPEAK", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Speech.
         /// </summary>
@@ -4850,7 +4844,7 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("USE_ALPHABETICAL_KEYBOARD_LAYOUT", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use simplify keyboard layout:.
         /// </summary>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -2393,6 +2393,24 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use MaryTTS speech synthesisez?.
+        /// </summary>
+        public static string MARYTTS_ENABLED_LABEL {
+            get {
+                return ResourceManager.GetString("MARYTTS_ENABLED_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MaryTTS Voice:.
+        /// </summary>
+        public static string MARYTTS_VOICE_LABEL {
+            get {
+                return ResourceManager.GetString("MARYTTS_VOICE_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Maximum number of dictionary matches:.
         /// </summary>
         public static string MAX_DICTIONARY_MATCHES_LABEL {

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -2400,7 +2400,40 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("MARYTTS_ENABLED_LABEL", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to ERROR: a valid &apos;marytts-server.bat&apos; file was not selected. Please try again..
+        /// </summary>
+        public static string MARYTTS_LOCATION_ERROR_LABEL
+        {
+            get
+            {
+                return ResourceManager.GetString("MARYTTS_LOCATION_ERROR_LABEL", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Find.
+        /// </summary>
+        public static string MARYTTS_LOCATION_FIND_LABEL
+        {
+            get
+            {
+                return ResourceManager.GetString("MARYTTS_LOCATION_FIND_LABEL", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to MaryTTS location (marytts-server.bat):.
+        /// </summary>
+        public static string MARYTTS_LOCATION_LABEL
+        {
+            get
+            {
+                return ResourceManager.GetString("MARYTTS_LOCATION_LABEL", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to MaryTTS Voice:.
         /// </summary>
@@ -4308,7 +4341,7 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("SPEAK", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Speech.
         /// </summary>
@@ -4817,7 +4850,7 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("USE_ALPHABETICAL_KEYBOARD_LAYOUT", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Use simplify keyboard layout:.
         /// </summary>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1845,4 +1845,10 @@ Search</value>
 Browsing</value>
     <comment>B</comment>
   </data>
+  <data name="MARYTTS_ENABLED_LABEL" xml:space="preserve">
+    <value>Use MaryTTS speech synthesizer?</value>
+  </data>
+  <data name="MARYTTS_VOICE_LABEL" xml:space="preserve">
+    <value>MaryTTS voice:</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1851,4 +1851,13 @@ Browsing</value>
   <data name="MARYTTS_VOICE_LABEL" xml:space="preserve">
     <value>MaryTTS voice:</value>
   </data>
+  <data name="MARYTTS_LOCATION_LABEL" xml:space="preserve">
+    <value>MaryTTS location (marytts-server.bat):</value>
+  </data>
+  <data name="MARYTTS_LOCATION_FIND_LABEL" xml:space="preserve">
+    <value>Find</value>
+  </data>
+  <data name="MARYTTS_LOCATION_ERROR_LABEL" xml:space="preserve">
+    <value>ERROR: a valid 'marytts-server.bat' file was not selected. Please try again.</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -1721,5 +1721,41 @@ namespace JuliusSweetland.OptiKey.Properties {
                 this["UseSimplifiedKeyboardLayout"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool MaryTTSEnabled {
+            get {
+                return ((bool)(this["MaryTTSEnabled"]));
+            }
+            set {
+                this["MaryTTSEnabled"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("en_GB")]
+        public string MaryTTSLocale {
+            get {
+                return ((string)(this["MaryTTSLocale"]));
+            }
+            set {
+                this["MaryTTSLocale"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("dfki-spike-hsmm")]
+        public string MaryTTSVoice {
+            get {
+                return ((string)(this["MaryTTSVoice"]));
+            }
+            set {
+                this["MaryTTSVoice"] = value;
+            }
+        }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -1745,5 +1745,17 @@ namespace JuliusSweetland.OptiKey.Properties {
                 this["MaryTTSVoice"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string MaryTTSLocation {
+            get {
+                return ((string)(this["MaryTTSLocation"]));
+            }
+            set {
+                this["MaryTTSLocation"] = value;
+            }
+        }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -1736,19 +1736,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("en_GB")]
-        public string MaryTTSLocale {
-            get {
-                return ((string)(this["MaryTTSLocale"]));
-            }
-            set {
-                this["MaryTTSLocale"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("dfki-spike-hsmm")]
+        [global::System.Configuration.DefaultSettingValueAttribute("cmu-slt-hsmm en_US female hmm")]
         public string MaryTTSVoice {
             get {
                 return ((string)(this["MaryTTSVoice"]));

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -980,5 +980,8 @@
     <Setting Name="MaryTTSVoice" Type="System.String" Scope="User">
       <Value Profile="(Default)">cmu-slt-hsmm en_US female hmm</Value>
     </Setting>
+    <Setting Name="MaryTTSLocation" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -977,11 +977,8 @@
     <Setting Name="MaryTTSEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="MaryTTSLocale" Type="System.String" Scope="User">
-      <Value Profile="(Default)">en_GB</Value>
-    </Setting>
     <Setting Name="MaryTTSVoice" Type="System.String" Scope="User">
-      <Value Profile="(Default)">dfki-spike-hsmm</Value>
+      <Value Profile="(Default)">cmu-slt-hsmm en_US female hmm</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -974,5 +974,14 @@
     <Setting Name="UseSimplifiedKeyboardLayout" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="MaryTTSEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="MaryTTSLocale" Type="System.String" Scope="User">
+      <Value Profile="(Default)">en_GB</Value>
+    </Setting>
+    <Setting Name="MaryTTSVoice" Type="System.String" Scope="User">
+      <Value Profile="(Default)">dfki-spike-hsmm</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/JuliusSweetland.OptiKey/Services/AudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AudioService.cs
@@ -91,6 +91,47 @@ namespace JuliusSweetland.OptiKey.Services
             return availableVoices;
         }
 
+        public List<string> GetAvailableMaryTTSLocales()
+        {
+            Log.Info("GetAvailableMaryTTSLocales called");
+            List<string> availableVoices = new List<string>();
+            availableVoices.Add("en_US");
+            availableVoices.Add("en_GB");
+            availableVoices.Add("de");
+            availableVoices.Add("fr");
+            availableVoices.Add("ru");
+            availableVoices.Add("tr");
+            availableVoices.Add("sv");
+            availableVoices.Add("it");
+            availableVoices.Add("te");
+            availableVoices.Add("lb");
+
+            Log.InfoFormat("GetAvailableMaryTTSLocales returing {0} voices", availableVoices.Count);
+
+            return availableVoices;
+        }
+
+        public List<string> GetAvailableMaryTTSVoices()
+        {
+            Log.Info("GetAvailableMaryTTSVoices called");
+            List<string> availableVoices = new List<string>();
+            availableVoices.Add("dfki-spike-hsmm");
+            availableVoices.Add("dfki-spike");
+            availableVoices.Add("dfki-prudence-hsmm");
+            availableVoices.Add("dfki-prudence");
+            availableVoices.Add("dfki-poppy-hsmm");
+            availableVoices.Add("dfki-poppy");
+            availableVoices.Add("dfki-obadiah-hsmm");
+            availableVoices.Add("dfki-obadiah");
+            availableVoices.Add("cmu-slt-hsmm");
+            availableVoices.Add("cmu-rms-hsmm");
+            availableVoices.Add("cmu-bdl-hsmm");
+
+            Log.InfoFormat("GetAvailableMaryTTSVoices returing {0} voices", availableVoices.Count);
+
+            return availableVoices;
+        }
+
         public void PlaySound(string file, int volume)
         {
             Log.InfoFormat("Playing sound '{0}' at volume '{1}'", file, volume);
@@ -149,7 +190,7 @@ namespace JuliusSweetland.OptiKey.Services
             Log.InfoFormat("Speaking '{0}' with volume '{1}', rate '{2}' and voice '{3}'", textToSpeak, volume, rate, voice);
             if (string.IsNullOrEmpty(textToSpeak)) return;
 
-            if (false)
+            if (!Settings.Default.MaryTTSEnabled)
             {
                 speechSynthesiser.Rate = rate ?? Settings.Default.SpeechRate;
                 speechSynthesiser.Volume = volume ?? Settings.Default.SpeechVolume;
@@ -186,11 +227,14 @@ namespace JuliusSweetland.OptiKey.Services
             }
             else
             {
+                int MaryTTSRate = rate ?? Settings.Default.SpeechRate;
+                int MaryTTSVolume = volume ?? Settings.Default.SpeechVolume;
+
                 SoundPlayer player = new SoundPlayer();
                 player.SoundLocation = "http://localhost:59125/process?"
                     + "INPUT_TYPE=TEXT&OUTPUT_TYPE=AUDIO&AUDIO=WAVE_FILE&"
-                    + "LOCALE=en_GB&"
-                    + "VOICE=dfki-spike-hsmm&"
+                    + "LOCALE=" + Settings.Default.MaryTTSLocale + "&" //en_GB&"
+                    + "VOICE=" + Settings.Default.MaryTTSVoice + "&" //dfki-spike-hsmm&"
                     + "INPUT_TEXT="+ textToSpeak
                     + "&effect_Volume_selected=on&effect_Volume_parameters=amount:1.0;";
 

--- a/src/JuliusSweetland.OptiKey/Services/AudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AudioService.cs
@@ -219,8 +219,16 @@ namespace JuliusSweetland.OptiKey.Services
             }
             else
             {
-                int MaryTTSRate = rate ?? Settings.Default.SpeechRate;
-                int MaryTTSVolume = volume ?? Settings.Default.SpeechVolume;
+                float MaryTTSRate = rate ?? Settings.Default.SpeechRate;
+                float MaryTTSVolume = volume ?? Settings.Default.SpeechVolume;
+
+                MaryTTSRate = (MaryTTSRate + 10.0f) / 20.0f * 3.0f;
+                MaryTTSRate = (MaryTTSRate < 0.1f) ? 0.1f
+                    : (MaryTTSRate > 3.0f) ? 3.0f : MaryTTSRate;
+
+                MaryTTSVolume = MaryTTSVolume / 100.0f * 1.4f;
+                MaryTTSVolume = (MaryTTSVolume < 0.0f) ? 0.0f 
+                    : (MaryTTSVolume > 1.4f) ? 1.4f : MaryTTSVolume;
 
                 List<string> VoiceParameters = Settings.Default.MaryTTSVoice.Split(' ').ToList();
 
@@ -229,8 +237,11 @@ namespace JuliusSweetland.OptiKey.Services
                     + "INPUT_TYPE=TEXT&OUTPUT_TYPE=AUDIO&AUDIO=WAVE_FILE&"
                     + "LOCALE=" + VoiceParameters.ElementAt(1) + "&"
                     + "VOICE=" + VoiceParameters.ElementAt(0) + "&"
-                    + "INPUT_TEXT="+ textToSpeak
-                    + "&effect_Volume_selected=on&effect_Volume_parameters=amount:1.0;";
+                    + "INPUT_TEXT=" + textToSpeak
+                    + "&effect_Rate_selected=on&effect_Rate_parameters=durScale:"
+                    + string.Format("{0:N1}", MaryTTSRate) + ";&"
+                    + "&effect_Volume_selected=on&effect_Volume_parameters=amount:"
+                    + string.Format("{0:N1}", MaryTTSVolume) + ";";
 
                 player.Load();
                 player.Play();

--- a/src/JuliusSweetland.OptiKey/Services/AudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AudioService.cs
@@ -295,7 +295,7 @@ namespace JuliusSweetland.OptiKey.Services
             // add 250 ms to the delay to ensure the speech is finished
             int delaytime = 250 + (int)(1000 * Convert.ToSingle(realised_durations.ElementAt(realised_durations.Count() - 2).Split(' ').ToList().ElementAt(0)));
             
-            Log.InfoFormat("MaryTTS speech ends in {0} ms", delaytime);
+            //Log.InfoFormat("MaryTTS speech ends in {0} ms", delaytime);
             
             Task SoundPlayerDelayTask = SoundPlayerDelayAsync(delaytime); 
 

--- a/src/JuliusSweetland.OptiKey/Services/AudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AudioService.cs
@@ -116,7 +116,7 @@ namespace JuliusSweetland.OptiKey.Services
             string responseText = readStream.ReadToEnd();
 
             availableVoices = responseText.Split('\n').ToList();
-            // remove the end one because it is blank
+            // remove the last entry because it is blank
             availableVoices.RemoveAt(availableVoices.Count() - 1);
 
             Log.InfoFormat("GetAvailableMaryTTSVoices returing {0} voices", availableVoices.Count);

--- a/src/JuliusSweetland.OptiKey/Services/IAudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/IAudioService.cs
@@ -6,6 +6,8 @@ namespace JuliusSweetland.OptiKey.Services
     public interface IAudioService : INotifyErrors
     {
         List<string> GetAvailableVoices();
+        List<string> GetAvailableMaryTTSLocales();
+        List<string> GetAvailableMaryTTSVoices();
         void PlaySound(string file, int volume);
         bool SpeakNewOrInterruptCurrentSpeech(string textToSpeak, Action onComplete, int? volume = null, int? rate = null, string voice = null);
     }

--- a/src/JuliusSweetland.OptiKey/Services/IAudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/IAudioService.cs
@@ -6,7 +6,6 @@ namespace JuliusSweetland.OptiKey.Services
     public interface IAudioService : INotifyErrors
     {
         List<string> GetAvailableVoices();
-        List<string> GetAvailableMaryTTSLocales();
         List<string> GetAvailableMaryTTSVoices();
         void PlaySound(string file, int volume);
         bool SpeakNewOrInterruptCurrentSpeech(string textToSpeak, Action onComplete, int? volume = null, int? rate = null, string voice = null);

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -187,6 +187,20 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref maryTTSVoice, value); }
         }
 
+        private bool useEmbeddedMaryTTS;
+        public bool UseEmbeddedMaryTTS
+        {
+            get { return useEmbeddedMaryTTS; }
+            set { SetProperty(ref useEmbeddedMaryTTS, value); }
+        }
+
+        private string maryTTSLocation;
+        public string MaryTTSLocation
+        {
+            get { return maryTTSLocation; }
+            set { SetProperty(ref maryTTSLocation, value); }
+        }
+
         private string infoSoundFile;
         public string InfoSoundFile
         {
@@ -329,7 +343,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
 
         public bool ChangesRequireRestart
         {
-            get { return Settings.Default.MaryTTSEnabled != MaryTTSEnabled; ; }
+            get
+            {
+                return Settings.Default.MaryTTSEnabled != MaryTTSEnabled
+                    || Settings.Default.MaryTTSLocation != MaryTTSLocation; ;
+            }
         }
 
         public DelegateCommand InfoSoundPlayCommand { get; private set; }
@@ -354,6 +372,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             SpeechRate = Settings.Default.SpeechRate;
             MaryTTSEnabled = Settings.Default.MaryTTSEnabled;
             MaryTTSVoice = Settings.Default.MaryTTSVoice;
+            MaryTTSLocation = Settings.Default.MaryTTSLocation;
             InfoSoundFile = Settings.Default.InfoSoundFile;
             InfoSoundVolume = Settings.Default.InfoSoundVolume;
             KeySelectionSoundFile = Settings.Default.KeySelectionSoundFile;
@@ -383,6 +402,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.SpeechRate = SpeechRate;
             Settings.Default.MaryTTSEnabled = MaryTTSEnabled;
             Settings.Default.MaryTTSVoice = MaryTTSVoice;
+            Settings.Default.MaryTTSLocation = MaryTTSLocation;
             Settings.Default.InfoSoundFile = InfoSoundFile;
             Settings.Default.InfoSoundVolume = InfoSoundVolume;
             Settings.Default.KeySelectionSoundFile = KeySelectionSoundFile;

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -329,7 +329,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
 
         public bool ChangesRequireRestart
         {
-            get { return false; }
+            get { return Settings.Default.MaryTTSEnabled != MaryTTSEnabled; ; }
         }
 
         public DelegateCommand InfoSoundPlayCommand { get; private set; }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -46,11 +46,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             get { return audioService.GetAvailableVoices(); }
         }
 
-        public List<string> MaryTTSLocales
-        {
-            get { return audioService.GetAvailableMaryTTSLocales(); }
-        }
-
         public List<string> MaryTTSVoices
         {
             get { return audioService.GetAvailableMaryTTSVoices(); }
@@ -183,13 +178,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return maryTTSEnabled; }
             set { SetProperty(ref maryTTSEnabled, value); }
-        }
-
-        private string maryTTSLocale;
-        public string MaryTTSLocale
-        {
-            get { return maryTTSLocale; }
-            set { SetProperty(ref maryTTSLocale, value); }
         }
 
         private string maryTTSVoice;
@@ -365,7 +353,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             SpeechVolume = Settings.Default.SpeechVolume;
             SpeechRate = Settings.Default.SpeechRate;
             MaryTTSEnabled = Settings.Default.MaryTTSEnabled;
-            MaryTTSLocale = Settings.Default.MaryTTSLocale;
             MaryTTSVoice = Settings.Default.MaryTTSVoice;
             InfoSoundFile = Settings.Default.InfoSoundFile;
             InfoSoundVolume = Settings.Default.InfoSoundVolume;
@@ -395,7 +382,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.SpeechVolume = SpeechVolume;
             Settings.Default.SpeechRate = SpeechRate;
             Settings.Default.MaryTTSEnabled = MaryTTSEnabled;
-            Settings.Default.MaryTTSLocale = MaryTTSLocale;
             Settings.Default.MaryTTSVoice = MaryTTSVoice;
             Settings.Default.InfoSoundFile = InfoSoundFile;
             Settings.Default.InfoSoundVolume = InfoSoundVolume;

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -45,7 +45,17 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return audioService.GetAvailableVoices(); }
         }
-        
+
+        public List<string> MaryTTSLocales
+        {
+            get { return audioService.GetAvailableMaryTTSLocales(); }
+        }
+
+        public List<string> MaryTTSVoices
+        {
+            get { return audioService.GetAvailableMaryTTSVoices(); }
+        }
+
         public List<KeyValuePair<string, string>> GeneralSoundFiles
         {
             get
@@ -168,6 +178,27 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref speechRate, value); }
         }
         
+        private bool maryTTSEnabled;
+        public bool MaryTTSEnabled
+        {
+            get { return maryTTSEnabled; }
+            set { SetProperty(ref maryTTSEnabled, value); }
+        }
+
+        private string maryTTSLocale;
+        public string MaryTTSLocale
+        {
+            get { return maryTTSLocale; }
+            set { SetProperty(ref maryTTSLocale, value); }
+        }
+
+        private string maryTTSVoice;
+        public string MaryTTSVoice
+        {
+            get { return maryTTSVoice; }
+            set { SetProperty(ref maryTTSVoice, value); }
+        }
+
         private string infoSoundFile;
         public string InfoSoundFile
         {
@@ -333,6 +364,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             SpeechVoice = Settings.Default.SpeechVoice;
             SpeechVolume = Settings.Default.SpeechVolume;
             SpeechRate = Settings.Default.SpeechRate;
+            MaryTTSEnabled = Settings.Default.MaryTTSEnabled;
+            MaryTTSLocale = Settings.Default.MaryTTSLocale;
+            MaryTTSVoice = Settings.Default.MaryTTSVoice;
             InfoSoundFile = Settings.Default.InfoSoundFile;
             InfoSoundVolume = Settings.Default.InfoSoundVolume;
             KeySelectionSoundFile = Settings.Default.KeySelectionSoundFile;
@@ -360,6 +394,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.SpeechVoice = SpeechVoice;
             Settings.Default.SpeechVolume = SpeechVolume;
             Settings.Default.SpeechRate = SpeechRate;
+            Settings.Default.MaryTTSEnabled = MaryTTSEnabled;
+            Settings.Default.MaryTTSLocale = MaryTTSLocale;
+            Settings.Default.MaryTTSVoice = MaryTTSVoice;
             Settings.Default.InfoSoundFile = InfoSoundFile;
             Settings.Default.InfoSoundVolume = InfoSoundVolume;
             Settings.Default.KeySelectionSoundFile = KeySelectionSoundFile;

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
@@ -27,7 +27,6 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.VOICE_LABEL}" 
@@ -54,7 +53,7 @@
                               VerticalAlignment="Center"
                               IsChecked="{Binding MaryTTSEnabled, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="MaryTTSLocale" 
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="MaryTTSVoices" 
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -68,34 +67,6 @@
                         </TextBlock.Style>
                     </TextBlock>
                     <ComboBox Grid.Row="4" Grid.Column="1" 
-                              ItemsSource="{Binding MaryTTSLocales}"
-                              SelectedValue="{Binding MaryTTSLocale, Mode=TwoWay}" >
-                        <ComboBox.Style>
-                            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
-                                <Setter Property="Visibility" Value="Visible" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ComboBox.Style>
-                    </ComboBox>
-
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="MaryTTSVoices" 
-                               VerticalAlignment="Center" Margin="5" >
-                        <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="Visible" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                    <ComboBox Grid.Row="5" Grid.Column="1" 
                               ItemsSource="{Binding MaryTTSVoices}"
                               SelectedValue="{Binding MaryTTSVoice, Mode=TwoWay}" >
                         <ComboBox.Style>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
@@ -25,6 +25,9 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.VOICE_LABEL}" 
@@ -44,6 +47,68 @@
                     <controls:NumericUpDown Grid.Row="2" Grid.Column="1" TextAlignment="Left"
                                             Minimum="-10" Maximum="10" Interval="1"
                                             Value="{Binding SpeechRate, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="MaryTTSEnable" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <CheckBox Grid.Row="3" Grid.Column="1" 
+                              VerticalAlignment="Center"
+                              IsChecked="{Binding MaryTTSEnabled, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="MaryTTSLocale" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <ComboBox Grid.Row="4" Grid.Column="1" 
+                              ItemsSource="{Binding MaryTTSLocales}"
+                              SelectedValue="{Binding MaryTTSLocale, Mode=TwoWay}" >
+                        <ComboBox.Style>
+                            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ComboBox.Style>
+                    </ComboBox>
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="MaryTTSVoices" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <ComboBox Grid.Row="5" Grid.Column="1" 
+                              ItemsSource="{Binding MaryTTSVoices}"
+                              SelectedValue="{Binding MaryTTSVoice, Mode=TwoWay}" >
+                        <ComboBox.Style>
+                            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ComboBox.Style>
+                    </ComboBox>
                 </Grid>
             </GroupBox>
         

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
@@ -47,13 +47,13 @@
                                             Minimum="-10" Maximum="10" Interval="1"
                                             Value="{Binding SpeechRate, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="3" Grid.Column="0" Text="MaryTTSEnable" 
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_ENABLED_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <CheckBox Grid.Row="3" Grid.Column="1" 
                               VerticalAlignment="Center"
                               IsChecked="{Binding MaryTTSEnabled, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="MaryTTSVoices" 
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_VOICE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
@@ -19,9 +19,11 @@
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
@@ -31,29 +33,29 @@
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.VOICE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <ComboBox Grid.Row="0" Grid.Column="1" 
+                    <ComboBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding SpeechVoices}"
                               SelectedValue="{Binding SpeechVoice, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static resx:Resources.VOLUME_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="1" Grid.Column="1" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Maximum="100" Interval="1"
                                             Value="{Binding SpeechVolume, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static resx:Resources.RATE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="2" Grid.Column="1" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="-10" Maximum="10" Interval="1"
                                             Value="{Binding SpeechRate, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_ENABLED_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <CheckBox Grid.Row="3" Grid.Column="1" 
+                    <CheckBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2"
                               VerticalAlignment="Center"
                               IsChecked="{Binding MaryTTSEnabled, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_VOICE_LABEL}" 
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_LOCATION_LABEL}" 
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -66,7 +68,51 @@
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-                    <ComboBox Grid.Row="4" Grid.Column="1" 
+                    <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Left">
+                        <Button Name="btnFindFile" Click="btnFindFile_Click" 
+                                MinWidth="100" Margin="0,5,5,5" VerticalAlignment="Center">
+                            <x:Static Member="resx:Resources.MARYTTS_LOCATION_FIND_LABEL"/>
+                        </Button>
+                        <StackPanel.Style>
+                            <Style TargetType="{x:Type StackPanel}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                    </StackPanel>
+                    <TextBlock Grid.Row="4" Grid.Column="2" Name="txtEditor"
+                               Text="{Binding MaryTTSLocation, Mode=TwoWay}" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_VOICE_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MaryTTSEnabled}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <ComboBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding MaryTTSVoices}"
                               SelectedValue="{Binding MaryTTSVoice, Mode=TwoWay}" >
                         <ComboBox.Style>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml.cs
@@ -1,4 +1,7 @@
 using System.Windows.Controls;
+using System.Windows;
+using Microsoft.Win32;
+using JuliusSweetland.OptiKey.Properties;
 
 namespace JuliusSweetland.OptiKey.UI.Views.Management
 {
@@ -10,6 +13,24 @@ namespace JuliusSweetland.OptiKey.UI.Views.Management
         public SoundsView()
         {
             InitializeComponent();
+        }
+
+        private void btnFindFile_Click(object sender, RoutedEventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            if (openFileDialog.ShowDialog() == true)
+            {
+                if (openFileDialog.FileName.EndsWith(@"\bin\marytts-server.bat"))
+                {
+                    txtEditor.Text = openFileDialog.FileName;
+                    Settings.Default.MaryTTSLocation = txtEditor.Text;
+                }
+                else
+                {
+                    txtEditor.Text = Properties.Resources.MARYTTS_LOCATION_ERROR_LABEL;
+                    Settings.Default.MaryTTSLocation = null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
[MaryTTS](https://github.com/marytts/marytts) is an alternative speech synthesizer that uses a java server with an HTTP interface instead of SAPI5. It has quite a few languages with rather good sounding voices. It comes with .bat files to start a GUI to install the desired voices and run the server.

To use MaryTTS with OptiKey get [marytts-5.2.zip](https://github.com/marytts/marytts/releases/download/v5.2/marytts-5.2.zip) (or later) and extract it to anywhere (such as "C:\MaryTTS\marytts-5.2\"). Then in Optikey's management console, under the Sounds tab, check `Use MaryTTS speech synthesizer` and press `FIND` to navigate to the unpacked `marytts-server.bat` ("C:\MaryTTS\marytts-5.2\bin\marytts-server.bat" in the example). After Optikey restarts a minimised cmd window will also be started containing the MaryTTS server and the available MaryTTS voices will be listed in the management console in the Sounds tab under `MaryTTS voice:`.

To install more MaryTTS voices run `marytts-component-installer.bat` ("C:\MaryTTS\marytts-5.2\bin\marytts-component-installer.bat" in the example).