### PR TITLE
Cancel Unsaved Settings Shall Restore Original Settings

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
@@ -1,17 +1,28 @@
 ﻿using NUnit.Framework;
+using Prism.Interactivity.InteractionRequest;
 using System.Windows;
 
 namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpecifications
 {
     [TestFixture]
-    public class WhenCancelCommand : ManagementViewModelTestBase
+    public abstract class WhenCancelCommand : ManagementViewModelTestBase
     {
         protected Window Window { get; private set; }
         protected bool IsWindowClosed { get; private set; }
+        protected bool IsWarningRaised { get; private set; }
+        protected bool IsCanceled { get; private set; }
+        protected bool confirm { get; set; }
 
         protected override void Arrange()
         {
             base.Arrange();
+            base.ManagementViewModel.ConfirmationRequest.Raised += (s, e) =>
+            {
+                Confirmation context = e.Context as Confirmation;
+                context.Confirmed = confirm;
+                e.Callback();
+            };
+
             Window = new Window();
             Window.Closed += (s, e) => IsWindowClosed = true;
         }
@@ -20,12 +31,39 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         {
             ManagementViewModel.CancelCommand.Execute(Window);
         }
+    }
+
+    [TestFixture]
+    public class WhenCancelCommandDismissed : WhenCancelCommand
+    {
+        protected override void Arrange()
+        {
+            base.confirm = true;
+            base.Arrange();
+        }
 
         [RequiresSTA]
         [Test]
         public void ThenWindowShouldBeClosed()
         {
             Assert.IsTrue(IsWindowClosed);
+        }
+    }
+
+    [TestFixture]
+    public class WhenCancelCommandStay : WhenCancelCommand
+    {
+        protected override void Arrange()
+        {
+            base.confirm = false;
+            base.Arrange();
+        }
+
+        [RequiresSTA]
+        [Test]
+        public void ThenWindowShouldStay()
+        {
+            Assert.IsFalse(IsWindowClosed);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -1019,7 +1019,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Settings have been updated, do you want to discard all changes?.
+        ///   Looks up a localized string similar to All changes made to the settings will be discarded, do you want to continue?.
         /// </summary>
         public static string DISCARD_CHANGED_SETTINGS {
             get {
@@ -4097,7 +4097,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Settings Changed.
+        ///   Looks up a localized string similar to Cancel Settings.
         /// </summary>
         public static string SETTINGS_CHANGED {
             get {

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace JuliusSweetland.OptiKey.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1015,6 +1015,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string DICTIONARY_FILE_NOT_FOUND_ERROR {
             get {
                 return ResourceManager.GetString("DICTIONARY_FILE_NOT_FOUND_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings have been updated, do you want to discard all changes?.
+        /// </summary>
+        public static string DISCARD_CHANGED_SETTINGS {
+            get {
+                return ResourceManager.GetString("DISCARD_CHANGED_SETTINGS", resourceCulture);
             }
         }
         
@@ -4084,6 +4093,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string SELECTION_PROGRESS_INDICATOR_START_SIZE_LABEL {
             get {
                 return ResourceManager.GetString("SELECTION_PROGRESS_INDICATOR_START_SIZE_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings Changed.
+        /// </summary>
+        public static string SETTINGS_CHANGED {
+            get {
+                return ResourceManager.GetString("SETTINGS_CHANGED", resourceCulture);
             }
         }
         

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1917,4 +1917,10 @@ The prediction method will be changed to NGram to prevent a crash on next run.</
   <data name="TOBII_PCEYE_GO_PLUS" xml:space="preserve">
     <value>Tobii PCEye Plus</value>
   </data>
+  <data name="DISCARD_CHANGED_SETTINGS" xml:space="preserve">
+    <value>Settings have been updated, do you want to discard all changes?</value>
+  </data>
+  <data name="SETTINGS_CHANGED" xml:space="preserve">
+    <value>Settings Changed</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1918,9 +1918,9 @@ The prediction method will be changed to NGram to prevent a crash on next run.</
     <value>Tobii PCEye Plus</value>
   </data>
   <data name="DISCARD_CHANGED_SETTINGS" xml:space="preserve">
-    <value>Settings have been updated, do you want to discard all changes?</value>
+    <value>All changes made to the settings will be discarded, do you want to continue?</value>
   </data>
   <data name="SETTINGS_CHANGED" xml:space="preserve">
-    <value>Settings Changed</value>
+    <value>Cancel Settings</value>
   </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/BasicAutoComplete.cs
@@ -8,11 +8,11 @@ using System.Linq;
 namespace JuliusSweetland.OptiKey.Services.Suggestions
 {
     public class BasicAutoComplete : IManagedSuggestions
-	{
-		private readonly Dictionary<string, HashSet<DictionaryEntry>> entries = new Dictionary<string, HashSet<DictionaryEntry>>();
-		private readonly HashSet<string> wordsIndex = new HashSet<string>();
+    {
+        private readonly Dictionary<string, HashSet<DictionaryEntry>> entries = new Dictionary<string, HashSet<DictionaryEntry>>();
+        private readonly HashSet<string> wordsIndex = new HashSet<string>();
 
-		private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         /// <summary>
         /// Removes all possible suggestions from the auto complete provider.
@@ -20,7 +20,7 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
         public void Clear()
         {
             Log.Debug("Clear called.");
-			entries.Clear();
+            entries.Clear();
         }
 
         public virtual IEnumerable<string> GetSuggestions(string root, bool nextWord)
@@ -36,8 +36,8 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
                             && char.IsLetter(inProgressWord.First())) //A word must start with a letter
                 {
                     return
-						entries
-							.Where(kvp => kvp.Key.StartsWith(simplifiedRoot, StringComparison.Ordinal))
+                        entries
+                            .Where(kvp => kvp.Key.StartsWith(simplifiedRoot, StringComparison.Ordinal))
                             .SelectMany(kvp => kvp.Value)
                             .Where(de => de.Entry.Length >= root.Length)
                             .Distinct()
@@ -64,68 +64,68 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
             //Also add to entries for auto complete
             var autoCompleteHash = entry.Normalise(log: false);
             
-			AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
-			if (!wordsIndex.Contains(autoCompleteHash))
-			{
-				wordsIndex.Add(autoCompleteHash);
-			}
+            AddToDictionary(entry, autoCompleteHash, newEntryWithUsageCount);
+            if (!wordsIndex.Contains(autoCompleteHash))
+            {
+                wordsIndex.Add(autoCompleteHash);
+            }
         }
 
         private void AddToDictionary (string entry, string autoCompleteHash, DictionaryEntry newEntryWithUsageCount)
         {
-			if (!string.IsNullOrWhiteSpace(autoCompleteHash))
-			{
-				if (entries.ContainsKey(autoCompleteHash))
-				{
-					if (entries[autoCompleteHash].All(nwwuc => nwwuc.Entry != entry))
-					{
-						entries[autoCompleteHash].Add(newEntryWithUsageCount);
-					}
-				}
-				else
-				{
-					entries.Add(autoCompleteHash, new HashSet<DictionaryEntry> { newEntryWithUsageCount });
-				}
-			}
-		}
+            if (!string.IsNullOrWhiteSpace(autoCompleteHash))
+            {
+                if (entries.ContainsKey(autoCompleteHash))
+                {
+                    if (entries[autoCompleteHash].All(nwwuc => nwwuc.Entry != entry))
+                    {
+                        entries[autoCompleteHash].Add(newEntryWithUsageCount);
+                    }
+                }
+                else
+                {
+                    entries.Add(autoCompleteHash, new HashSet<DictionaryEntry> { newEntryWithUsageCount });
+                }
+            }
+        }
 
         public void RemoveEntry(string entry)
         {
-			var autoCompleteHash = entry.Normalise(log: false);
-			RemoveEntryWorker(entry, autoCompleteHash);
+            var autoCompleteHash = entry.Normalise(log: false);
+            RemoveEntryWorker(entry, autoCompleteHash);
 
-			var normalizedHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false);
-			RemoveEntryWorker(entry, autoCompleteHash);
-			wordsIndex.Remove(normalizedHash);
-		}
+            var normalizedHash = entry.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false);
+            RemoveEntryWorker(entry, autoCompleteHash);
+            wordsIndex.Remove(normalizedHash);
+        }
 
-		private void RemoveEntryWorker(string entry, string hash)
-		{
-			if (!string.IsNullOrWhiteSpace(hash)
-					&& entries.ContainsKey(hash))
-			{
-				var foundEntryForAutoComplete = entries[hash].FirstOrDefault(ewuc => ewuc.Entry == entry);
+        private void RemoveEntryWorker(string entry, string hash)
+        {
+            if (!string.IsNullOrWhiteSpace(hash)
+                    && entries.ContainsKey(hash))
+            {
+                var foundEntryForAutoComplete = entries[hash].FirstOrDefault(ewuc => ewuc.Entry == entry);
 
-				if (foundEntryForAutoComplete != null)
-				{
-					entries[hash].Remove(foundEntryForAutoComplete);
+                if (foundEntryForAutoComplete != null)
+                {
+                    entries[hash].Remove(foundEntryForAutoComplete);
 
-					if (!entries[hash].Any())
-					{
-						entries.Remove(hash);
-					}
-				}
-			}
-		}
+                    if (!entries[hash].Any())
+                    {
+                        entries.Remove(hash);
+                    }
+                }
+            }
+        }
 
-		public Dictionary<string, HashSet<DictionaryEntry>> GetEntries()
-		{
-			return entries;
-		}
+        public Dictionary<string, HashSet<DictionaryEntry>> GetEntries()
+        {
+            return entries;
+        }
 
-		public HashSet<string> GetWordsHashes()
-		{
-			return wordsIndex;
-		}
-	}
+        public HashSet<string> GetWordsHashes()
+        {
+            return wordsIndex;
+        }
+    }
 }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
@@ -114,27 +114,20 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
         private void Cancel(Window window)
         {
-            if (ChangesRequireRestart)
-            {
-                //Warn if wants to discard all the changes
-                ConfirmationRequest.Raise(
-                    new Confirmation
+            //Warn if wants to discard all the changes
+            ConfirmationRequest.Raise(
+                new Confirmation
+                {
+                    Title = Resources.SETTINGS_CHANGED,
+                    Content = Resources.DISCARD_CHANGED_SETTINGS
+                }, confirmation =>
+                {
+                    if (confirmation.Confirmed)
                     {
-                        Title = Resources.SETTINGS_CHANGED,
-                        Content = Resources.DISCARD_CHANGED_SETTINGS
-                    }, confirmation =>
-                    {
-                        if (confirmation.Confirmed)
-                        {
-                            Settings.Default.Reload();
-                            window.Close();
-                        }
-                    });
-            }
-            else
-            {
-                window.Close();
-            }
+                        Settings.Default.Reload();
+                        window.Close();
+                    }
+                });
         }
 
         #endregion

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
@@ -112,9 +112,30 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             }
         }
 
-        private static void Cancel(Window window)
+        private void Cancel(Window window)
         {
-            window.Close();
+            if (ChangesRequireRestart)
+            {
+                //Warn if wants to discard all the changes
+                ConfirmationRequest.Raise(
+                    new Confirmation
+                    {
+                        Title = "Settings Changed",
+                        Content = "Settings have been updated, do you want to discard all changes?"
+                    }, confirmation =>
+                    {
+                        if (confirmation.Confirmed)
+                        {
+                            Settings.Default.Reload();
+                            window.Close();
+                        }
+                    });
+            }
+            else
+            {
+                window.Close();
+            }
+
         }
 
         #endregion

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
@@ -120,8 +120,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 ConfirmationRequest.Raise(
                     new Confirmation
                     {
-                        Title = "Settings Changed",
-                        Content = "Settings have been updated, do you want to discard all changes?"
+                        Title = Resources.SETTINGS_CHANGED,
+                        Content = Resources.DISCARD_CHANGED_SETTINGS
                     }, confirmation =>
                     {
                         if (confirmation.Confirmed)
@@ -135,7 +135,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             {
                 window.Close();
             }
-
         }
 
         #endregion


### PR DESCRIPTION
As noted in issue #365, if canceling unsaved changes, not all settings will be restored to their previous values. This could cause problems if users accidentally changed some settings (e.g. checked a checkbox without noticing that) but don't have a way to back out what they have changed.

Now, new settings view will always check if a change has been made, and if so, when user click "Cancel" button to close the modal view, they will be asked if they want to discard the changes -- if they choose to proceed, all changes will be restored to the previous values; otherwise, the settings modal view will stay.

Be noted that `BasicAutoComplete.cs` isn't actually changed at all, but VS 2017 behaved weird again by changing all the spacing again, which made it look like being altered, but this PR does not change any of its code (but please double check and feel free to revert any unintended code changes).