### PR TITLE
Save file selections in the Settings to view model properties instead

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
@@ -9,8 +9,6 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
     {
         protected Window Window { get; private set; }
         protected bool IsWindowClosed { get; private set; }
-        protected bool IsWarningRaised { get; private set; }
-        protected bool IsCanceled { get; private set; }
         protected bool confirm { get; set; }
 
         protected override void Arrange()

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
@@ -292,7 +292,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.UseAlphabeticalKeyboardLayout = UseAlphabeticalKeyboardLayout;
             Settings.Default.EnableCommuniKateKeyboardLayout = EnableCommuniKateKeyboardLayout;
             Settings.Default.CommuniKatePagesetLocation = CommuniKatePagesetLocation;
-            CommuniKateStagedForDeletion = Settings.Default.CommuniKateStagedForDeletion;
+            Settings.Default.CommuniKateStagedForDeletion = CommuniKateStagedForDeletion;
             Settings.Default.UseCommuniKateKeyboardLayoutByDefault = UseCommuniKateKeyboardLayoutByDefault;
             Settings.Default.UsingCommuniKateKeyboardLayout = UseCommuniKateKeyboardLayoutByDefault;
             Settings.Default.UseSimplifiedKeyboardLayout = UseSimplifiedKeyboardLayout;

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/ManagementViewModel.cs
@@ -124,7 +124,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 {
                     if (confirmation.Confirmed)
                     {
-                        Settings.Default.Reload();
                         window.Close();
                     }
                 });

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/SoundsView.xaml.cs
@@ -1,7 +1,7 @@
-using System.Windows.Controls;
-using System.Windows;
+using JuliusSweetland.OptiKey.UI.ViewModels.Management;
 using Microsoft.Win32;
-using JuliusSweetland.OptiKey.Properties;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace JuliusSweetland.OptiKey.UI.Views.Management
 {
@@ -22,17 +22,25 @@ namespace JuliusSweetland.OptiKey.UI.Views.Management
                 FileName = "marytts-server.bat",
                 Filter = "marytts-server|marytts-server.bat"
             };
+
             if (openFileDialog.ShowDialog() == true)
             {
+                string fileLocation = null;
+
                 if (openFileDialog.FileName.EndsWith(@"\bin\marytts-server.bat"))
                 {
                     txtMaryTtsLocation.Text = openFileDialog.FileName;
-                    Settings.Default.MaryTTSLocation = txtMaryTtsLocation.Text;
+                    fileLocation = txtMaryTtsLocation.Text;
                 }
                 else
                 {
                     txtMaryTtsLocation.Text = Properties.Resources.MARYTTS_LOCATION_ERROR_LABEL;
-                    Settings.Default.MaryTTSLocation = null;
+                }
+
+                SoundsViewModel viewModel = this.DataContext as SoundsViewModel;
+                if (viewModel != null && !string.IsNullOrWhiteSpace(fileLocation))
+                {
+                    viewModel.MaryTTSLocation = fileLocation;
                 }
             }
         }

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml.cs
@@ -2,6 +2,8 @@ using System.Windows.Controls;
 using System.Windows;
 using Microsoft.Win32;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.UI.ViewModels;
+using JuliusSweetland.OptiKey.UI.ViewModels.Management;
 
 namespace JuliusSweetland.OptiKey.UI.Views.Management
 {
@@ -21,18 +23,26 @@ namespace JuliusSweetland.OptiKey.UI.Views.Management
             {
                 Filter = "Open Board Format (*.obz)|*.obz"
             };
+
             if (openFileDialog.ShowDialog() == true)
             {
+                string fileLocation = null;
+
                 if (openFileDialog.FileName.EndsWith(@".obz"))
                 {
                     txtCommuniKateTopPageLocation.Text = openFileDialog.FileName;
-                    Settings.Default.CommuniKatePagesetLocation = txtCommuniKateTopPageLocation.Text;
-                    Settings.Default.CommuniKateStagedForDeletion = true;
+                    fileLocation = txtCommuniKateTopPageLocation.Text;
                 }
                 else
                 {
                     txtCommuniKateTopPageLocation.Text = Properties.Resources.COMMUNIKATE_TOPPAGE_LOCATION_ERROR_LABEL;
-                    Settings.Default.CommuniKatePagesetLocation = null;
+                }
+
+                WordsViewModel viewModel = this.DataContext as WordsViewModel;
+                if (viewModel != null && !string.IsNullOrWhiteSpace(fileLocation))
+                {
+                    viewModel.CommuniKatePagesetLocation = fileLocation;
+                    viewModel.CommuniKateStagedForDeletion = true;
                 }
             }
         }


### PR DESCRIPTION
As discussed in issue #365, `SoundsView` and `WordsView` in the settings modal view have broken the `ApplyChanges()` pattern by saving file selections to the Settings object directly. In specific, when updating "Mary TTS Location" setting in `SoundsView`, or "CommuniKate Pageset Location" in `WordsView`, the changes will be applied to Settings directly, such that even if users choose to click the "Cancel" button to discard all the changes, these two file locations would still be updated -- they're bypassing the `ApplyChanges()` call, which are triggered by the "Ok" button only. 

This actually lead to the original issue as raised by issue #365. The solution would be enforcing the `ApplyChanges()` patter: instead of saving file selections directly to Settings, we will apply the settings to the model properties. These properties will be used to update Settings when `ApplyChanges()` is invoked.