### PR TITLE
Adding support to multi-selection in Presage

### DIFF
--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
@@ -23,7 +23,7 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
 			entries.Clear();
         }
 
-        public IEnumerable<string> GetSuggestions(string root, bool nextWord)
+        public virtual IEnumerable<string> GetSuggestions(string root, bool nextWord)
         {
             Log.DebugFormat("GetAutoCompleteSuggestions called with root '{0}'", root);
 

--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs
@@ -1,37 +1,26 @@
 using JuliusSweetland.OptiKey.Models;
 using log4net;
 using presage;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace JuliusSweetland.OptiKey.Services.Suggestions
 {
-	public class PresageSuggestions : IManagedSuggestions
-    {
-        private readonly Dictionary<string, HashSet<DictionaryEntry>> entries = new Dictionary<string, HashSet<DictionaryEntry>>();
-        private readonly HashSet<string> wordsIndex = new HashSet<string>();
+	public class PresageSuggestions : BasicAutoComplete
+	{
+		private readonly Dictionary<string, HashSet<DictionaryEntry>> entries = new Dictionary<string, HashSet<DictionaryEntry>>();
+		private readonly HashSet<string> wordsIndex = new HashSet<string>();
+		private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-        private Presage prsg;
-
+		private Presage prsg;
         private string root = "";
 
-        public PresageSuggestions()
+        public PresageSuggestions() : base()
         {
             prsg = new Presage(this.callback_get_past_stream, this.callback_get_future_stream);
         }
 
-        /// <summary>
-        /// Removes all possible suggestions from the auto complete provider.
-        /// </summary>
-        public void Clear()
-        {
-            Log.Debug("Clear called.");
-        }
-
-        public IEnumerable<string> GetSuggestions(string root, bool nextWord)
+        public override IEnumerable<string> GetSuggestions(string root, bool nextWord)
         {
             Log.DebugFormat("GetSuggestions called with root '{0}'", root);
 
@@ -54,30 +43,6 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
             }
 
             return Enumerable.Empty<string>();
-        }
-
-        public Dictionary<string, HashSet<DictionaryEntry>> GetEntries()
-        {
-            return entries;
-        }
-
-        public HashSet<string> GetWordsHashes()
-        {
-            return wordsIndex;
-        }
-
-        public void AddEntry(string entry, DictionaryEntry dictionaryEntry, string normalizedHash = "")
-        {
-
-        }
-
-        private void AddToDictionary(string entry, string pleteHash, DictionaryEntry newEntryWithUsageCount)
-        {
-
-        }
-
-        public void RemoveEntry(string entry)
-        {
         }
 
         private string callback_get_past_stream()


### PR DESCRIPTION
We unhooked user dictionary with Presage words suggestions to protect local user dictionary in my last commit, however, this temporary workaround has obvious flaws: 1. user dictionary's words usage won't be updated when using Presage; 2. multi-selection is essentially useless because this feature relies on using user dictionary to make predictions. 

To amend the above deficiencies, I'm trying to make the following changes: instead of making `PresageSuggestions.cs` to implement `IManagedSuggestions`, inheriting the `BasicAutoComplete.cs` and overriding the `GetSuggestions` method. 

By doing this, we will still load/save user dictionaries as if we're using the BasicAutoComplete suggestion across the board (including the multi-selection suggestions), but normal word suggestion will render Presage predictions, and user dictionary will also be updated with user entries.
	
Files changed:
- modified:   _src/JuliusSweetland.OptiKey/Services/DictionaryService.cs_ (mostly unplug safeguards around Presage suggestions in file I/O APIs)
- modified:   _src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs_ (make GetSuggetions method virtual to be override-able)
- modified:   _src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs_ (inherit `BasicAutoComplete.cs` and override `GetSuggestions`)

The reason to inherit Basic suggestion instead of NGram is because Basic suggestion dictionary has a lighter footprint in memory, and it is the suggestion used before we updated the dictionary service; but NGram is more robust in suggestion accuracy, so I'm open to either choice (but prefer Basic).
