### PR TITLE
Fix for an error in MultiKeySelection

### DIFF
--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -479,7 +479,9 @@ namespace JuliusSweetland.OptiKey.Models
 
         public static List<KeyValue> MultiKeySelectionKeys
         {
-            get { return multiKeySelectionKeys[Settings.Default.KeyboardAndDictionaryLanguage]; }
+            get { return multiKeySelectionKeys.Keys.Contains(Settings.Default.KeyboardAndDictionaryLanguage) 
+                        ? multiKeySelectionKeys[Settings.Default.KeyboardAndDictionaryLanguage]
+                        : new List<KeyValue>(); }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
@@ -145,6 +145,7 @@ namespace JuliusSweetland.OptiKey.Services
                             Log.Debug("Selection mode is KEY and the key on which the trigger occurred is enabled.");
 
                             if (MultiKeySelectionSupported
+                                && keyStateService.KeyEnabledStates[KeyValues.MultiKeySelectionIsOnKey]
                                 && keyStateService.KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value.IsDownOrLockedDown()
                                 && triggerSignal.PointAndKeyValue.KeyValue != null
                                 && KeyValues.MultiKeySelectionKeys.Contains(triggerSignal.PointAndKeyValue.KeyValue)


### PR DESCRIPTION
As discussed in #401, when MultiKeySelection is enabled in a
language where the KeyValues.MultiKeySelectionKeys does not have a set
specified it crashes.

KeyValues.MultiKeySelectionKeys will now return an empty collection if the key
language is not found and the EnabledState of the MultiKeySelectionIsOnKey
is checked before multi-key selection is performed.