### PR TITLE
Fixing word suggestions when using Basic suggestions

### DIFF
--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
@@ -54,21 +54,21 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
 
         public void AddEntry(string entry, DictionaryEntry newEntryWithUsageCount, string normalizedHash = "")
         {
-			//Also add to entries for auto complete
-			var autoCompleteHash = entry.Normalise(log: false);
-            
-			AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
-			if (!wordsIndex.Contains(autoCompleteHash))
-			{
-				wordsIndex.Add(autoCompleteHash);
-			}
-
             if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
             {
                 //Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
                 var phraseAutoCompleteHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: false);
                 AddEntry(phraseAutoCompleteHash, newEntryWithUsageCount);
             }
+
+            //Also add to entries for auto complete
+            var autoCompleteHash = entry.Normalise(log: false);
+            
+			AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
+			if (!wordsIndex.Contains(autoCompleteHash))
+			{
+				wordsIndex.Add(autoCompleteHash);
+			}
         }
 
         private void AddToDictionary (string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)

--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
@@ -54,27 +54,22 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
 
         public void AddEntry(string entry, DictionaryEntry newEntryWithUsageCount, string normalizedHash = "")
         {
-			if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
-			{
-				//Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
-				var phraseAutoCompleteHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: false);
-				AddEntry(phraseAutoCompleteHash, newEntryWithUsageCount);
-			}
-
 			//Also add to entries for auto complete
 			var autoCompleteHash = entry.Normalise(log: false);
-
-			//Also add the normalized hash to the dictionary
-			normalizedHash = string.IsNullOrWhiteSpace(normalizedHash)
-								? entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false)
-								: normalizedHash;
-
-			AddToDictionary(entry, normalizedHash, newEntryWithUsageCount);
-			if (!wordsIndex.Contains(normalizedHash))
+            
+			AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
+			if (!wordsIndex.Contains(autoCompleteHash))
 			{
-				wordsIndex.Add(normalizedHash);
+				wordsIndex.Add(autoCompleteHash);
 			}
-		}
+
+            if (!string.IsNullOrWhiteSpace(entry) && entry.Contains(" "))
+            {
+                //Entry is a phrase - also add with a dictionary entry hash (first letter of each word)
+                var phraseAutoCompleteHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: false);
+                AddEntry(phraseAutoCompleteHash, newEntryWithUsageCount);
+            }
+        }
 
         private void AddToDictionary (string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)
         {


### PR DESCRIPTION
Currently when using Basic suggestions, some of the words with same characters in neighboring positions (e.g. _aardvark_) will not show in the suggestions. This issue is caused by inappropriately indexing the words. 

Files modified:
- _BasicAutoComplete.cs_: now we are going to index the word using _normalize_ method (previously we were using _NormaliseAndRemoveRepeatingCharactersAndHandlePhrases_ method to index the entry).