### PR TITLE
Fix for #364

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
@@ -79,6 +79,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             {
                 SetProperty(ref this.keyboardAndDictionaryLanguage, value);
                 OnPropertyChanged(() => UseAlphabeticalKeyboardLayoutIsVisible);
+                OnPropertyChanged(() => EnableCommuniKateKeyboardLayoutIsVisible);
                 OnPropertyChanged(() => UseCommuniKateKeyboardLayoutByDefault);
                 OnPropertyChanged(() => UseSimplifiedKeyboardLayoutIsVisible);
             }
@@ -140,7 +141,10 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             get { return enableCommuniKateKeyboardLayout; }
             set { SetProperty(ref enableCommuniKateKeyboardLayout, value
                         && useAlphabeticalKeyboardLayout == false
-                        && useSimplifiedKeyboardLayout == false);
+                        && useSimplifiedKeyboardLayout == false
+                        && (KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
+                            || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
+                            || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS));
             }
         }
 
@@ -182,16 +186,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return usingCommuniKateKeyboardLayout; }
             set { SetProperty(ref usingCommuniKateKeyboardLayout, useCommuniKateKeyboardLayoutByDefault); }
-        }
-
-        public bool UseCommuniKatedKeyboardLayoutIsVisible
-        {
-            get
-            {
-                return KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
-                    || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
-                    || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS;
-            }
         }
 
         private bool forceCapsLock;

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml
@@ -75,7 +75,7 @@
                               IsChecked="{Binding EnableCommuniKateKeyboardLayout, Mode=TwoWay}" >
                         <CheckBox.Style>
                             <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
-                                <Setter Property="Visibility" Value="{Binding UseCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding UseAlphabeticalKeyboardLayout}" Value="True">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -92,7 +92,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding UseCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding UseAlphabeticalKeyboardLayout}" Value="True">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -112,7 +112,7 @@
                               IsChecked="{Binding UseCommuniKateKeyboardLayoutByDefault, Mode=TwoWay}" >
                         <CheckBox.Style>
                             <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
-                                <Setter Property="Visibility" Value="{Binding UseCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding UseAlphabeticalKeyboardLayout}" Value="True">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -132,7 +132,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="Visible" />
+                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -153,7 +153,7 @@
                         </Button>
                         <StackPanel.Style>
                             <Style TargetType="{x:Type StackPanel}">
-                                <Setter Property="Visibility" Value="Visible" />
+                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -173,7 +173,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="Visible" />
+                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />


### PR DESCRIPTION
All Communikate settings now use EnableCommuniKateKeyboardLayoutIsVisible
for their initial visibility settling. If the language is set to something
other than English the CommuniKate settings are immediately hidden. Then
they are also disabled when the non-English language is confirmed.

I believe this should not have any conflicts with #346.