### PR TITLE
Roll back Compression version

### DIFF
--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -126,8 +126,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    <Reference Include="System.IO.Compression, Version=4.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.4.0.0\lib\net46\System.IO.Compression.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />

--- a/src/JuliusSweetland.OptiKey/packages.config
+++ b/src/JuliusSweetland.OptiKey/packages.config
@@ -17,5 +17,5 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-WPF" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Xaml" version="2.2.5" targetFramework="net45" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression" version="4.0.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Rolled back the Compression version to 4.0.0 because 4.1.2.0 / 4.3.0 was
not working. Initially discussed in issue #353.