### PR TITLE
Hide dictionary controls if not using Basic or NGram

### DIFF
--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace JuliusSweetland.OptiKey.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1033,6 +1033,18 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string DICTIONARY_FILE_NOT_FOUND_ERROR {
             get {
                 return ResourceManager.GetString("DICTIONARY_FILE_NOT_FOUND_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Presage dictionary cannot be edited from here.
+        ///It&apos;s default location is &quot;C:\Program Files (x86)\presage\share\presage\database_en.db&quot;.
+        ///It can be edited with a program which can read SQLite format 3 files 
+        ///such as &quot;DB Browser for SQLite&quot; (which is a free program)..
+        /// </summary>
+        public static string DICTIONARY_IS_PRESAGE {
+            get {
+                return ResourceManager.GetString("DICTIONARY_IS_PRESAGE", resourceCulture);
             }
         }
         

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1941,4 +1941,10 @@ The prediction method will be changed to NGram to prevent a crash on next run.</
   <data name="SETTINGS_CHANGED" xml:space="preserve">
     <value>Cancel Settings</value>
   </data>
+  <data name="DICTIONARY_IS_PRESAGE" xml:space="preserve">
+    <value>The Presage dictionary cannot be edited from here.
+It's default location is "C:\Program Files (x86)\presage\share\presage\database_en.db".
+It can be edited with a program which can read SQLite format 3 files 
+such as "DB Browser for SQLite" (which is a free program).</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/DictionaryViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/DictionaryViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Services;
 using log4net;
 using Prism.Commands;
@@ -49,6 +50,32 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             { 
                 SetProperty(ref newEntry, value);
                 AddCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        public bool DictionaryControlsAvailable
+        {
+            get
+            {
+                return Settings.Default.SuggestionMethod == Enums.SuggestionMethods.NGram
+                    || Settings.Default.SuggestionMethod == Enums.SuggestionMethods.Basic;
+            }
+        }
+
+        public bool DictionaryControlsUnavailable
+        {
+            get
+            {
+                return Settings.Default.SuggestionMethod != Enums.SuggestionMethods.NGram
+                    && Settings.Default.SuggestionMethod != Enums.SuggestionMethods.Basic;
+            }
+        }
+
+        public bool DictionaryIsPresage
+        {
+            get
+            {
+                return Settings.Default.SuggestionMethod == Enums.SuggestionMethods.Presage;
             }
         }
 

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/DictionaryViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/DictionaryViewModel.cs
@@ -53,29 +53,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             }
         }
 
-        public bool DictionaryControlsAvailable
+        public bool DictionaryIsNotPresage
         {
             get
             {
-                return Settings.Default.SuggestionMethod == Enums.SuggestionMethods.NGram
-                    || Settings.Default.SuggestionMethod == Enums.SuggestionMethods.Basic;
-            }
-        }
-
-        public bool DictionaryControlsUnavailable
-        {
-            get
-            {
-                return Settings.Default.SuggestionMethod != Enums.SuggestionMethods.NGram
-                    && Settings.Default.SuggestionMethod != Enums.SuggestionMethods.Basic;
-            }
-        }
-
-        public bool DictionaryIsPresage
-        {
-            get
-            {
-                return Settings.Default.SuggestionMethod == Enums.SuggestionMethods.Presage;
+                return Settings.Default.SuggestionMethod != Enums.SuggestionMethods.Presage;
             }
         }
 

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/DictionaryView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/DictionaryView.xaml
@@ -8,13 +8,13 @@
              d:DesignHeight="300" d:DesignWidth="300">
 
     <UserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <CollectionViewSource x:Key="EntriesCollectionViewSource" Source="{Binding Entries}" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </UserControl.Resources>
 
     <Grid>
         <Grid IsSharedSizeScope="True"
-              Visibility="{Binding DictionaryControlsAvailable, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
+              Visibility="{Binding DictionaryIsNotPresage, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -110,16 +110,15 @@
             </ItemsControl>
         </Grid>
 
-        <Grid Grid.RowSpan="2" 
-              Visibility="{Binding DictionaryControlsUnavailable, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
+        <Grid Grid.RowSpan="2" >
             <Viewbox Stretch="Uniform">
-                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Margin="5" >
+                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Margin="5" 
+                           Text="{x:Static resx:Resources.DICTIONARY_IS_PRESAGE}" >
                     <TextBlock.Style>
                         <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                            <Setter Property="Text" Value="x:Static resx:Resources.DICTIONARY_CONTROLS_UNAVAILABLE}" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding DictionaryIsPresage}" Value="True">
-                                    <Setter Property="Text" Value="x:Static resx:Resources.DICTIONARY_IS_PRESAGE}" />
+                                <DataTrigger Binding="{Binding DictionaryIsNotPresage}" Value="True">
+                                    <Setter Property="Visibility" Value="Hidden" />
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/DictionaryView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/DictionaryView.xaml
@@ -6,104 +6,126 @@
              xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    
+
     <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <CollectionViewSource x:Key="EntriesCollectionViewSource" Source="{Binding Entries}" />
     </UserControl.Resources>
-    
-    <Grid IsSharedSizeScope="True">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        
-        <StackPanel Grid.Row="0" 
-                    Orientation="Horizontal" 
-                    HorizontalAlignment="Center">
-            <Label Content="{x:Static resx:Resources.ADD_NEW_ENTRY_TO_DICTIONARY}" 
-                   FontWeight="Bold"
-                   Margin="2" 
-                   VerticalAlignment="Center" />
-            <TextBox MinWidth="150" 
-                     Text="{Binding NewEntry, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                     Margin="2" 
-                     VerticalAlignment="Center" />
-            <Button Content="{x:Static resx:Resources.ADD_DICTIONARY_ENTRY}" 
-                    Command="{Binding AddCommand}" 
-                    Margin="2" 
-                    VerticalAlignment="Center" />
-        </StackPanel>
-        
-        <ItemsControl Grid.Row="1"
-                      VirtualizingStackPanel.IsVirtualizing="True"
-                      ScrollViewer.CanContentScroll="True"
-                      ItemsSource="{Binding Source={StaticResource EntriesCollectionViewSource}, Mode=OneWay}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="ToggleDeleteButtonColumn" />
-                        </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" 
-                                   Text="{Binding Entry}"
-                                   HorizontalAlignment="Left" 
-                                   VerticalAlignment="Center" 
-                                   Margin="50,2,50,2">
-                            <TextBlock.Style>
-                                <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Deleted}" Value="True">
-                                            <Setter Property="Foreground" Value="Red" />
-                                            <Setter Property="TextDecorations" Value="Strikethrough" />
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding Added}" Value="True">
-                                            <Setter Property="Foreground" Value="Green" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>        
-                       </TextBlock>
+    <Grid>
+        <Grid IsSharedSizeScope="True"
+              Visibility="{Binding DictionaryControlsAvailable, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+        
+            <StackPanel Grid.Row="0" 
+                        Orientation="Horizontal" 
+                        HorizontalAlignment="Center">
+                <Label Content="{x:Static resx:Resources.ADD_NEW_ENTRY_TO_DICTIONARY}" 
+                       FontWeight="Bold"
+                       Margin="2" 
+                       VerticalAlignment="Center" />
+                <TextBox MinWidth="150" 
+                         Text="{Binding NewEntry, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                         Margin="2" 
+                         VerticalAlignment="Center" />
+                <Button Content="{x:Static resx:Resources.ADD_DICTIONARY_ENTRY}" 
+                        Command="{Binding AddCommand}" 
+                        Margin="2" 
+                        VerticalAlignment="Center" />
+            </StackPanel>
+        
+            <ItemsControl Grid.Row="1"
+                          VirtualizingStackPanel.IsVirtualizing="True"
+                          ScrollViewer.CanContentScroll="True"
+                          ItemsSource="{Binding Source={StaticResource EntriesCollectionViewSource}, Mode=OneWay}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="ToggleDeleteButtonColumn" />
+                            </Grid.ColumnDefinitions>
 
-                        <Button Grid.Column="1" 
-                                VerticalAlignment="Center" 
-                                MinWidth="100" 
-                                Margin="50,2,50,2"
-                                Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, Path=DataContext.ToggleDeleteCommand}" 
-                                CommandParameter="{Binding Entry}">
-                            <Button.Style>
-                                <Style TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">
-                                    <Setter Property="Content" Value="{x:Static resx:Resources.DELETE_DICTIONARY_ENTRY}" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Deleted}" Value="True">
-                                            <Setter Property="Content" Value="{x:Static resx:Resources.RESTORE_DICTIONARY_ENTRY}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Button.Style>        
-                        </Button>
-                    </Grid>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <VirtualizingStackPanel />
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.Template>
-                <ControlTemplate>
-                    <Border BorderThickness="{TemplateBinding Border.BorderThickness}"
-                            Padding="{TemplateBinding Control.Padding}"
-                            BorderBrush="{TemplateBinding Border.BorderBrush}"
-                            Background="{TemplateBinding Panel.Background}"
-                            SnapsToDevicePixels="True">
-                        <ScrollViewer Padding="{TemplateBinding Control.Padding}" Focusable="False">
-                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}" />
-                        </ScrollViewer>
-                    </Border>
-                </ControlTemplate>
-            </ItemsControl.Template>
-        </ItemsControl>
+                            <TextBlock Grid.Column="0" 
+                                       Text="{Binding Entry}"
+                                       HorizontalAlignment="Left" 
+                                       VerticalAlignment="Center" 
+                                       Margin="50,2,50,2">
+                                <TextBlock.Style>
+                                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Deleted}" Value="True">
+                                                <Setter Property="Foreground" Value="Red" />
+                                                <Setter Property="TextDecorations" Value="Strikethrough" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Added}" Value="True">
+                                                <Setter Property="Foreground" Value="Green" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>        
+                           </TextBlock>
+
+                            <Button Grid.Column="1" 
+                                    VerticalAlignment="Center" 
+                                    MinWidth="100" 
+                                    Margin="50,2,50,2"
+                                    Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, Path=DataContext.ToggleDeleteCommand}" 
+                                    CommandParameter="{Binding Entry}">
+                                <Button.Style>
+                                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Type Button}}">
+                                        <Setter Property="Content" Value="{x:Static resx:Resources.DELETE_DICTIONARY_ENTRY}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Deleted}" Value="True">
+                                                <Setter Property="Content" Value="{x:Static resx:Resources.RESTORE_DICTIONARY_ENTRY}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>        
+                            </Button>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.Template>
+                    <ControlTemplate>
+                        <Border BorderThickness="{TemplateBinding Border.BorderThickness}"
+                                Padding="{TemplateBinding Control.Padding}"
+                                BorderBrush="{TemplateBinding Border.BorderBrush}"
+                                Background="{TemplateBinding Panel.Background}"
+                                SnapsToDevicePixels="True">
+                            <ScrollViewer Padding="{TemplateBinding Control.Padding}" Focusable="False">
+                                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Border>
+                    </ControlTemplate>
+                </ItemsControl.Template>
+            </ItemsControl>
+        </Grid>
+
+        <Grid Grid.RowSpan="2" 
+              Visibility="{Binding DictionaryControlsUnavailable, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
+            <Viewbox Stretch="Uniform">
+                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Margin="5" >
+                    <TextBlock.Style>
+                        <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                            <Setter Property="Text" Value="x:Static resx:Resources.DICTIONARY_CONTROLS_UNAVAILABLE}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding DictionaryIsPresage}" Value="True">
+                                    <Setter Property="Text" Value="x:Static resx:Resources.DICTIONARY_IS_PRESAGE}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Viewbox>
+        </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This is to fulfil issue #369.

When the suggestion method isn't Basic or NGram hide the dictionary
controls and display a message to explain that is the case.

When the suggestion method is set to Presage display a message about where
the dictionary is and how to access it.