### PR TITLE
451 look to scroll bug

### DIFF
--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -1072,7 +1072,7 @@
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <SubType>Designer</SubType>
-      <LastGenOutput>Settings1.Designer.cs</LastGenOutput>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -2734,6 +2734,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Stop scrolling upon switching keyboards:.
+        /// </summary>
+        public static string LOOK_TO_SCROLL_DEACTIVATE_UPON_SWITCHING_KEYBOARDS_LABEL {
+            get {
+                return ResourceManager.GetString("LOOK_TO_SCROLL_DEACTIVATE_UPON_SWITCHING_KEYBOARDS_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invert scrolling direction:.
         /// </summary>
         public static string LOOK_TO_SCROLL_DIRECTION_INVERTED_LABEL {

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -2889,6 +2889,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatically resume scrolling afterwards:.
+        /// </summary>
+        public static string LOOK_TO_SCROLL_RESUME_AFTER_CHOOSING_POINT_FOR_MOUSE_LABEL {
+            get {
+                return ResourceManager.GetString("LOOK_TO_SCROLL_RESUME_AFTER_CHOOSING_POINT_FOR_MOUSE_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show overlay window (requires restart):.
         /// </summary>
         public static string LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL {
@@ -2930,6 +2939,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string LOOK_TO_SCROLL_SPEED_KEY_TEXT_SLOW {
             get {
                 return ResourceManager.GetString("LOOK_TO_SCROLL_SPEED_KEY_TEXT_SLOW", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stop scrolling when choosing where to move, click or drag the mouse:.
+        /// </summary>
+        public static string LOOK_TO_SCROLL_SUSPEND_BEFORE_CHOOSING_POINT_FOR_MOUSE_LABEL {
+            get {
+                return ResourceManager.GetString("LOOK_TO_SCROLL_SUSPEND_BEFORE_CHOOSING_POINT_FOR_MOUSE_LABEL", resourceCulture);
             }
         }
         

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -2041,6 +2041,12 @@ such as "DB Browser for SQLite" (which is a free program).</value>
   <data name="LOOK_TO_SCROLL_BRING_WINDOW_TO_FRONT_AFTER_CHOOSING_SCREENPOINT_LABEL" xml:space="preserve">
     <value>After choosing screen point, bring any window there to the front:</value>
   </data>
+  <data name="LOOK_TO_SCROLL_SUSPEND_BEFORE_CHOOSING_POINT_FOR_MOUSE_LABEL" xml:space="preserve">
+    <value>Stop scrolling when choosing where to move, click or drag the mouse:</value>
+  </data>
+  <data name="LOOK_TO_SCROLL_RESUME_AFTER_CHOOSING_POINT_FOR_MOUSE_LABEL" xml:space="preserve">
+    <value>Automatically resume scrolling afterwards:</value>
+  </data>
   <data name="LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL" xml:space="preserve">
     <value>Show overlay window (requires restart):</value>
   </data>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -2047,6 +2047,9 @@ such as "DB Browser for SQLite" (which is a free program).</value>
   <data name="LOOK_TO_SCROLL_RESUME_AFTER_CHOOSING_POINT_FOR_MOUSE_LABEL" xml:space="preserve">
     <value>Automatically resume scrolling afterwards:</value>
   </data>
+  <data name="LOOK_TO_SCROLL_DEACTIVATE_UPON_SWITCHING_KEYBOARDS_LABEL" xml:space="preserve">
+    <value>Stop scrolling upon switching keyboards:</value>
+  </data>
   <data name="LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL" xml:space="preserve">
     <value>Show overlay window (requires restart):</value>
   </data>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -2361,6 +2361,19 @@ namespace JuliusSweetland.OptiKey.Properties {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool LookToScrollDeactivateUponSwitchingKeyboards {
+            get {
+                return ((bool)(this["LookToScrollDeactivateUponSwitchingKeyboards"]));
+            }
+            set {
+                this["LookToScrollDeactivateUponSwitchingKeyboards"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public bool LookToScrollShowOverlayWindow {
             get {
                 return ((bool)(this["LookToScrollShowOverlayWindow"]));

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -2335,6 +2335,32 @@ namespace JuliusSweetland.OptiKey.Properties {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool LookToScrollSuspendBeforeChoosingPointForMouse {
+            get {
+                return ((bool)(this["LookToScrollSuspendBeforeChoosingPointForMouse"]));
+            }
+            set {
+                this["LookToScrollSuspendBeforeChoosingPointForMouse"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool LookToScrollResumeAfterChoosingPointForMouse {
+            get {
+                return ((bool)(this["LookToScrollResumeAfterChoosingPointForMouse"]));
+            }
+            set {
+                this["LookToScrollResumeAfterChoosingPointForMouse"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public bool LookToScrollShowOverlayWindow {
             get {
                 return ((bool)(this["LookToScrollShowOverlayWindow"]));

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -1189,6 +1189,12 @@
     <Setting Name="LookToScrollBringWindowToFrontAfterChoosingScreenPoint" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="LookToScrollSuspendBeforeChoosingPointForMouse" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="LookToScrollResumeAfterChoosingPointForMouse" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="LookToScrollShowOverlayWindow" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -1195,6 +1195,9 @@
     <Setting Name="LookToScrollResumeAfterChoosingPointForMouse" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="LookToScrollDeactivateUponSwitchingKeyboards" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="LookToScrollShowOverlayWindow" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.LookToScroll.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.LookToScroll.cs
@@ -958,6 +958,15 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             return resumeAction;
         }
 
+        private void DeactivateLookToScrollUponSwitchingKeyboards()
+        {
+            if (Settings.Default.LookToScrollDeactivateUponSwitchingKeyboards)
+            {
+                keyStateService.KeyDownStates[KeyValues.LookToScrollActiveKey].Value = KeyDownStates.Up;
+                Log.Info("Look to scroll is no longer active.");
+            }
+        }
+
         private Rect GetVirtualScreenBoundsInPixels()
         {
             return new Rect

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.LookToScroll.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.LookToScroll.cs
@@ -159,7 +159,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                     if (Settings.Default.LookToScrollBringWindowToFrontAfterChoosingScreenPoint)
                     {
-                        IntPtr hWnd = GetHwndForFrontmostWindowAtPoint(point.Value);
+                        IntPtr hWnd = HideCursorAndGetHwndForFrontmostWindowAtPoint(point.Value);
 
                         if (hWnd == IntPtr.Zero)
                         {
@@ -198,7 +198,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     }
                     else
                     {
-                        IntPtr hWnd = GetHwndForFrontmostWindowAtPoint(point.Value);
+                        IntPtr hWnd = HideCursorAndGetHwndForFrontmostWindowAtPoint(point.Value);
 
                         if (hWnd == IntPtr.Zero)
                         {
@@ -234,7 +234,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 {
                     Log.InfoFormat("User chose {0} as the first corner.", firstCorner.Value);
 
-                    IntPtr firstHWnd = GetHwndForFrontmostWindowAtPoint(firstCorner.Value);
+                    IntPtr firstHWnd = HideCursorAndGetHwndForFrontmostWindowAtPoint(firstCorner.Value);
 
                     if (firstHWnd == IntPtr.Zero)
                     {
@@ -252,7 +252,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                             {
                                 Log.InfoFormat("User chose {0} as the second corner.", secondCorner.Value);
 
-                                IntPtr secondHWnd = GetHwndForFrontmostWindowAtPoint(secondCorner.Value);
+                                IntPtr secondHWnd = HideCursorAndGetHwndForFrontmostWindowAtPoint(secondCorner.Value);
                                 var rect = new Rect(firstCorner.Value, secondCorner.Value);
 
                                 if (secondHWnd == IntPtr.Zero)
@@ -305,9 +305,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
         private IntPtr GetHwndForFrontmostWindowAtPoint(Point point)
         {
-            // Make sure the cursor is hidden or else it may be picked as the front-most "window"!
-            ShowCursor = false;
-
             IntPtr shellWindow = PInvoke.GetShellWindow();
 
             Func<IntPtr, bool> criteria = hWnd => 
@@ -353,6 +350,14 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             windows = Static.Windows.ReplaceUWPTopLevelWindowsWithCoreWindowChildren(windows);
             windows = windows.Where(criteria).ToList();
             return Static.Windows.GetFrontmostWindow(windows);
+        }
+
+        private IntPtr HideCursorAndGetHwndForFrontmostWindowAtPoint(Point point)
+        {
+            // Make sure the cursor is hidden or else it may be picked as the front-most "window"!
+            ShowCursor = false;
+
+            return GetHwndForFrontmostWindowAtPoint(point);
         }
 
         private void ChooseCustomLookToScrollBoundsTarget(Action<bool> callback)

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -409,6 +409,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         private void HandleFunctionKeySelectionResult(KeyValue singleKeyValue)
         {
             var currentKeyboard = Keyboard;
+            Action resumeLookToScroll;
 
             switch (singleKeyValue.FunctionKey.Value)
             {
@@ -914,6 +915,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                 case FunctionKeys.MouseDrag:
                     Log.Info("Mouse drag selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(firstFinalPoint =>
                     {
                         if (firstFinalPoint != null)
@@ -974,6 +976,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                                         }
 
                                         ResetAndCleanupAfterMouseAction();
+                                        resumeLookToScroll();
                                     };
 
                                     if (keyStateService.KeyDownStates[KeyValues.MouseMagnifierKey].Value.IsDownOrLockedDown())
@@ -1011,6 +1014,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                             {
                                 keyStateService.KeyDownStates[KeyValues.MouseMagnifierKey].Value = KeyDownStates.Up; //Release magnifier if down but not locked down
                             }
+                            resumeLookToScroll();
                         }
 
                         //Reset and clean up
@@ -1181,6 +1185,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                 case FunctionKeys.MouseMoveAndLeftClick:
                     Log.Info("Mouse move and left click selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1204,11 +1209,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     });
                     break;
 
                 case FunctionKeys.MouseMoveAndLeftDoubleClick:
                     Log.Info("Mouse move and left double click selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1232,11 +1239,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
                             
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     });
                     break;
 
                 case FunctionKeys.MouseMoveAndMiddleClick:
                     Log.Info("Mouse move and middle click selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1260,11 +1269,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     });
                     break;
                         
                 case FunctionKeys.MouseMoveAndRightClick:
                     Log.Info("Mouse move and right click selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1288,6 +1299,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     });
                     break;
 
@@ -1323,6 +1335,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                 case FunctionKeys.MouseMoveAndScrollToBottom:
                     Log.Info("Mouse move and scroll to bottom selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1346,11 +1359,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     }, suppressMagnification:true);
                     break;
 
                 case FunctionKeys.MouseMoveAndScrollToLeft:
                     Log.Info("Mouse move and scroll to left selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1374,11 +1389,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     }, suppressMagnification: true);
                     break;
 
                 case FunctionKeys.MouseMoveAndScrollToRight:
                     Log.Info("Mouse move and scroll to right selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1402,11 +1419,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     }, suppressMagnification: true);
                     break;
 
                 case FunctionKeys.MouseMoveAndScrollToTop:
                     Log.Info("Mouse move and scroll to top selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1430,6 +1449,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                         }
 
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     }, suppressMagnification: true);
                     break;
 
@@ -1481,6 +1501,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                 case FunctionKeys.MouseMoveTo:
                     Log.Info("Mouse move to selected.");
+                    resumeLookToScroll = SuspendLookToScrollWhileChoosingPointForMouse();
                     SetupFinalClickAction(finalPoint =>
                     {
                         if (finalPoint != null)
@@ -1501,6 +1522,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                             simulateMoveTo(finalPoint.Value);
                         }
                         ResetAndCleanupAfterMouseAction();
+                        resumeLookToScroll();
                     });
                     break;
 

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.cs
@@ -125,6 +125,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             get { return keyboard; }
             set
             {
+                DeactivateLookToScrollUponSwitchingKeyboards();
                 keyboard?.OnExit(); // previous keyboard
                 SetProperty(ref keyboard, value);
                 keyboard?.OnEnter(); // new keyboard

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/OtherViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/OtherViewModel.cs
@@ -144,6 +144,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref lookToScrollResumeAfterChoosingPointForMouse, value); }
         }
 
+        private bool lookToScrollDeactivateUponSwitchingKeyboards;
+        public bool LookToScrollDeactivateUponSwitchingKeyboards
+        {
+            get { return lookToScrollDeactivateUponSwitchingKeyboards; }
+            set { SetProperty(ref lookToScrollDeactivateUponSwitchingKeyboards, value); }
+        }
+
         private bool lookToScrollShowOverlayWindow;
         public bool LookToScrollShowOverlayWindow
         {
@@ -275,6 +282,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             LookToScrollBringWindowToFrontAfterChoosingScreenPoint = Settings.Default.LookToScrollBringWindowToFrontAfterChoosingScreenPoint;
             LookToScrollSuspendBeforeChoosingPointForMouse = Settings.Default.LookToScrollSuspendBeforeChoosingPointForMouse;
             LookToScrollResumeAfterChoosingPointForMouse = Settings.Default.LookToScrollResumeAfterChoosingPointForMouse;
+            LookToScrollDeactivateUponSwitchingKeyboards = Settings.Default.LookToScrollDeactivateUponSwitchingKeyboards;
             LookToScrollShowOverlayWindow = Settings.Default.LookToScrollShowOverlayWindow;
             LookToScrollOverlayBoundsColour = Settings.Default.LookToScrollOverlayBoundsColour;
             LookToScrollOverlayDeadzoneColour = Settings.Default.LookToScrollOverlayDeadzoneColour;
@@ -308,6 +316,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.LookToScrollBringWindowToFrontAfterChoosingScreenPoint = LookToScrollBringWindowToFrontAfterChoosingScreenPoint;
             Settings.Default.LookToScrollSuspendBeforeChoosingPointForMouse = LookToScrollSuspendBeforeChoosingPointForMouse;
             Settings.Default.LookToScrollResumeAfterChoosingPointForMouse = LookToScrollResumeAfterChoosingPointForMouse;
+            Settings.Default.LookToScrollDeactivateUponSwitchingKeyboards = LookToScrollDeactivateUponSwitchingKeyboards;
             Settings.Default.LookToScrollShowOverlayWindow = LookToScrollShowOverlayWindow;
             Settings.Default.LookToScrollOverlayBoundsColour = LookToScrollOverlayBoundsColour;
             Settings.Default.LookToScrollOverlayDeadzoneColour = LookToScrollOverlayDeadzoneColour;

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/OtherViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/OtherViewModel.cs
@@ -130,6 +130,20 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref lookToScrollBringWindowToFrontAfterChoosingScreenPoint, value); }
         }
 
+        private bool lookToScrollSuspendBeforeChoosingPointForMouse;
+        public bool LookToScrollSuspendBeforeChoosingPointForMouse
+        {
+            get { return lookToScrollSuspendBeforeChoosingPointForMouse; }
+            set { SetProperty(ref lookToScrollSuspendBeforeChoosingPointForMouse, value); }
+        }
+
+        private bool lookToScrollResumeAfterChoosingPointForMouse;
+        public bool LookToScrollResumeAfterChoosingPointForMouse
+        {
+            get { return lookToScrollResumeAfterChoosingPointForMouse; }
+            set { SetProperty(ref lookToScrollResumeAfterChoosingPointForMouse, value); }
+        }
+
         private bool lookToScrollShowOverlayWindow;
         public bool LookToScrollShowOverlayWindow
         {
@@ -259,6 +273,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             LookToScrollCentreMouseWhenActivated = Settings.Default.LookToScrollCentreMouseWhenActivated;
             LookToScrollBringWindowToFrontWhenActivated = Settings.Default.LookToScrollBringWindowToFrontWhenActivated;
             LookToScrollBringWindowToFrontAfterChoosingScreenPoint = Settings.Default.LookToScrollBringWindowToFrontAfterChoosingScreenPoint;
+            LookToScrollSuspendBeforeChoosingPointForMouse = Settings.Default.LookToScrollSuspendBeforeChoosingPointForMouse;
+            LookToScrollResumeAfterChoosingPointForMouse = Settings.Default.LookToScrollResumeAfterChoosingPointForMouse;
             LookToScrollShowOverlayWindow = Settings.Default.LookToScrollShowOverlayWindow;
             LookToScrollOverlayBoundsColour = Settings.Default.LookToScrollOverlayBoundsColour;
             LookToScrollOverlayDeadzoneColour = Settings.Default.LookToScrollOverlayDeadzoneColour;
@@ -290,6 +306,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.LookToScrollCentreMouseWhenActivated = LookToScrollCentreMouseWhenActivated;
             Settings.Default.LookToScrollBringWindowToFrontWhenActivated = LookToScrollBringWindowToFrontWhenActivated;
             Settings.Default.LookToScrollBringWindowToFrontAfterChoosingScreenPoint = LookToScrollBringWindowToFrontAfterChoosingScreenPoint;
+            Settings.Default.LookToScrollSuspendBeforeChoosingPointForMouse = LookToScrollSuspendBeforeChoosingPointForMouse;
+            Settings.Default.LookToScrollResumeAfterChoosingPointForMouse = LookToScrollResumeAfterChoosingPointForMouse;
             Settings.Default.LookToScrollShowOverlayWindow = LookToScrollShowOverlayWindow;
             Settings.Default.LookToScrollOverlayBoundsColour = LookToScrollOverlayBoundsColour;
             Settings.Default.LookToScrollOverlayDeadzoneColour = LookToScrollOverlayDeadzoneColour;

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/OtherView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/OtherView.xaml
@@ -131,6 +131,8 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_DIRECTION_INVERTED_LABEL}" 
@@ -163,104 +165,118 @@
                               VerticalAlignment="Center"
                               IsChecked="{Binding LookToScrollBringWindowToFrontAfterChoosingScreenPoint, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL}" 
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_SUSPEND_BEFORE_CHOOSING_POINT_FOR_MOUSE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <CheckBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
                               VerticalAlignment="Center"
+                              IsChecked="{Binding LookToScrollSuspendBeforeChoosingPointForMouse, Mode=TwoWay}" />
+                    
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_RESUME_AFTER_CHOOSING_POINT_FOR_MOUSE_LABEL}" 
+                               VerticalAlignment="Center" Margin="5"
+                               Visibility="{Binding Path=LookToScrollSuspendBeforeChoosingPointForMouse, Converter={StaticResource BooleanToVisibility}}" />
+                    <CheckBox Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2"
+                              VerticalAlignment="Center"
+                              IsChecked="{Binding LookToScrollResumeAfterChoosingPointForMouse, Mode=TwoWay}"
+                              Visibility="{Binding Path=LookToScrollSuspendBeforeChoosingPointForMouse, Converter={StaticResource BooleanToVisibility}}" />
+
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <CheckBox Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2"
+                              VerticalAlignment="Center"
                               IsChecked="{Binding LookToScrollShowOverlayWindow, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_COLOUR_LABEL}" 
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_COLOUR_LABEL}" 
                                VerticalAlignment="Center" Margin="5"
                                Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <ComboBox Grid.Row="6" Grid.Column="1"
+                    <ComboBox Grid.Row="8" Grid.Column="1"
                               ItemsSource="{Binding ColourNames}"
                               SelectedValue="{Binding LookToScrollOverlayBoundsColour, Mode=TwoWay}" 
                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <Border Grid.Row="6" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
+                    <Border Grid.Row="8" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
                             BorderBrush="{Binding LookToScrollOverlayBoundsColour, Converter={StaticResource ColourNameToBrush}}"
                             BorderThickness="{Binding LookToScrollOverlayBoundsThickness}" 
                             Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_THICKNESS_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" 
-                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <controls:NumericUpDown Grid.Row="7" Grid.Column="1" TextAlignment="Left"
-                                            Minimum="0" Interval="1" StringFormat="###,##0"
-                                            Value="{Binding LookToScrollOverlayBoundsThickness, Mode=TwoWay}"
-                                            Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_COLOUR_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" 
-                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <ComboBox Grid.Row="8" Grid.Column="1"
-                              ItemsSource="{Binding ColourNames}"
-                              SelectedValue="{Binding LookToScrollOverlayDeadzoneColour, Mode=TwoWay}" 
-                              Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-
-                    <Border Grid.Row="8" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
-                            BorderBrush="{Binding LookToScrollOverlayDeadzoneColour, Converter={StaticResource ColourNameToBrush}}"
-                            BorderThickness="{Binding LookToScrollOverlayDeadzoneThickness}"
-                            Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    
-                    <TextBlock Grid.Row="9" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_THICKNESS_LABEL}" 
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_THICKNESS_LABEL}" 
                                VerticalAlignment="Center" Margin="5" 
                                Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
                     <controls:NumericUpDown Grid.Row="9" Grid.Column="1" TextAlignment="Left"
                                             Minimum="0" Interval="1" StringFormat="###,##0"
+                                            Value="{Binding LookToScrollOverlayBoundsThickness, Mode=TwoWay}"
+                                            Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
+                    
+                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_COLOUR_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" 
+                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
+                    <ComboBox Grid.Row="10" Grid.Column="1"
+                              ItemsSource="{Binding ColourNames}"
+                              SelectedValue="{Binding LookToScrollOverlayDeadzoneColour, Mode=TwoWay}" 
+                              Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
+
+                    <Border Grid.Row="10" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
+                            BorderBrush="{Binding LookToScrollOverlayDeadzoneColour, Converter={StaticResource ColourNameToBrush}}"
+                            BorderThickness="{Binding LookToScrollOverlayDeadzoneThickness}"
+                            Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
+                    
+                    <TextBlock Grid.Row="11" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_THICKNESS_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" 
+                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
+                    <controls:NumericUpDown Grid.Row="11" Grid.Column="1" TextAlignment="Left"
+                                            Minimum="0" Interval="1" StringFormat="###,##0"
                                             Value="{Binding LookToScrollOverlayDeadzoneThickness, Mode=TwoWay}" 
                                             Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_HORIZONTAL_DEADZONE_LABEL}" 
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_HORIZONTAL_DEADZONE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="10" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="5" StringFormat="###,##0"
                                             Value="{Binding LookToScrollHorizontalDeadzone, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="11" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_VERTICAL_DEADZONE_LABEL}" 
+                    <TextBlock Grid.Row="13" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_VERTICAL_DEADZONE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="5" StringFormat="###,##0"
                                             Value="{Binding LookToScrollVerticalDeadzone, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_INCREMENT_CHOICES_LABEL}" 
+                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_INCREMENT_CHOICES_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <TextBox Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left" 
+                    <TextBox Grid.Row="14" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left" 
                              Text="{Binding LookToScrollIncrementChoices, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="13" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_SLOW_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
-                                            Minimum="0" Interval="0.1" StringFormat="###,##0.0"
-                                            Value="{Binding LookToScrollBaseSpeedSlow, Mode=TwoWay}" />
-
-                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_MEDIUM_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="14" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
-                                            Minimum="0" Interval="0.1" StringFormat="###,##0.0"
-                                            Value="{Binding LookToScrollBaseSpeedMedium, Mode=TwoWay}" />
-
-                    <TextBlock Grid.Row="15" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_FAST_LABEL}" 
+                    <TextBlock Grid.Row="15" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_SLOW_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="15" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.1" StringFormat="###,##0.0"
-                                            Value="{Binding LookToScrollBaseSpeedFast, Mode=TwoWay}" />
+                                            Value="{Binding LookToScrollBaseSpeedSlow, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_SLOW_LABEL}" 
+                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_MEDIUM_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="16" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                                            Minimum="0" Interval="0.1" StringFormat="###,##0.0"
+                                            Value="{Binding LookToScrollBaseSpeedMedium, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="17" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_FAST_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <controls:NumericUpDown Grid.Row="17" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                                            Minimum="0" Interval="0.1" StringFormat="###,##0.0"
+                                            Value="{Binding LookToScrollBaseSpeedFast, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_SLOW_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <controls:NumericUpDown Grid.Row="18" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.001" StringFormat="###,##0.000"
                                             Value="{Binding LookToScrollAccelerationSlow, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="17" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_MEDIUM_LABEL}" 
+                    <TextBlock Grid.Row="19" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_MEDIUM_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="17" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="19" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.001" StringFormat="###,##0.000"
                                             Value="{Binding LookToScrollAccelerationMedium, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_FAST_LABEL}" 
+                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_FAST_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="18" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="20" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.001" StringFormat="###,##0.000"
                                             Value="{Binding LookToScrollAccelerationFast, Mode=TwoWay}" />
                 </Grid>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/OtherView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/OtherView.xaml
@@ -133,6 +133,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_DIRECTION_INVERTED_LABEL}" 
@@ -179,104 +180,110 @@
                               IsChecked="{Binding LookToScrollResumeAfterChoosingPointForMouse, Mode=TwoWay}"
                               Visibility="{Binding Path=LookToScrollSuspendBeforeChoosingPointForMouse, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <TextBlock Grid.Row="7" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL}" 
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_DEACTIVATE_UPON_SWITCHING_KEYBOARDS_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <CheckBox Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2"
                               VerticalAlignment="Center"
+                              IsChecked="{Binding LookToScrollDeactivateUponSwitchingKeyboards, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_SHOW_OVERLAY_WINDOW_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <CheckBox Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2"
+                              VerticalAlignment="Center"
                               IsChecked="{Binding LookToScrollShowOverlayWindow, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_COLOUR_LABEL}" 
+                    <TextBlock Grid.Row="9" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_COLOUR_LABEL}" 
                                VerticalAlignment="Center" Margin="5"
                                Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <ComboBox Grid.Row="8" Grid.Column="1"
+                    <ComboBox Grid.Row="9" Grid.Column="1"
                               ItemsSource="{Binding ColourNames}"
                               SelectedValue="{Binding LookToScrollOverlayBoundsColour, Mode=TwoWay}" 
                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <Border Grid.Row="8" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
+                    <Border Grid.Row="9" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
                             BorderBrush="{Binding LookToScrollOverlayBoundsColour, Converter={StaticResource ColourNameToBrush}}"
                             BorderThickness="{Binding LookToScrollOverlayBoundsThickness}" 
                             Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <TextBlock Grid.Row="9" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_THICKNESS_LABEL}" 
+                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_BOUNDS_THICKNESS_LABEL}" 
                                VerticalAlignment="Center" Margin="5" 
                                Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <controls:NumericUpDown Grid.Row="9" Grid.Column="1" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="10" Grid.Column="1" TextAlignment="Left"
                                             Minimum="0" Interval="1" StringFormat="###,##0"
                                             Value="{Binding LookToScrollOverlayBoundsThickness, Mode=TwoWay}"
                                             Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
                     
-                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_COLOUR_LABEL}" 
+                    <TextBlock Grid.Row="11" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_COLOUR_LABEL}" 
                                VerticalAlignment="Center" Margin="5" 
                                Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <ComboBox Grid.Row="10" Grid.Column="1"
+                    <ComboBox Grid.Row="11" Grid.Column="1"
                               ItemsSource="{Binding ColourNames}"
                               SelectedValue="{Binding LookToScrollOverlayDeadzoneColour, Mode=TwoWay}" 
                               Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <Border Grid.Row="10" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
+                    <Border Grid.Row="11" Grid.Column="2" Grid.RowSpan="2" Margin="5" Width="50"
                             BorderBrush="{Binding LookToScrollOverlayDeadzoneColour, Converter={StaticResource ColourNameToBrush}}"
                             BorderThickness="{Binding LookToScrollOverlayDeadzoneThickness}"
                             Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
                     
-                    <TextBlock Grid.Row="11" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_THICKNESS_LABEL}" 
+                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_OVERLAY_DEADZONE_THICKNESS_LABEL}" 
                                VerticalAlignment="Center" Margin="5" 
                                Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
-                    <controls:NumericUpDown Grid.Row="11" Grid.Column="1" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="12" Grid.Column="1" TextAlignment="Left"
                                             Minimum="0" Interval="1" StringFormat="###,##0"
                                             Value="{Binding LookToScrollOverlayDeadzoneThickness, Mode=TwoWay}" 
                                             Visibility="{Binding LookToScrollShowOverlayWindow, Converter={StaticResource BooleanToVisibility}}" />
 
-                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_HORIZONTAL_DEADZONE_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
-                                            Minimum="0" Interval="5" StringFormat="###,##0"
-                                            Value="{Binding LookToScrollHorizontalDeadzone, Mode=TwoWay}" />
-
-                    <TextBlock Grid.Row="13" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_VERTICAL_DEADZONE_LABEL}" 
+                    <TextBlock Grid.Row="13" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_HORIZONTAL_DEADZONE_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="5" StringFormat="###,##0"
+                                            Value="{Binding LookToScrollHorizontalDeadzone, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_VERTICAL_DEADZONE_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <controls:NumericUpDown Grid.Row="14" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                                            Minimum="0" Interval="5" StringFormat="###,##0"
                                             Value="{Binding LookToScrollVerticalDeadzone, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_INCREMENT_CHOICES_LABEL}" 
+                    <TextBlock Grid.Row="15" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_INCREMENT_CHOICES_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <TextBox Grid.Row="14" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left" 
+                    <TextBox Grid.Row="15" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left" 
                              Text="{Binding LookToScrollIncrementChoices, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="15" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_SLOW_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="15" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
-                                            Minimum="0" Interval="0.1" StringFormat="###,##0.0"
-                                            Value="{Binding LookToScrollBaseSpeedSlow, Mode=TwoWay}" />
-
-                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_MEDIUM_LABEL}" 
+                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_SLOW_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="16" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.1" StringFormat="###,##0.0"
-                                            Value="{Binding LookToScrollBaseSpeedMedium, Mode=TwoWay}" />
+                                            Value="{Binding LookToScrollBaseSpeedSlow, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="17" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_FAST_LABEL}" 
+                    <TextBlock Grid.Row="17" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_MEDIUM_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="17" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.1" StringFormat="###,##0.0"
-                                            Value="{Binding LookToScrollBaseSpeedFast, Mode=TwoWay}" />
+                                            Value="{Binding LookToScrollBaseSpeedMedium, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_SLOW_LABEL}" 
+                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_BASE_SPEED_FAST_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="18" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
-                                            Minimum="0" Interval="0.001" StringFormat="###,##0.000"
-                                            Value="{Binding LookToScrollAccelerationSlow, Mode=TwoWay}" />
+                                            Minimum="0" Interval="0.1" StringFormat="###,##0.0"
+                                            Value="{Binding LookToScrollBaseSpeedFast, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="19" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_MEDIUM_LABEL}" 
+                    <TextBlock Grid.Row="19" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_SLOW_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="19" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.001" StringFormat="###,##0.000"
-                                            Value="{Binding LookToScrollAccelerationMedium, Mode=TwoWay}" />
+                                            Value="{Binding LookToScrollAccelerationSlow, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_FAST_LABEL}" 
+                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_MEDIUM_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="20" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                                            Minimum="0" Interval="0.001" StringFormat="###,##0.000"
+                                            Value="{Binding LookToScrollAccelerationMedium, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="21" Grid.Column="0" Text="{x:Static resx:Resources.LOOK_TO_SCROLL_ACCELERATION_FAST_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <controls:NumericUpDown Grid.Row="21" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="0" Interval="0.001" StringFormat="###,##0.000"
                                             Value="{Binding LookToScrollAccelerationFast, Mode=TwoWay}" />
                 </Grid>


### PR DESCRIPTION
Fixes bug spotted in issue #451 and adds the additional features requested: suspending look to scroll while using any of the mouse keys requiring you to choose a point and deactivating look to scroll when leaving the Mouse or Web Browsing keyboards.

Please see commit messages for more details.