### PR TITLE
Add a user defined delay before speech

### DIFF
--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -4382,6 +4382,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delay before speech (ms):.
+        /// </summary>
+        public static string SPEECH_DELAY_LABEL {
+            get {
+                return ResourceManager.GetString("SPEECH_DELAY_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Startup keyboard:.
         /// </summary>
         public static string STARTUP_KEYBOARD_LABEL {

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1887,4 +1887,7 @@ You can check the path for MaryTTS
 and change the voice back to it 
 from the Management Console (ALT + M).</value>
   </data>
+  <data name="SPEECH_DELAY_LABEL" xml:space="preserve">
+    <value>Delay before speech (ms):</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -1800,5 +1800,17 @@ namespace JuliusSweetland.OptiKey.Properties {
                 this["KeySelectionTriggerFixationCompleteTimesByKeyValues"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int SpeechDelay {
+            get {
+                return ((int)(this["SpeechDelay"]));
+            }
+            set {
+                this["SpeechDelay"] = value;
+            }
+        }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -992,5 +992,8 @@
   &lt;/item&gt;
 &lt;/dictionary&gt;</Value>
     </Setting>
+    <Setting Name="SpeechDelay" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/JuliusSweetland.OptiKey/Services/AudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AudioService.cs
@@ -193,6 +193,7 @@ namespace JuliusSweetland.OptiKey.Services
             Log.InfoFormat("Speaking '{0}' with volume '{1}', rate '{2}' and voice '{3}'", textToSpeak, volume, rate, 
                 !Settings.Default.MaryTTSEnabled ? voice : Settings.Default.MaryTTSVoice);
             if (string.IsNullOrEmpty(textToSpeak)) return;
+            System.Threading.Thread.Sleep(Settings.Default.SpeechDelay);
 
             if (!Settings.Default.MaryTTSEnabled)
             {

--- a/src/JuliusSweetland.OptiKey/Services/AudioService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/AudioService.cs
@@ -193,7 +193,9 @@ namespace JuliusSweetland.OptiKey.Services
             Log.InfoFormat("Speaking '{0}' with volume '{1}', rate '{2}' and voice '{3}'", textToSpeak, volume, rate, 
                 !Settings.Default.MaryTTSEnabled ? voice : Settings.Default.MaryTTSVoice);
             if (string.IsNullOrEmpty(textToSpeak)) return;
-            System.Threading.Thread.Sleep(Settings.Default.SpeechDelay);
+
+            if (Settings.Default.SpeechDelay > 0 && Settings.Default.SpeechDelay < 10000)
+                System.Threading.Thread.Sleep(Settings.Default.SpeechDelay);
 
             if (!Settings.Default.MaryTTSEnabled)
             {

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -182,7 +182,14 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             get { return speechRate; }
             set { SetProperty(ref speechRate, value); }
         }
-        
+
+        private int speechDelay;
+        public int SpeechDelay
+        {
+            get { return speechDelay; }
+            set { SetProperty(ref speechDelay, value); }
+        }
+
         private bool maryTTSEnabled;
         public bool MaryTTSEnabled
         {
@@ -380,6 +387,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             SpeechVoice = Settings.Default.SpeechVoice;
             SpeechVolume = Settings.Default.SpeechVolume;
             SpeechRate = Settings.Default.SpeechRate;
+            SpeechDelay = Settings.Default.SpeechDelay;
             MaryTTSEnabled = Settings.Default.MaryTTSEnabled;
             MaryTTSVoice = Settings.Default.MaryTTSVoice;
             MaryTTSLocation = Settings.Default.MaryTTSLocation;
@@ -410,6 +418,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.SpeechVoice = SpeechVoice;
             Settings.Default.SpeechVolume = SpeechVolume;
             Settings.Default.SpeechRate = SpeechRate;
+            Settings.Default.SpeechDelay = SpeechDelay;
             Settings.Default.MaryTTSEnabled = MaryTTSEnabled;
             Settings.Default.MaryTTSVoice = MaryTTSVoice;
             Settings.Default.MaryTTSLocation = MaryTTSLocation;

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml
@@ -29,6 +29,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.MARYTTS_ENABLED_LABEL}" 
@@ -147,6 +148,12 @@
                     <controls:NumericUpDown Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="-10" Maximum="10" Interval="1"
                                             Value="{Binding SpeechRate, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{x:Static resx:Resources.SPEECH_DELAY_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <controls:NumericUpDown Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                                            Minimum="0" Maximum="5000" Interval="1"
+                                            Value="{Binding SpeechDelay, Mode=TwoWay}" />
                 </Grid>
             </GroupBox>
         


### PR DESCRIPTION
It may be beneficial to have a small delay between selection of the Speak
key and when the speaking starts. This could be either because the key
selection sound is detracting from the speech of a single short word like
"no" or because a Bluetooth speaker is in use and cuts off the beginning
of the speech. The delay has been limited to a maximum of five seconds.