### PR TITLE
Stop displaying NGram's internal entries in config menu's dict tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs
 
 # Release deployment, including certificates, etc
 deployment/

--- a/src/JuliusSweetland.OptiKey.UnitTests/packages.config
+++ b/src/JuliusSweetland.OptiKey.UnitTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.1.1" targetFramework="net46" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net46" />
   <package id="Moq" version="4.7.99" targetFramework="net46" />
-  <package id="NUnit" version="2.6.4" targetFramework="net46" />
+  <package id="NUnit" version="3.7.1" targetFramework="net46" />
   <package id="Prism.Core" version="6.3.0" targetFramework="net46" />
   <package id="Prism.Wpf" version="6.3.0" targetFramework="net46" />
 </packages>

--- a/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/DictionaryService.cs
@@ -30,24 +30,24 @@ namespace JuliusSweetland.OptiKey.Services
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private readonly SuggestionMethods suggestionMethod;
 
-	private Dictionary<string, HashSet<DictionaryEntry>> entries;
-	private IManagedSuggestions managedSuggestions;
+    private Dictionary<string, HashSet<DictionaryEntry>> entries;
+    private IManagedSuggestions managedSuggestions;
 
         #endregion
 
-	#region Events
+        #region Events
 
         public event EventHandler<Exception> Error;
 
         #endregion
 
-		#region On closing events callback
-		public void OnAppClosing(object sender, System.ComponentModel.CancelEventArgs e)
-		{
-			// Save entries to user file when leaving the app.
-			this.SaveUserDictionaryToFile();
-		}
-		#endregion
+        #region On closing events callback
+        public void OnAppClosing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            // Save entries to user file when leaving the app.
+            this.SaveUserDictionaryToFile();
+        }
+        #endregion
 
         #region Ctor
 
@@ -62,11 +62,11 @@ namespace JuliusSweetland.OptiKey.Services
             Settings.Default.OnPropertyChanges(settings => settings.KeyboardAndDictionaryLanguage).Subscribe(_ => LoadDictionary());
         }
 
-	#endregion
+    #endregion
 
-	#region Migrate Legacy User Dictionaries
+        #region Migrate Legacy User Dictionaries
 
-	private static void MigrateLegacyDictionaries()
+        private static void MigrateLegacyDictionaries()
         {
             var oldNewDictionaryFileNames = new List<Tuple<string, string>>
             {
@@ -110,11 +110,11 @@ namespace JuliusSweetland.OptiKey.Services
             {
                 managedSuggestions = CreateSuggestions();
 
-		// Create reference to the actual storage of the dictionary entries.
-		entries = managedSuggestions.GetEntries();
+                // Create reference to the actual storage of the dictionary entries.
+                entries = managedSuggestions.GetEntries();
 
-		//Load the user dictionary
-		var userDictionaryPath = GetUserDictionaryPath(Settings.Default.KeyboardAndDictionaryLanguage);
+                //Load the user dictionary
+                var userDictionaryPath = GetUserDictionaryPath(Settings.Default.KeyboardAndDictionaryLanguage);
 
                 if (File.Exists(userDictionaryPath))
                 {
@@ -122,7 +122,7 @@ namespace JuliusSweetland.OptiKey.Services
                 }
                 else
                 {
-		    LoadDictionaryFromLanguageFile();
+                    LoadDictionaryFromLanguageFile();
                 }
             }
             catch (Exception exception)
@@ -131,61 +131,61 @@ namespace JuliusSweetland.OptiKey.Services
             }
         }
 
-	private void LoadDictionaryFromLanguageFile()
-	{
-		//Load the original dictionary
-		var originalDictionaryPath = Path.GetFullPath(string.Format(@"{0}{1}{2}", OriginalDictionariesSubPath, Settings.Default.KeyboardAndDictionaryLanguage, DictionaryFileType));
+        private void LoadDictionaryFromLanguageFile()
+        {
+             //Load the original dictionary
+             var originalDictionaryPath = Path.GetFullPath(string.Format(@"{0}{1}{2}", OriginalDictionariesSubPath, Settings.Default.KeyboardAndDictionaryLanguage, DictionaryFileType));
 
-		if (File.Exists(originalDictionaryPath))
-		{
-			LoadOriginalDictionaryFromFile(originalDictionaryPath);
+            if (File.Exists(originalDictionaryPath))
+            {
+                LoadOriginalDictionaryFromFile(originalDictionaryPath);
 
-			//Create a user specific version of the dictionary in a worker thread
-			Thread writeToFile = new Thread(() => SaveUserDictionaryToFile());
-			writeToFile.Start();
-		}
-		else
-		{
-			throw new ApplicationException(string.Format(Resources.DICTIONARY_FILE_NOT_FOUND_ERROR, originalDictionaryPath));
-		}
-	}
+                //Create a user specific version of the dictionary in a worker thread
+                Thread writeToFile = new Thread(() => SaveUserDictionaryToFile());
+                writeToFile.Start();
+            }
+            else
+            {
+                throw new ApplicationException(string.Format(Resources.DICTIONARY_FILE_NOT_FOUND_ERROR, originalDictionaryPath));
+            }
+        }
 
-	private void LoadOriginalDictionaryFromFile(string filePath)
+        private void LoadOriginalDictionaryFromFile(string filePath)
         {
             Log.DebugFormat("Loading original dictionary from file '{0}'", filePath);
 
-		StreamReader reader = null;
-		string line = string.Empty;
+            StreamReader reader = null;
+            string line = string.Empty;
 
-		try
-		{
-			using (reader = new StreamReader(filePath))
-			{
-				while (reader.Peek() >= 0)
-				{
-					line = reader.ReadLine();
+            try
+            {
+                using (reader = new StreamReader(filePath))
+                {
+                    while (reader.Peek() >= 0)
+                    {
+                       line = reader.ReadLine();
 
-					//Entries must be londer than 1 character
-					if (!string.IsNullOrWhiteSpace(line)
-						&& line.Trim().Length > 1)
-					{
-						AddEntryToDictionary(line.Trim(), loadedFromDictionaryFile: true, usageCount: 0);
-					}
-				}
-			}
-		}
-		catch (Exception exception)
-		{
-			PublishError(this, exception);
-		}
-		finally
-		{
-			if (reader != null)
-			{
-				reader.Dispose();
-			}
-		}
-	}
+                        //Entries must be londer than 1 character
+                        if (!string.IsNullOrWhiteSpace(line)
+                            && line.Trim().Length > 1)
+                        {
+                            AddEntryToDictionary(line.Trim(), loadedFromDictionaryFile: true, usageCount: 0);
+                        }
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                PublishError(this, exception);
+            }
+            finally
+            {
+                if (reader != null)
+                {
+                    reader.Dispose();
+                }
+            }
+        }
 
         private static string GetUserDictionaryPath(Languages? language)
         {
@@ -201,140 +201,140 @@ namespace JuliusSweetland.OptiKey.Services
 
         private void LoadUserDictionaryFromFile(string filePath)
         {
-			Log.DebugFormat("Loading user dictionary from file '{0}'", filePath);
+            Log.DebugFormat("Loading user dictionary from file '{0}'", filePath);
 
-			StreamReader reader = null;
-			List<DictionaryEntry> tempStore = new List<DictionaryEntry>();
+            StreamReader reader = null;
+            List<DictionaryEntry> tempStore = new List<DictionaryEntry>();
 
-			string hash = string.Empty;
-			string line = string.Empty;
-			int usageCount = 0;
+            string hash = string.Empty;
+            string line = string.Empty;
+            int usageCount = 0;
 
-			try
-			{
-				using (reader = new StreamReader(filePath))
-				{
-					while (reader.Peek() >= 0)
-					{
-						line = reader.ReadLine();
+            try
+            {
+                using (reader = new StreamReader(filePath))
+                {
+                    while (reader.Peek() >= 0)
+                    {
+                        line = reader.ReadLine();
 
-						var entryWithUsageCount = line.Trim().Split('|');
-						if (entryWithUsageCount.Length == 2)
-						{
-							var entry = entryWithUsageCount[0];
-							if (!int.TryParse(entryWithUsageCount[1], out usageCount))
-							{
-								usageCount = 0;
-							}
+                        var entryWithUsageCount = line.Trim().Split('|');
+                        if (entryWithUsageCount.Length == 2)
+                        {
+                            var entry = entryWithUsageCount[0];
+                            if (!int.TryParse(entryWithUsageCount[1], out usageCount))
+                            {
+                                usageCount = 0;
+                            }
 
-							hash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false);
-							managedSuggestions.AddEntry(entry, new DictionaryEntry(entry, usageCount), hash);
-						}
-					}
-				}
+                            hash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false);
+                            managedSuggestions.AddEntry(entry, new DictionaryEntry(entry, usageCount), hash);
+                        }
+                    }
+                }
 
-				if (managedSuggestions.GetWordsHashes().Count == 0)
-				{
-					// Loading from user dictionary yield empty dict, then try load from 
-					// source of truth -- this will flush any previous user entry counts.
-					LoadDictionaryFromLanguageFile();
-				}
-			}
-			catch (Exception exception)
-			{
-				PublishError(this, exception);
-			}
-			finally
-			{
-				if (reader != null)
-				{
-					reader.Dispose();
-				}
-			}
-		}
+                if (managedSuggestions.GetWordsHashes().Count == 0)
+                {
+                    // Loading from user dictionary yield empty dict, then try load from 
+                    // source of truth -- this will flush any previous user entry counts.
+                    LoadDictionaryFromLanguageFile();
+                }
+            }
+            catch (Exception exception)
+            {
+                PublishError(this, exception);
+            }
+            finally
+            {
+                if (reader != null)
+                {
+                    reader.Dispose();
+                }
+            }
+        }
 
         private void SaveUserDictionaryToFile()
         {
-			lock (Settings.Default)
-			{
-				try
-				{
-					var userDictionaryPath = GetUserDictionaryPath(Settings.Default.KeyboardAndDictionaryLanguage);
-					StreamWriter writer = null;
+            lock (Settings.Default)
+            {
+                try
+                {
+                    var userDictionaryPath = GetUserDictionaryPath(Settings.Default.KeyboardAndDictionaryLanguage);
+                    StreamWriter writer = null;
 
-					Log.DebugFormat("Saving user dictionary to file '{0}'", userDictionaryPath);
+                    Log.DebugFormat("Saving user dictionary to file '{0}'", userDictionaryPath);
 
-					try
-					{
-						List<DictionaryEntry> userDictToSave = managedSuggestions.
-																GetWordsHashes().
-																SelectMany(hash => entries[hash]).
-																Distinct().ToList();
+                    try
+                    {
+                        List<DictionaryEntry> userDictToSave = managedSuggestions.
+                                                                GetWordsHashes().
+                                                                SelectMany(hash => entries[hash]).
+                                                                Distinct().ToList();
 
-						if (userDictToSave != null && userDictToSave.Count > 0)
-						{
-							// Only save dictionary if it's not empty, to prevent override user dictionary with
-							//	Presage dictionary (which use external dictionary, hence local dict cache is empty),
-							//	or when the in-memory dict is corrupted. 
-							writer = new StreamWriter(userDictionaryPath);
+                        if (userDictToSave != null && userDictToSave.Count > 0)
+                        {
+                            // Only save dictionary if it's not empty, to prevent override user dictionary with
+                            //	Presage dictionary (which use external dictionary, hence local dict cache is empty),
+                            //	or when the in-memory dict is corrupted. 
+                            writer = new StreamWriter(userDictionaryPath);
 
-							foreach (var entryWithUsageCount in userDictToSave)
-							{
-								if (!typeof(NGramAutoComplete.EntryMetadata).IsInstanceOfType(entryWithUsageCount))
-								{
-									writer.WriteLine(string.Format("{0}|{1}", entryWithUsageCount.Entry, entryWithUsageCount.UsageCount));
-								}
-							}
-						}
-					}
-					finally
-					{
-						if (writer != null)
-						{
-							writer.Dispose();
-						}
-					}
-				}
-				catch (Exception exception)
-				{
-					PublishError(this, exception);
-				}
-			}
-		}
+                            foreach (var entryWithUsageCount in userDictToSave)
+                            {
+                                if (!typeof(NGramAutoComplete.EntryMetadata).IsInstanceOfType(entryWithUsageCount))
+                                {
+                                    writer.WriteLine(string.Format("{0}|{1}", entryWithUsageCount.Entry, entryWithUsageCount.UsageCount));
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (writer != null)
+                        {
+                            writer.Dispose();
+                        }
+                    }
+                }
+                catch (Exception exception)
+                {
+                    PublishError(this, exception);
+                }
+            }
+        }
 
-		private void WriteNewEntryToDictionaryFile(string newEntry)
-		{
-			try
-			{
-				var userDictionaryPath = GetUserDictionaryPath(Settings.Default.KeyboardAndDictionaryLanguage);
+        private void WriteNewEntryToDictionaryFile(string newEntry)
+        {
+            try
+            {
+                var userDictionaryPath = GetUserDictionaryPath(Settings.Default.KeyboardAndDictionaryLanguage);
 
-				Log.DebugFormat("Saving new entry {0} to dictionary file '{1}'", newEntry, userDictionaryPath);
+                Log.DebugFormat("Saving new entry {0} to dictionary file '{1}'", newEntry, userDictionaryPath);
 
-				StreamWriter writer = null;
-				try
-				{
-					writer = new StreamWriter(userDictionaryPath, append: true);
-					writer.WriteLine(string.Format("{0}|{1}", newEntry, 1));
-				}
-				finally
-				{
-					if (writer != null)
-					{
-						writer.Dispose();
-					}
-				}
-			}
-			catch (Exception exception)
-			{
-				PublishError(this, exception);
-			}
-		}
+                StreamWriter writer = null;
+                try
+                {
+                    writer = new StreamWriter(userDictionaryPath, append: true);
+                    writer.WriteLine(string.Format("{0}|{1}", newEntry, 1));
+                }
+                finally
+                {
+                    if (writer != null)
+                    {
+                        writer.Dispose();
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                PublishError(this, exception);
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Exists In Dictionary
+        #region Exists In Dictionary
 
-		public bool ExistsInDictionary(string entryToFind)
+        public bool ExistsInDictionary(string entryToFind)
         {
             Log.DebugFormat("ExistsInDictionary called with '{0}'.", entryToFind);
 
@@ -342,7 +342,7 @@ namespace JuliusSweetland.OptiKey.Services
                 && !string.IsNullOrWhiteSpace(entryToFind))
             {
                 var exists = managedSuggestions.GetWordsHashes()
-					.SelectMany(hash => entries[hash]) //Expand out all values in the dictionary and all values in the sorted lists
+                    .SelectMany(hash => entries[hash]) //Expand out all values in the dictionary and all values in the sorted lists
                     .Select(dictionaryEntryWithUsageCount => dictionaryEntryWithUsageCount.Entry)
                     .Any(dictionaryEntry => !string.IsNullOrWhiteSpace(dictionaryEntry) && dictionaryEntry.Trim().Equals(entryToFind.Trim()));
 
@@ -370,24 +370,24 @@ namespace JuliusSweetland.OptiKey.Services
             if (entries != null
                 && !string.IsNullOrWhiteSpace(entry))
             {
-				//Add to in-memory (hashed) dictionary (and then save to custom dictionary file if new entry entered by user)
-				var hash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: !loadedFromDictionaryFile);
-				if (!string.IsNullOrWhiteSpace(hash))
-				{
-					var newEntryWithUsageCount = new DictionaryEntry(entry, usageCount);
+                //Add to in-memory (hashed) dictionary (and then save to custom dictionary file if new entry entered by user)
+                var hash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: !loadedFromDictionaryFile);
+                if (!string.IsNullOrWhiteSpace(hash))
+                {
+                    var newEntryWithUsageCount = new DictionaryEntry(entry, usageCount);
 
-					//Also add to entries for auto complete
-					managedSuggestions.AddEntry(entry, newEntryWithUsageCount, hash);
+                    //Also add to entries for auto complete
+                    managedSuggestions.AddEntry(entry, newEntryWithUsageCount, hash);
 
-					if (!loadedFromDictionaryFile)
-					{
-						Log.DebugFormat("Adding new (not loaded from dictionary file) entry '{0}' to in-memory dictionary with hash '{1}'", entry, hash);
+                    if (!loadedFromDictionaryFile)
+                    {
+                        Log.DebugFormat("Adding new (not loaded from dictionary file) entry '{0}' to in-memory dictionary with hash '{1}'", entry, hash);
 
-						Thread writeToFile = new Thread(() => WriteNewEntryToDictionaryFile(entry));
-						writeToFile.Start();
-					}
-				}
-			}
+                        Thread writeToFile = new Thread(() => WriteNewEntryToDictionaryFile(entry));
+                        writeToFile.Start();
+                    }
+                }
+            }
         }
 
         #endregion
@@ -429,16 +429,16 @@ namespace JuliusSweetland.OptiKey.Services
 
             if (entries != null)
             {
-				var enumerator = managedSuggestions.GetWordsHashes()
-					.SelectMany(hash => entries[hash])
-					.Where(dictEntry => !(typeof(NGramAutoComplete.EntryMetadata).IsInstanceOfType(dictEntry)))
-					.OrderBy(entryWithUsageCount => entryWithUsageCount.Entry)
-					.GetEnumerator();
+                var enumerator = managedSuggestions.GetWordsHashes()
+                    .SelectMany(hash => entries[hash])
+                    .Where(dictEntry => !(typeof(NGramAutoComplete.EntryMetadata).IsInstanceOfType(dictEntry)))
+                    .OrderBy(entryWithUsageCount => entryWithUsageCount.Entry)
+                    .GetEnumerator();
 
-				while (enumerator.MoveNext())
-				{
-					yield return enumerator.Current;
-				}
+                while (enumerator.MoveNext())
+                {
+                    yield return enumerator.Current;
+                }
             }
         }
 
@@ -596,35 +596,35 @@ namespace JuliusSweetland.OptiKey.Services
                 Log.DebugFormat("Attempting to match using filtered string: '{0}'", filteredStrings.Item1);
 
                 cancellationTokenSource = new CancellationTokenSource();
-				var matches = new List<string>();
+                var matches = new List<string>();
 
-				GetHashes()
-					.AsParallel()
-					.WithCancellation(cancellationTokenSource.Token)
-					.Where(hash => reliableFirstCharCleansed == null || hash.First() == reliableFirstCharCleansed.Value)
-					.Where(hash => reliableLastCharCleansed == null || hash.Last() == reliableLastCharCleansed.Value)
-					.Select(hash =>
-					{
-						var lcs = filteredStrings.Item1.LongestCommonSubsequence(hash);
+                GetHashes()
+                    .AsParallel()
+                    .WithCancellation(cancellationTokenSource.Token)
+                    .Where(hash => reliableFirstCharCleansed == null || hash.First() == reliableFirstCharCleansed.Value)
+                    .Where(hash => reliableLastCharCleansed == null || hash.Last() == reliableLastCharCleansed.Value)
+                    .Select(hash =>
+                    {
+                        var lcs = filteredStrings.Item1.LongestCommonSubsequence(hash);
 
-						return new
-						{
-							Hash = hash,
-							HashLastLetter = hash.Last(),
-							CaptureLastLetter = filteredStrings.Item1.Last(),
-							SimilarityToMeanFilteredString = ((double)lcs / (double)hash.Length) * (double)lcs
-						};
-					})
-					.OrderByDescending(x => x.SimilarityToMeanFilteredString)
-					.ThenByDescending(x => x.HashLastLetter == x.CaptureLastLetter) //Matching last letter - assume some reliability
-					.SelectMany(x => GetEntries(x.Hash))
-					.Take(Settings.Default.MaxDictionaryMatchesOrSuggestions)
-					.ToList()
-					.ForEach(matches.Add);
+                        return new
+                        {
+                            Hash = hash,
+                            HashLastLetter = hash.Last(),
+                            CaptureLastLetter = filteredStrings.Item1.Last(),
+                            SimilarityToMeanFilteredString = ((double)lcs / (double)hash.Length) * (double)lcs
+                        };
+                    })
+                    .OrderByDescending(x => x.SimilarityToMeanFilteredString)
+                    .ThenByDescending(x => x.HashLastLetter == x.CaptureLastLetter) //Matching last letter - assume some reliability
+                    .SelectMany(x => GetEntries(x.Hash))
+                    .Take(Settings.Default.MaxDictionaryMatchesOrSuggestions)
+                    .ToList()
+                    .ForEach(matches.Add);
 
-				matches.ForEach(match => Log.DebugFormat("Returning dictionary match: {0}", match));
+                matches.ForEach(match => Log.DebugFormat("Returning dictionary match: {0}", match));
                 return new Tuple<List<Point>, FunctionKeys?, string, List<string>>(points, null, null, matches.Any() ? matches : null);
-			}
+            }
             catch (OperationCanceledException)
             {
                 Log.Error("Map capture to dictionary matches cancelled - returning nothing");
@@ -690,13 +690,13 @@ namespace JuliusSweetland.OptiKey.Services
 
             if (entries != null)
             {
-				var enumerator = managedSuggestions.GetWordsHashes().GetEnumerator();
+                var enumerator = managedSuggestions.GetWordsHashes().GetEnumerator();
 
-				while (enumerator.MoveNext())
-				{
-					yield return enumerator.Current;
-				}
-			}
+                while (enumerator.MoveNext())
+                {
+                    yield return enumerator.Current;
+                }
+            }
         }
 
         #endregion
@@ -709,18 +709,18 @@ namespace JuliusSweetland.OptiKey.Services
 
             if (entries != null
                 && entries.ContainsKey(hash))
-			{
-				var enumerator = entries[hash]
-					.Where(dictEntry => !(typeof(NGramAutoComplete.EntryMetadata).IsInstanceOfType(dictEntry)))
-					.OrderByDescending(entryWithUsageCount => entryWithUsageCount.UsageCount)
-					.Select(entryWithUsageCount => entryWithUsageCount.Entry)
-					.GetEnumerator();
+            {
+                var enumerator = entries[hash]
+                    .Where(dictEntry => !(typeof(NGramAutoComplete.EntryMetadata).IsInstanceOfType(dictEntry)))
+                    .OrderByDescending(entryWithUsageCount => entryWithUsageCount.UsageCount)
+                    .Select(entryWithUsageCount => entryWithUsageCount.Entry)
+                    .GetEnumerator();
 
                 while (enumerator.MoveNext()
                     && !string.IsNullOrWhiteSpace(enumerator.Current))
-				{
-					yield return enumerator.Current;
-				}
+                {
+                    yield return enumerator.Current;
+                }
             }
         }
 


### PR DESCRIPTION
Currently if using NGram, config menu's dictionary tab will pull in helper entries as well. They're created for internal use only, and shouldn't being pulled out for user-facing UIs.

Files modified:
- _DictionaryService.cs::GetAllEntries()_: now we will filter all the helper entries when returning the dictionary entries. Currently this function is called by user facing UI view's to display the content of the dictionary entries, hence we should filter those internal-only entries. 