### PR TITLE
Fixes #398 - OptiKey blink floating window and then jump to docked to…

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/Windows/MainWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Windows/MainWindow.xaml.cs
@@ -85,6 +85,9 @@ namespace JuliusSweetland.OptiKey.UI.Windows
             });
 
             Title = string.Format(Properties.Resources.WINDOW_TITLE, DiagnosticInfo.AssemblyVersion);
+
+            Width = 0;
+            Height = 0;
         }
 
         public IWindowManipulationService WindowManipulationService { get; set; }


### PR DESCRIPTION
When the main window is created, it has a NaN value for both Width and Height. This value allows a render of a floating window in the center of the screen before the final position and size of the main window are defined.

Setting the Width and Height on the constructor to zero solves it. The main window is only rendered in its final position and size.

