### PR TITLE
Fix invisible whole-screen window being selected when UIAccess enabled

### DIFF
--- a/OptiKey.sln
+++ b/OptiKey.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		docs\Installing certificate on cryptographic card.pdf = docs\Installing certificate on cryptographic card.pdf
 		docs\Localisation.xls = docs\Localisation.xls
 		docs\Localize.md = docs\Localize.md
+		docs\Look to scroll overlay flickering.txt = docs\Look to scroll overlay flickering.txt
 		docs\Physical setup of eye trackers.txt = docs\Physical setup of eye trackers.txt
 		docs\UiAccess.txt = docs\UiAccess.txt
 		docs\Unicode standard for diacritic marks.pdf = docs\Unicode standard for diacritic marks.pdf

--- a/docs/Look to scroll overlay flickering.txt
+++ b/docs/Look to scroll overlay flickering.txt
@@ -1,0 +1,6 @@
+The overlay that WPF's debugging tools add to our own "look to scroll" overlay window can cause
+flickering or jumpy scrolling behavior as the WPF overlay competes with the actual window 
+underneath to be seen as "front-most" at the current point source position. This can be fixed at 
+runtime by toggling off the "Show runtime tools in application" toolbar button in Visual Studio's
+Live Visual Tree pane. There's also a setting in Visual Studio of the same name under 
+Tools > Settings > Debugging > General > "Enable UI Debugging Tools for XAML" that can be disabled.

--- a/docs/UiAccess.txt
+++ b/docs/UiAccess.txt
@@ -14,3 +14,9 @@ Requirements to work:
 	2.Signed assembly (by a trusted certificate) - use the Signing tab on project properties to sign manifests (deployment and application manifests) AND assembly
 	3."Secure location" - Click2Speak appears to install a shill in the ClickOnce location and the rest of the files in Program Files
 	4.UiAccess="True" flag - this prevents debugging so set in Release mode Post-Build/Pre-Publish* only
+
+Refer to "Certificates and signing notes.txt" for steps to create and sign OptiKey.exe using a test certificate.
+
+You can get around the "Secure location" requirement and run the OptiKey.exe that's in the build output folder (and that's been signed)
+with UIAccess enabled by configuring local/group policy. Refer to: 
+https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-account-control-only-elevate-uiaccess-applications-that-are-installed-in-secure-locations

--- a/src/JuliusSweetland.OptiKey/Native/PInvoke.cs
+++ b/src/JuliusSweetland.OptiKey/Native/PInvoke.cs
@@ -101,5 +101,20 @@ namespace JuliusSweetland.OptiKey.Native
 
         [DllImport("dwmapi.dll")]
         public static extern int DwmGetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE dwAttribute, out RECT pvAttribute, int cbAttribute);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWindowVisible(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsIconic(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumChildWindows(IntPtr hwndParent, EnumWindowsProc lpEnumFunc, int lParam);
     }
 } 


### PR DESCRIPTION
-  Filter out the lock screen, Start screen, and desktop wallpaper manager from window selection.
- Take into account the top-level windows left around by UWP apps even while the app isn't running. Use their CoreWindows in the selection process instead.
- Add a few notes about getting OptiKey running with UIAccess
- Get rid of WS_EX_NOACTIVATE check. This was to fix a problem only occurring during development when running out of Visual Studio and was due to the presence of WPF's debugging overlay window. Rather than possibly excluding legitimate windows that could otherwise be selected just to fix something only a developer would see, I've gotten rid of the check and just added some notes that hopefully a developer will find if they run into the problem.
- Fix potential exception in GetFrontmostWindow due to lazy iteration. hWnds.Any() returned true, the window was immediately closed by the user afterwards, and then it proceeded to try to call hWnds.First().