### PR TITLE
Make "Manual Mode" usable if eye tracker's failed to launch

### DIFF
--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -210,13 +210,13 @@ namespace JuliusSweetland.OptiKey
                 {
                     mainWindowManipulationService.SizeAndPositionInitialised -= sizeAndPositionInitialised; //Ensure this handler only triggers once
                     await ShowSplashScreen(inputService, audioService, mainViewModel);
+                    await mainViewModel.RaisePreloadErrorsToastNotification();
                     await AttemptToStartMaryTTSService(inputService, audioService, mainViewModel);
                     await AlertIfPresageBitnessOrBootstrapOrVersionFailure(presageInstallationProblem, inputService, audioService, mainViewModel);
 
                     inputService.RequestResume(); //Start the input service
 
                     // Raise any preload errors in the toast notification now.
-                    mainViewModel.RaisePreloadErrorsToastNotification();
 
                     await CheckForUpdates(inputService, audioService, mainViewModel);
                 };

--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -203,7 +203,7 @@ namespace JuliusSweetland.OptiKey
 
                 //Show the main window
                 mainWindow.Show();
-
+                
                 //Display splash screen and check for updates (and display message) after the window has been sized and positioned for the 1st time
                 EventHandler sizeAndPositionInitialised = null;
                 sizeAndPositionInitialised = async (_, __) =>
@@ -214,6 +214,9 @@ namespace JuliusSweetland.OptiKey
                     await AlertIfPresageBitnessOrBootstrapOrVersionFailure(presageInstallationProblem, inputService, audioService, mainViewModel);
 
                     inputService.RequestResume(); //Start the input service
+
+                    // Raise any preload errors in the toast notification now.
+                    mainViewModel.RaisePreloadErrorsToastNotification();
 
                     await CheckForUpdates(inputService, audioService, mainViewModel);
                 };

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace JuliusSweetland.OptiKey.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -827,7 +827,7 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("CRASH_TITLE", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Croatian (Croatia) / Hrvatski (Hrvatska).
         /// </summary>
@@ -3337,7 +3337,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Muli-key selection ending:.
+        ///   Looks up a localized string similar to Multi-key selection ending:.
         /// </summary>
         public static string MULTI_KEY_SELECTION_ENDING_SOUND_LABEL {
             get {
@@ -3356,7 +3356,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Muli-key selection starting:.
+        ///   Looks up a localized string similar to Multi-key selection starting:.
         /// </summary>
         public static string MULTI_KEY_SELECTION_STARTING_SOUND_LABEL {
             get {
@@ -3803,6 +3803,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string PORTUGUESE_PORTUGAL_SPLIT_WITH_NEWLINE {
             get {
                 return ResourceManager.GetString("PORTUGUESE_PORTUGAL_SPLIT_WITH_NEWLINE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uh-oh! We&apos;ve encountered the following errors during the launch:.
+        /// </summary>
+        public static string PRELOAD_CRASH_TITLE {
+            get {
+                return ResourceManager.GetString("PRELOAD_CRASH_TITLE", resourceCulture);
             }
         }
         
@@ -4850,7 +4859,7 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Time until point becomes irrelevent (ms):.
+        ///   Looks up a localized string similar to Time until point becomes irrelevant (ms):.
         /// </summary>
         public static string TIME_UNTIL_POINT_BECOMES_IRRELEVENT_LABEL {
             get {

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -1992,4 +1992,7 @@ such as "DB Browser for SQLite" (which is a free program).</value>
   <data name="USE_QWERTY_KEYBOARD_LAYOUT" xml:space="preserve">
     <value>Use QWERTY keyboard layout (default)</value>
   </data>
+  <data name="PRELOAD_CRASH_TITLE" xml:space="preserve">
+    <value>Uh-oh! We've encountered the following errors during the launch:</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -1993,12 +1993,21 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         }
 
         private void HandleServiceError(object sender, Exception exception)
-        {
-            Log.Error("Error event received from service. Raising ErrorNotificationRequest and playing ErrorSoundFile (from settings)", exception);
+        {                        
+	    audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
 
-            inputService.RequestSuspend();
-            audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
-            RaiseToastNotification(Resources.CRASH_TITLE, exception.Message, NotificationTypes.Error, () => inputService.RequestResume());
+            if (ToastNotification != null)
+            {
+                // Only raise toast notifications if it has been initialized
+		Log.Error("Error event received from service. Raising ErrorNotificationRequest and playing ErrorSoundFile (from settings)", exception);
+		    
+                inputService.RequestSuspend();
+                RaiseToastNotification(Resources.CRASH_TITLE, exception.Message, NotificationTypes.Error, () => inputService.RequestResume());
+            }
+	    else
+	    {
+		Log.Error("Error event received from service beore main window is initialized and shown, only playing ErrorSoundFile (from settings)", exception);
+	    }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.ServiceModel;
 using System.Windows;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
-using JuliusSweetland.OptiKey.UI.Controls;
 using JuliusSweetland.OptiKey.UI.ViewModels.Keyboards;
 using JuliusSweetland.OptiKey.UI.ViewModels.Keyboards.Base;
 
@@ -1986,6 +1984,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             ShowCursor = false;
             MagnifyAtPoint = null;
             MagnifiedPointSelectionAction = null;
+
             if (keyStateService.KeyDownStates[KeyValues.MouseMagnifierKey].Value == KeyDownStates.Down)
             {
                 keyStateService.KeyDownStates[KeyValues.MouseMagnifierKey].Value = KeyDownStates.Up; //Release magnifier if down but not locked down
@@ -1993,21 +1992,22 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         }
 
         private void HandleServiceError(object sender, Exception exception)
-        {                        
-	    audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
-
+        {
             if (ToastNotification != null)
             {
                 // Only raise toast notifications if it has been initialized
-		Log.Error("Error event received from service. Raising ErrorNotificationRequest and playing ErrorSoundFile (from settings)", exception);
-		    
+                Log.Error("Error event received from service. Raising ErrorNotificationRequest and playing ErrorSoundFile (from settings)", exception);
+
+                audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
                 inputService.RequestSuspend();
                 RaiseToastNotification(Resources.CRASH_TITLE, exception.Message, NotificationTypes.Error, () => inputService.RequestResume());
             }
-	    else
-	    {
-		Log.Error("Error event received from service beore main window is initialized and shown, only playing ErrorSoundFile (from settings)", exception);
-	    }
+            else
+            {
+                Log.Error("Error event received from service beore main window is initialized and shown, only playing ErrorSoundFile (from settings)", exception);
+
+                StorePreloadErrors(exception.Message);
+            }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
@@ -612,6 +612,12 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             {
                 ToastNotification(this, new NotificationEventArgs(title, content, notificationType, callback));
             }
+            else
+            {
+                // Raise errors before the ToastNotification is initialized yet, 
+                // in this case, just raise callback to clean the rest up for now.
+                callback();
+            }
         }
 
         #endregion


### PR DESCRIPTION
This PR is aimed to resolve issue #408, where if the eye tracker can't be activated (e.g. the device is not connected, the device's failed to initialize, etc.), the input service isn't properly resumed in the initialization process, and as a result, users won't be able to switch to "Manual Mode" because the shield count is incorrectly set during the initialization process. 

The root cause is actually the same to issue #409: the eye tracker service is initialized before the `ToastNoticifcationPopup` is loaded; and when the activation failed, we would try to raise a `ToastNotificationPopup` to inform the users, however, since the popup's not available yet at that moment, the popup will not be raised. But the effort to raise the popup have added a shield on top of the keyboard, but the shield is never lowered (the callback to the popup is responsible for lowering the shield, since the popup is never launched, the callback is never invoked either), which will then block the workflow to switch to the manual mode.

The solution is to add rail guards around the error handlers: 1. if the popup hasn't been loaded yet, don't try to raise it and bring up the shield; 2. if someone tries to bring up the popup prematurely in the future, we will fallback on calling the callback directly to clean anything up, such that we won't accidentally block the keyboard because the clean-up callback is not raised. 

Be noted that this is not the full solution to issue #409, it's kind of difficult to make sure the popup is loaded before all the services are initialized -- there're quite entangled code dependencies and assumptions made in the app-launching code, so I would envision a little bit more sophisticated fix to issue #409: (the easier solution) save off all the errors encountered during service initialization, then bring up the toast notification after the main window is fully loaded (before or after the splash popup); (the harder solution) if eye track devices are failed to activate, fallback to the mouse pointer mode (aka the Manual Mode).   