### PR TITLE
Add toast notifications for MaryTTS and Presage launch errors

### DIFF
--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -2429,6 +2429,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MaryTTS is not available.
+        /// </summary>
+        public static string MARYTTS_UNAVAILABLE {
+            get {
+                return ResourceManager.GetString("MARYTTS_UNAVAILABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MaryTTS voice:.
         /// </summary>
         public static string MARYTTS_VOICE_LABEL {
@@ -3581,6 +3590,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string PRESAGE_SUGGESTION {
             get {
                 return ResourceManager.GetString("PRESAGE_SUGGESTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Presage word prediction not available.
+        /// </summary>
+        public static string PRESAGE_UNAVAILABLE {
+            get {
+                return ResourceManager.GetString("PRESAGE_UNAVAILABLE", resourceCulture);
             }
         }
         
@@ -4887,6 +4905,29 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string USE_SIMPLIFIED_KEYBOARD_LAYOUT {
             get {
                 return ResourceManager.GetString("USE_SIMPLIFIED_KEYBOARD_LAYOUT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Setting the suggestion method to: ({0}).
+        ///You can change this back 
+        ///from the Management Console (ALT + M)..
+        /// </summary>
+        public static string USING_DEFAULT_SUGGESTION_METHOD {
+            get {
+                return ResourceManager.GetString("USING_DEFAULT_SUGGESTION_METHOD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Setting the speech voice to the system voice: ({0}).
+        ///You can check the path for MaryTTS 
+        ///and change the voice back to it 
+        ///from the Management Console (ALT + M)..
+        /// </summary>
+        public static string USING_DEFAULT_VOICE {
+            get {
+                return ResourceManager.GetString("USING_DEFAULT_VOICE", resourceCulture);
             }
         }
         

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1858,16 +1858,34 @@ Browsing</value>
   <data name="MARYTTS_LOCATION_ERROR_LABEL" xml:space="preserve">
     <value>ERROR: a valid 'marytts-server.bat' file was not selected. Please try again.</value>
   </data>
-    <data name="BASIC_SUGGESTION" xml:space="preserve">
-      <value>Basic</value>
-    </data>
-    <data name="NGRAM_SUGGESTION" xml:space="preserve">
-      <value>NGram</value>
-    </data>
-    <data name="PRESAGE_SUGGESTION" xml:space="preserve">
-      <value>Presage</value>
-    </data>
-    <data name="SUGGESTION_METHOD" xml:space="preserve">
-      <value>Suggestion method:</value>
-    </data>
+  <data name="BASIC_SUGGESTION" xml:space="preserve">
+    <value>Basic</value>
+  </data>
+  <data name="NGRAM_SUGGESTION" xml:space="preserve">
+    <value>NGram</value>
+  </data>
+  <data name="PRESAGE_SUGGESTION" xml:space="preserve">
+    <value>Presage</value>
+  </data>
+  <data name="SUGGESTION_METHOD" xml:space="preserve">
+    <value>Suggestion method:</value>
+  </data>
+  <data name="MARYTTS_UNAVAILABLE" xml:space="preserve">
+    <value>MaryTTS is not available</value>
+  </data>
+  <data name="PRESAGE_UNAVAILABLE" xml:space="preserve">
+    <value>Presage word prediction not available</value>
+    <comment>RESAGE</comment>
+  </data>
+  <data name="USING_DEFAULT_SUGGESTION_METHOD" xml:space="preserve">
+    <value>Setting the suggestion method to: ({0}).
+You can change this back 
+from the Management Console (ALT + M).</value>
+  </data>
+  <data name="USING_DEFAULT_VOICE" xml:space="preserve">
+    <value>Setting the speech voice to the system voice: ({0}).
+You can check the path for MaryTTS 
+and change the voice back to it 
+from the Management Console (ALT + M).</value>
+  </data>
 </root>


### PR DESCRIPTION
An error toast notification now appears if there is a problem with MaryTTS
or Presage at launch. The notifications include what the respective
settings have been automatically changed to.