### PR TITLE
Fix keyboard freeze due to incorrect input request count

### DIFF
--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -785,6 +785,7 @@ namespace JuliusSweetland.OptiKey
                         keySelectionSb.Append(string.Format(" ({0})", Settings.Default.KeySelectionTriggerMouseDownUpButton));
                         break;
                 }
+
                 message.AppendLine(string.Format(OptiKey.Properties.Resources.KEY_SELECTION_TRIGGER_DESCRIPTION, keySelectionSb));
 
                 var pointSelectionSb = new StringBuilder();
@@ -947,6 +948,7 @@ namespace JuliusSweetland.OptiKey
         }
 
         #endregion
+
         #region Clean Up Extracted CommuniKate Files If Staged For Deletion
 
         private static void CleanupAndPrepareCommuniKateInitialState()
@@ -1077,6 +1079,7 @@ namespace JuliusSweetland.OptiKey
                         "Disabling MaryTTS and using System Voice '{1}' instead.", ExpectedMaryTTSLocationSuffix, Settings.Default.SpeechVoice);
                     Settings.Default.MaryTTSEnabled = false;
 
+                    inputService.RequestSuspend();
                     mainViewModel.RaiseToastNotification(OptiKey.Properties.Resources.MARYTTS_UNAVAILABLE,
                         string.Format(OptiKey.Properties.Resources.USING_DEFAULT_VOICE, Settings.Default.SpeechVoice),
                         NotificationTypes.Error, () =>

--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -803,8 +803,8 @@ namespace JuliusSweetland.OptiKey
                         pointSelectionSb.Append(string.Format(" ({0})", Settings.Default.PointSelectionTriggerMouseDownUpButton));
                         break;
                 }
-                message.AppendLine(string.Format(OptiKey.Properties.Resources.POINT_SELECTION_DESCRIPTION, pointSelectionSb));
 
+                message.AppendLine(string.Format(OptiKey.Properties.Resources.POINT_SELECTION_DESCRIPTION, pointSelectionSb));
                 message.AppendLine(OptiKey.Properties.Resources.MANAGEMENT_CONSOLE_DESCRIPTION);
                 message.AppendLine(OptiKey.Properties.Resources.WEBSITE_DESCRIPTION);
 
@@ -1001,6 +1001,7 @@ namespace JuliusSweetland.OptiKey
                         "Disabling MaryTTS and using System Voice '{0}' instead.", Settings.Default.SpeechVoice);
                     Settings.Default.MaryTTSEnabled = false;
 
+                    inputService.RequestSuspend();
                     mainViewModel.RaiseToastNotification(OptiKey.Properties.Resources.MARYTTS_UNAVAILABLE,
                         string.Format(OptiKey.Properties.Resources.USING_DEFAULT_VOICE, Settings.Default.SpeechVoice),
                         NotificationTypes.Error, () =>

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -478,14 +478,23 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
 
         private void ValidateMaryTTSVoiceSettings()
         {
-            if (MaryTTSEnabled)
+            if (MaryTTSEnabled && 
+                (!File.Exists(MaryTTSLocation) || !MaryTTSLocation.EndsWith(ExpectedMaryTTSLocationSuffix)))
             {
-                if (!File.Exists(MaryTTSLocation) || !MaryTTSLocation.EndsWith(ExpectedMaryTTSLocationSuffix))
+                // The current MaryTTS setting won't be able to start, try to fix the problem now.
+                if (Settings.Default.MaryTTSEnabled 
+                    && File.Exists(Settings.Default.MaryTTSLocation) 
+                    && Settings.Default.MaryTTSLocation.EndsWith(ExpectedMaryTTSLocationSuffix))
                 {
-                    // MaryTTS won't be able to start, revert changes
+                    // if it's previously enabled and the service location is correct, fallback to
+                    // the correct setting.
+                    MaryTTSLocation = Settings.Default.MaryTTSLocation;
+                }
+                else
+                {
+                    // if fallback settings isn't valid either, turn off this setting
                     MaryTTSEnabled = false;
                     MaryTTSLocation = "";
-                    MaryTTSVoice = "";
                 }
             }
         }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/SoundsViewModel.cs
@@ -6,6 +6,7 @@ using JuliusSweetland.OptiKey.Services;
 using log4net;
 using Prism.Commands;
 using Prism.Mvvm;
+using System.IO;
 
 namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
 {
@@ -14,6 +15,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         #region Private Member Vars
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private const string ExpectedMaryTTSLocationSuffix = @"\bin\marytts-server.bat";
 
         private IAudioService audioService;
 
@@ -386,7 +388,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             get
             {
                 return Settings.Default.MaryTTSEnabled != MaryTTSEnabled
-                    || Settings.Default.MaryTTSLocation != MaryTTSLocation; ;
+                    || Settings.Default.MaryTTSLocation != MaryTTSLocation;
             }
         }
 
@@ -441,6 +443,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
 
         public void ApplyChanges()
         {
+            ValidateMaryTTSVoiceSettings();
+
             Settings.Default.SpeechVoice = SpeechVoice;
             Settings.Default.SpeechVolume = SpeechVolume;
             Settings.Default.SpeechRate = SpeechRate;
@@ -470,6 +474,20 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.MouseDoubleClickSoundVolume = MouseDoubleClickSoundVolume;
             Settings.Default.MouseScrollSoundFile = MouseScrollSoundFile;
             Settings.Default.MouseScrollSoundVolume = MouseScrollSoundVolume;
+        }
+
+        private void ValidateMaryTTSVoiceSettings()
+        {
+            if (MaryTTSEnabled)
+            {
+                if (!File.Exists(MaryTTSLocation) || !MaryTTSLocation.EndsWith(ExpectedMaryTTSLocationSuffix))
+                {
+                    // MaryTTS won't be able to start, revert changes
+                    MaryTTSEnabled = false;
+                    MaryTTSLocation = "";
+                    MaryTTSVoice = "";
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
For the background of the problem, see descriptions of issue #404. The freeze was caused by missed calculation on the number of the remaining pause requests to the keyboard, such that the keyboard would not be resumed for input if such an error occurs.

The root cause is that in `App.xaml.cs`, when we fail to initiate the MaryTTS service, we only ask `inputService` to resume the requested pause, but that's the porblem -- there's no service suspend request being made prior to the resume request. This will cause the downstream problem when finishing a multi-key selection, the multi-key selection service would then request a release, however, at this moment the requested pause count has dropped below 0 (because the failed MaryTTS service call messed up the count number), and we won't actually resume the input service because we only do so when pause count is reduced to exactly 0.

The solution is to request an input service pause before we get a chance to request the release, and this is also the pattern used by other service launching/validation code happening in the same workflow. In addition, we will force checking the MaryTTS settings before allowing them to be saved -- if the MaryTTS service isn't available, we will automatically toggle back the "MaryTTS Enabled" setting, such that unless users set a valid MaryTTS service location, they service will then be default to "False". 