### PR TITLE
Fix "OptiKey has stopped working" notification on exit.

### DIFF
--- a/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyboardKeyDownUpSource.cs
+++ b/src/JuliusSweetland.OptiKey/Observables/TriggerSources/KeyboardKeyDownUpSource.cs
@@ -40,6 +40,12 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
                 Enabled = true
             };
 
+            System.Windows.Application.Current.Exit += (sender, args) =>
+            {
+                keyboardHookListener.Dispose();
+                Log.Debug("Keyboard hook listener disposed.");
+            };
+
             /*
              * Keys: http://msdn.microsoft.com/en-GB/library/system.windows.forms.keys.aspx
              * KeyDown: happens when the person presses a key (when the keyboard first detects a finger on a key, this happens when the key is pressed down).

--- a/src/JuliusSweetland.OptiKey/Observables/TriggerSources/MouseButtonDownUpSource.cs
+++ b/src/JuliusSweetland.OptiKey/Observables/TriggerSources/MouseButtonDownUpSource.cs
@@ -2,6 +2,7 @@
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Windows.Forms;
+using log4net;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
@@ -14,6 +15,8 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
     public class MouseButtonDownUpSource : ITriggerSource
     {
         #region Fields
+
+        private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         private readonly MouseButtons triggerButton;
         private readonly IPointSource pointSource;
@@ -35,6 +38,12 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
             mouseHookListener = new MouseHookListener(new GlobalHooker())
             {
                 Enabled = true
+            };
+
+            System.Windows.Application.Current.Exit += (sender, args) =>
+            {
+                mouseHookListener.Dispose();
+                Log.Debug("Mouse hook listener disposed.");
             };
         }
 


### PR DESCRIPTION
If the mouse was in motion during the exit of OptiKey the notification
"OptiKey has stopped working" would pop-up (sometimes twice). Disposing
the mouse hook on exit prevents this. The same has been applied to the
keyboard hook to preempt a similar issue.

This issue was discussed in issue #454.