### PR TITLE
Disable combining keys when MultiKeys mode is on

### DIFF
--- a/src/JuliusSweetland.OptiKey/Models/CapturingStateManager.cs
+++ b/src/JuliusSweetland.OptiKey/Models/CapturingStateManager.cs
@@ -17,6 +17,8 @@ namespace JuliusSweetland.OptiKey.Models
         }
 
         private bool capturingMultiKeySelection;
+        private bool multiKeyDownOrLocked;
+
         public bool CapturingMultiKeySelection
         {
             get { return capturingMultiKeySelection; }
@@ -35,6 +37,12 @@ namespace JuliusSweetland.OptiKey.Models
                             : Settings.Default.MultiKeySelectionCaptureEndSoundVolume);
                 }
             }
+        }
+
+        public bool MultiKeyDownOrLocked
+        {
+             get { return multiKeyDownOrLocked; }
+             set { SetProperty(ref multiKeyDownOrLocked, value); }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Models/ICapturingStateManager.cs
+++ b/src/JuliusSweetland.OptiKey/Models/ICapturingStateManager.cs
@@ -5,5 +5,6 @@ namespace JuliusSweetland.OptiKey.Models
     public interface ICapturingStateManager : INotifyPropertyChanged
     {
         bool CapturingMultiKeySelection { get; set; }
+        bool MultiKeyDownOrLocked { get; set; }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Models/KeyEnabledStates.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyEnabledStates.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Linq;
-using System.Windows.Data;
-using JuliusSweetland.OptiKey.Enums;
+﻿using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Services;
 using Prism.Mvvm;
+using System;
+using System.Linq;
+using System.Windows.Data;
 
 namespace JuliusSweetland.OptiKey.Models
 {
@@ -319,6 +319,13 @@ namespace JuliusSweetland.OptiKey.Models
                     && !KeyValues.MultiKeySelectionKeys.Contains(keyValue))
                 {
                     return false;
+                }
+
+                // Multi-key is down/locked, we shouldn't allow combining keys anymore
+                if (capturingStateManager.MultiKeyDownOrLocked
+                    && KeyValues.KeysDisabledWithMultiKeysSelectionIsOn.Contains(keyValue))
+                {
+                    return false; 
                 }
 
                 //Catalan specific rules

--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -263,7 +263,11 @@ namespace JuliusSweetland.OptiKey.Models
                 { Languages.EnglishCanada, defaultList },
                 { Languages.EnglishUK, defaultList },
                 { Languages.EnglishUS, defaultList },
-                { Languages.FrenchFrance, defaultList },
+                { Languages.FrenchFrance, "abcdefghijklmnopqrstuvwxyzçé"
+                                                .ToCharArray()
+                                                .Select(c => new KeyValue(c.ToString(CultureInfo.InvariantCulture)))
+                                                .ToList()
+                },
                 { Languages.GermanGermany, "abcdefghijklmnopqrstuvwxyzß"
                                                 .ToCharArray()
                                                 .Select(c => new KeyValue (c.ToString(CultureInfo.InvariantCulture) ))
@@ -274,8 +278,16 @@ namespace JuliusSweetland.OptiKey.Models
                                                 .Select(c => new KeyValue (c.ToString(CultureInfo.InvariantCulture) ))
                                                 .ToList()
                 },
-                { Languages.ItalianItaly, defaultList },
-                { Languages.PortuguesePortugal, defaultList },
+                { Languages.ItalianItaly, "abcdefghijklmnopqrstuvwxyzî"
+                                                .ToCharArray()
+                                                .Select(c => new KeyValue(c.ToString(CultureInfo.InvariantCulture)))
+                                                .ToList()
+                },
+                { Languages.PortuguesePortugal, "abcdefghijklmnopqrstuvwxyzçà"
+                                                .ToCharArray()
+                                                .Select(c => new KeyValue(c.ToString(CultureInfo.InvariantCulture)))
+                                                .ToList()
+                },
                 { Languages.RussianRussia, "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
                                                 .ToCharArray()
                                                 .Select(c => new KeyValue (c.ToString(CultureInfo.InvariantCulture) ))
@@ -367,9 +379,7 @@ namespace JuliusSweetland.OptiKey.Models
         {
             get
             {
-                List<KeyValue> list = CombiningKeys.Concat(KeysWhichCanBeLockedDown).Distinct().ToList();
-                list.Remove(MultiKeySelectionIsOnKey);
-                return list;
+                return CombiningKeys.Concat(KeysWhichPreventTextCaptureIfDownOrLocked).Distinct().ToList();
             }
         }
 

--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Properties;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using JuliusSweetland.OptiKey.Enums;
-using JuliusSweetland.OptiKey.Properties;
 
 namespace JuliusSweetland.OptiKey.Models
 {
@@ -360,6 +360,16 @@ namespace JuliusSweetland.OptiKey.Models
                     LeftCtrlKey,
                     LeftWinKey
                 };
+            }
+        }
+
+        public static List<KeyValue> KeysDisabledWithMultiKeysSelectionIsOn
+        {
+            get
+            {
+                List<KeyValue> list = CombiningKeys.Concat(KeysWhichCanBeLockedDown).Distinct().ToList();
+                list.Remove(MultiKeySelectionIsOnKey);
+                return list;
             }
         }
 

--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -379,7 +379,7 @@ namespace JuliusSweetland.OptiKey.Models
         {
             get
             {
-                return CombiningKeys.Concat(KeysWhichPreventTextCaptureIfDownOrLocked).Distinct().ToList();
+                return CombiningKeys;
             }
         }
 

--- a/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Extensions;
+using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Observables.TriggerSources;
+using JuliusSweetland.OptiKey.Properties;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
@@ -6,11 +11,6 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using JuliusSweetland.OptiKey.Enums;
-using JuliusSweetland.OptiKey.Extensions;
-using JuliusSweetland.OptiKey.Models;
-using JuliusSweetland.OptiKey.Observables.TriggerSources;
-using JuliusSweetland.OptiKey.Properties;
 
 namespace JuliusSweetland.OptiKey.Services
 {
@@ -355,6 +355,14 @@ namespace JuliusSweetland.OptiKey.Services
                         }
 
                         PublishSelectionResult(result);
+
+                        // if the key is up now, then update the key state
+                        if (keyStateService.KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value == KeyDownStates.Up
+                             && capturingStateManager.MultiKeyDownOrLocked)
+                        {
+                            // this will raise the property changed event and untoggle disabled keys
+                            capturingStateManager.MultiKeyDownOrLocked = false;
+                        }
                     }
                 }
             }

--- a/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Reactive.Linq;
-using System.Reflection;
-using JuliusSweetland.OptiKey.Enums;
+﻿using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
 using log4net;
 using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reflection;
 
 namespace JuliusSweetland.OptiKey.Services
 {
@@ -23,7 +23,8 @@ namespace JuliusSweetland.OptiKey.Services
         private readonly KeyEnabledStates keyEnabledStates;
         private readonly Action<KeyValue> fireKeySelectionEvent;
         private readonly Dictionary<bool, KeyStateServiceState> state = new Dictionary<bool, KeyStateServiceState>();
-        
+        private readonly ICapturingStateManager capturingStateManager;
+
         private bool simulateKeyStrokes;
         private bool turnOnMultiKeySelectionWhenKeysWhichPreventTextCaptureAreReleased;
         
@@ -39,9 +40,10 @@ namespace JuliusSweetland.OptiKey.Services
             Action<KeyValue> fireKeySelectionEvent)
         {
             this.fireKeySelectionEvent = fireKeySelectionEvent;
-            keySelectionProgress = new NotifyingConcurrentDictionary<KeyValue, double>();
-            keyDownStates = new NotifyingConcurrentDictionary<KeyValue, KeyDownStates>();
-            keyEnabledStates = new KeyEnabledStates(this, suggestionService, capturingStateManager, lastMouseActionStateManager, calibrationService);
+            this.capturingStateManager = capturingStateManager;
+            this.keySelectionProgress = new NotifyingConcurrentDictionary<KeyValue, double>();
+            this.keyDownStates = new NotifyingConcurrentDictionary<KeyValue, KeyDownStates>();
+            this.keyEnabledStates = new KeyEnabledStates(this, suggestionService, capturingStateManager, lastMouseActionStateManager, calibrationService);
 
             InitialiseKeyDownStates();
             AddSettingChangeHandlers();
@@ -94,6 +96,11 @@ namespace JuliusSweetland.OptiKey.Services
                     Log.DebugFormat("Changing key down state of '{0}' key from {1} to UP.", keyValue,
                         KeyDownStates[keyValue].Value == Enums.KeyDownStates.Down ? "DOWN" : "LOCKED DOWN");
                     KeyDownStates[keyValue].Value = Enums.KeyDownStates.Up;
+                }
+
+                if (keyValue == KeyValues.MultiKeySelectionIsOnKey)
+                {
+                    capturingStateManager.MultiKeyDownOrLocked = !(KeyDownStates[keyValue].Value == Enums.KeyDownStates.Up);
                 }
             }
         }

--- a/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
@@ -130,6 +130,11 @@ namespace JuliusSweetland.OptiKey.Services
                 || (!SimulateKeyStrokes && Settings.Default.MultiKeySelectionLockedDownWhenNotSimulatingKeyStrokes))
                     ? Enums.KeyDownStates.LockedDown
                     : Enums.KeyDownStates.Up;
+
+            if (KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value != Enums.KeyDownStates.Up)
+            {
+                capturingStateManager.MultiKeyDownOrLocked = true;
+            }
         }
 
         private void AddSettingChangeHandlers()

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
-using JuliusSweetland.OptiKey.Enums;
+﻿using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.UI.Utilities;
 using JuliusSweetland.OptiKey.UI.ViewModels;
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace JuliusSweetland.OptiKey.UI.Controls
 {
@@ -92,13 +91,21 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             Action<KeyDownStates, bool> calculateDisplayShiftDownText = (shiftDownState, capturingMultiKeySelection) => 
                     DisplayShiftDownText = shiftDownState == KeyDownStates.LockedDown 
                     || (shiftDownState == KeyDownStates.Down && !capturingMultiKeySelection);
+
             var capturingMultiKeySelectionSubscription = capturingStateManager
                 .OnPropertyChanges(csm => csm.CapturingMultiKeySelection)
                 .Subscribe(value => calculateDisplayShiftDownText(keyStateService.KeyDownStates[KeyValues.LeftShiftKey].Value, value));
             onUnloaded.Add(capturingMultiKeySelectionSubscription);
+
+            // if multikeys is on, calculate if key should be disabled/enabled
+            var multikeyStateSubscription = capturingStateManager
+                .OnPropertyChanges(state => state.MultiKeyDownOrLocked)
+                .Subscribe(_ => calculateIsEnabled());
+
             var leftShiftKeyStateSubscription = keyStateService.KeyDownStates[KeyValues.LeftShiftKey]
                 .OnPropertyChanges(sds => sds.Value)
                 .Subscribe(value => calculateDisplayShiftDownText(value, capturingStateManager.CapturingMultiKeySelection));
+
             onUnloaded.Add(leftShiftKeyStateSubscription);
             calculateDisplayShiftDownText(keyStateService.KeyDownStates[KeyValues.LeftShiftKey].Value, capturingStateManager.CapturingMultiKeySelection);
             


### PR DESCRIPTION
This PR will disable accent combining keys if MultiKeys mode is turned on (either in single word mode, or locked down mode) in many keyboards we support. Due to the natures of how these accent combining keys work, they couldn't really fit into the MultiKey selection workflow, hence we will disable those keys to avoid confusions.

However, there are quite a number of keyboards that contain _on-board_ accent keys, for example, the "Ç" and "é" in French keyboard. In some of the keyboards, these on-board keys are enabled for multi-key selection, while some are not. To be consistent, this PR will treat all on-board accent keys as multi-key enabled (and also adding them to the multi-key enabled key list). 

In addition, we're going to disable the left "Control", "Alt", and "Win" keys. These keys are in grey area since they aren't really useful in multi-key selection mode, so they should be turned off as well. But we can revert this change if necessary.