### PR TITLE
Fixes #396 - OptiKey starts holding down shift key

### DIFF
--- a/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyboardOutputService.cs
@@ -685,6 +685,7 @@ namespace JuliusSweetland.OptiKey.Services
                     && keyStateService.KeyDownStates[KeyValues.LeftShiftKey].Value == KeyDownStates.Up)
                 {
                     keyStateService.KeyDownStates[KeyValues.LeftShiftKey].Value = KeyDownStates.Down;
+                    publishService.KeyUp(VirtualKeyCode.LSHIFT); // Do not keep 'real' shift down when app start with a ShiftAware Keyboard #396
                     if (fireKeySelectionEvent != null) fireKeySelectionEvent(KeyValues.LeftShiftKey);
                     return;
                 }


### PR DESCRIPTION
When Reinstate Auto Capitalisation, do not keep left shift down. Register the model with the down value but publish an up value.