### PR TITLE
Raise notifications sequentially

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/Controls/ToastNotificationPopup.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/ToastNotificationPopup.cs
@@ -21,7 +21,6 @@ namespace JuliusSweetland.OptiKey.UI.Controls
         private Screen screen;
         private ToastNotification toastNotification;
         private Queue<Models.NotificationEventArgs> messageQueue;
-        private int openPopupCounts;
 
         #endregion
 

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -2019,9 +2019,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         private void HandleServiceError(object sender, Exception exception)
         {
             Log.Error("Error event received from service. Raising ErrorNotificationRequest and playing ErrorSoundFile (from settings)", exception);
+
             inputService.RequestSuspend();
-            audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
-            RaiseToastNotification(Resources.CRASH_TITLE, exception.Message, NotificationTypes.Error, () => inputService.RequestResume());
+
+            if (RaiseToastNotification(Resources.CRASH_TITLE, exception.Message, NotificationTypes.Error, () => inputService.RequestResume()))
+            {
+                audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
+            }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
@@ -622,11 +622,14 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             }
         }
 
-        internal void RaiseToastNotification(string title, string content, NotificationTypes notificationType, Action callback)
+        internal bool RaiseToastNotification(string title, string content, NotificationTypes notificationType, Action callback)
         {
+            bool notificationRaised = false;
+
             if (ToastNotification != null)
             {
                 ToastNotification(this, new NotificationEventArgs(title, content, notificationType, callback));
+                notificationRaised = true;
             }
             else
             {
@@ -638,6 +641,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 //Error raised before the ToastNotification is initialised. Call callback delegate to ensure everything continues.
                 callback();
             }
+
+            return notificationRaised;
         }
 
         internal async Task<bool> RaiseAnyPendingErrorToastNotifications()


### PR DESCRIPTION
This PR is to address the new problems found with issue #408. 

Right now there're 2 things wrong with the Roast Notification Popup:
- If 2 notifications are raised simultaneously (e.g. a normal information popup + an error/warning popup), only the 2nd notification will be displayed. This is because only 1 popup form is brought up, but its content are set by the 1st notification request and then overridden by the 2nd popup request. This is slightly annoying because usually it is the informative popup request that's overridden, so we lose 1 popup but are still able to see the error popup.
- The 2nd issue is more serious -- before raising the notification, we usually raise a shield to protect the keyboard from being interact-able when the popup is on, and the shield will be lowered after the popup is gone. However, when 2 notification are raised together, only 1 popup-close-callback will be invoked, causing the shield raised by the 1st notification up forever, and make the keyboard unusable if this takes place. 

Now in this PR, we're going to revise how the popup are raised. We will use the Producer-Consumer pattern, such that all notifications that are raised together will be queued and displayed in sequential orders. And since they'll be raised one after the other, each of them will invoke the post-close-callback and clean up any shields raised by the pre-raise code. 