### PR TITLE
CommuniKate for all languages and Presage contraction support

### DIFF
--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -429,6 +429,7 @@
     <Compile Include="UI\TriggerActions\ConfirmationWindowAction.cs" />
     <Compile Include="UI\TriggerActions\OpenManagementWindowAction.cs" />
     <Compile Include="UI\Controls\KeyboardHost.cs" />
+    <Compile Include="UI\ValueConverters\CommuniKateCalculateBoarderWidth.cs" />
     <Compile Include="UI\ValueConverters\CommuniKateTwoColoursToForegroundBrush.cs" />
     <Compile Include="UI\ValueConverters\ColourNameToBrush.cs" />
     <Compile Include="UI\ValueConverters\EnumMapper.cs" />
@@ -554,7 +555,7 @@
     <Compile Include="UI\Views\Keyboards\Danish\ConversationAlpha1.xaml.cs">
       <DependentUpon>ConversationAlpha1.xaml</DependentUpon>
     </Compile>
-    <Compile Include="UI\Views\Keyboards\English\CommuniKate.xaml.cs">
+    <Compile Include="UI\Views\Keyboards\Common\CommuniKate.xaml.cs">
       <DependentUpon>CommuniKate.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\Views\Keyboards\English\AlphabeticalAlpha1.xaml.cs">
@@ -1250,7 +1251,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="UI\Views\Keyboards\English\CommuniKate.xaml">
+    <Page Include="UI\Views\Keyboards\Common\CommuniKate.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -791,6 +791,9 @@
     <EmbeddedResource Include="Properties\Resources.hr-HR.resx" />
     <EmbeddedResource Include="Properties\Resources.da-DK.resx" />
     <EmbeddedResource Include="Resources.ja-JP.resx" />
+    <Content Include="Resources\Presage\database.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Resource Include="Resources\Icons\Management.ico" />
     <Resource Include="Resources\Icons\Main.ico" />
     <None Include="..\..\LICENSE.txt">

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -4421,6 +4421,24 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Location of Presage database .db file:.
+        /// </summary>
+        public static string PRESAGE_DATABASE_LOCATION_LABEL {
+            get {
+                return ResourceManager.GetString("PRESAGE_DATABASE_LOCATION_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Number of Presage suggestions to show:.
+        /// </summary>
+        public static string PRESAGE_NUMBER_OF_SUGGESTIONS_LABEL {
+            get {
+                return ResourceManager.GetString("PRESAGE_NUMBER_OF_SUGGESTIONS_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Presage.
         /// </summary>
         public static string PRESAGE_SUGGESTION {
@@ -5080,7 +5098,7 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("SIMILAR_DICTIONARY_ENTRIES_EXIST", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SIZE &amp; POSITION.
         /// </summary>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.Designer.cs
@@ -650,6 +650,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CommuniKate.
+        /// </summary>
+        public static string COMMUNIKATE {
+            get {
+                return ResourceManager.GetString("COMMUNIKATE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CommuniKate is currently disabled (use QWERTY).
         /// </summary>
         public static string COMMUNIKATE_DISABLED {

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -2204,4 +2204,7 @@ Française
   <data name="MANUAL_MODE" xml:space="preserve">
     <value>MANUAL MODE</value>
   </data>
+  <data name="COMMUNIKATE" xml:space="preserve">
+    <value>CommuniKate</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey/Properties/Resources.resx
@@ -2207,4 +2207,10 @@ Française
   <data name="COMMUNIKATE" xml:space="preserve">
     <value>CommuniKate</value>
   </data>
+  <data name="PRESAGE_DATABASE_LOCATION_LABEL" xml:space="preserve">
+    <value>Location of Presage database .db file:</value>
+  </data>
+  <data name="PRESAGE_NUMBER_OF_SUGGESTIONS_LABEL" xml:space="preserve">
+    <value>Number of Presage suggestions to show:</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.Designer.cs
@@ -2515,5 +2515,31 @@ namespace JuliusSweetland.OptiKey.Properties {
                 this["SimplifiedKeyboardContext"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string PresageDatabaseLocation {
+            get {
+                return ((string)(this["PresageDatabaseLocation"]));
+            }
+            set {
+                this["PresageDatabaseLocation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("11")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public int PresageNumberOfSuggestions {
+            get {
+                return ((int)(this["PresageNumberOfSuggestions"]));
+            }
+            set {
+                this["PresageNumberOfSuggestions"] = value;
+            }
+        }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Properties/Settings.settings
+++ b/src/JuliusSweetland.OptiKey/Properties/Settings.settings
@@ -1241,5 +1241,11 @@
     <Setting Name="SimplifiedKeyboardContext" Roaming="true" Type="JuliusSweetland.OptiKey.Enums.SimplifiedKeyboardContexts" Scope="User">
       <Value Profile="(Default)">Home</Value>
     </Setting>
+    <Setting Name="PresageDatabaseLocation" Roaming="true" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="PresageNumberOfSuggestions" Roaming="true" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">11</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs
@@ -4,6 +4,7 @@ using log4net;
 using presage;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace JuliusSweetland.OptiKey.Services.Suggestions
 {
@@ -33,7 +34,7 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
                 }
                 else
                 {
-                    this.root = root;
+                    this.root = UTF8EncodingToDefault(root);
 
                     // force presage to suggest the next word by adding a space 
                     if (nextWord && root.Length > 0 && char.IsLetterOrDigit(root.Last()))
@@ -44,7 +45,12 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
 
                 if (prsg != null)
                 {
-                    return prsg.predict();
+                    List<string> suggestions = new List<string>();
+                    foreach (string suggestion in prsg.predict())
+                    {
+                        suggestions.Add(defaultEncodingToUTF8(suggestion));
+                    }
+                    return suggestions;
                 }
             }
             catch (PresageException pe)
@@ -65,6 +71,35 @@ namespace JuliusSweetland.OptiKey.Services.Suggestions
         private string callback_get_future_stream()
         {
             return "";
+        }
+
+        /// <summary>
+        /// Buffer to hold byte representation of string for encoding conversion
+        /// </summary>
+        private byte[] _byteBuffer = new byte[10240];
+
+        /// <summary>
+        /// Converts default encoding to UTF8
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        protected string defaultEncodingToUTF8(string input)
+        {
+            int length = Encoding.Default.GetBytes(input, 0, input.Length, _byteBuffer, 0);
+
+            return Encoding.UTF8.GetString(_byteBuffer, 0, length).Replace('’', '\'');
+        }
+
+        /// <summary>
+        /// Converts UTF8 encoded string to the default encoding
+        /// </summary>
+        /// <param name="input">input string</param>
+        /// <returns>converted string</returns>
+        protected string UTF8EncodingToDefault(string input)
+        {
+            int length = Encoding.UTF8.GetBytes(input.Replace('\'', '’'), 0, input.Length, _byteBuffer, 0);
+
+            return Encoding.Default.GetString(_byteBuffer, 0, length).Replace('\'', '`');
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/Suggestions/PresageSuggestions.cs
@@ -5,6 +5,7 @@ using presage;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.IO;
 
 namespace JuliusSweetland.OptiKey.Services.Suggestions
 {

--- a/src/JuliusSweetland.OptiKey/UI/Controls/CK20Page.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/CK20Page.xaml
@@ -22,6 +22,7 @@
                     <valueConverters:IsSvgImage x:Key="IsSvgImage" />
                     <valueConverters:CommuniKateBackgroundColourToForegroundBrush x:Key="CommuniKateBackgroundColourToForegroundBrush" />
                     <valueConverters:CommuniKateTwoColoursToForegroundBrush x:Key="CommuniKateTwoColoursToForegroundBrush" />
+                    <valueConverters:CommuniKateCalculateBoarderWidth x:Key="CommuniKateCalculateBoarderWidth" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -172,41 +173,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_00, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -286,41 +287,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                    <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_01, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -400,41 +401,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_02, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -514,41 +515,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_03, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -628,41 +629,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_04, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -743,41 +744,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_10, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -857,41 +858,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_11, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -971,41 +972,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_12, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1085,41 +1086,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_13, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1199,41 +1200,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_14, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1314,41 +1315,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_20, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1428,41 +1429,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_21, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1542,41 +1543,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_22, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1656,41 +1657,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_23, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1770,41 +1771,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_24, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1885,41 +1886,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_30, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -1999,41 +2000,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_31, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -2113,41 +2114,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_32, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -2227,41 +2228,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_33, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">
@@ -2341,41 +2342,41 @@
                     </Style>
                 </Viewbox.Style>
             </Viewbox>
-            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto" StrokeThickness="8" Stroke="{Binding Path=CKBoCo_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" />
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+            <Rectangle Grid.RowSpan="2" Height="auto" Width="auto"
+                       Stroke="{Binding Path=CKBoCo_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" >
+                <Rectangle.StrokeThickness>
+                    <MultiBinding Converter="{StaticResource CommuniKateCalculateBoarderWidth}">
+                        <Binding Path="CKGridRows" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                        <Binding Path="CKGridColumns" RelativeSource="{RelativeSource AncestorType={x:Type controls:CK20Page}}" />
+                    </MultiBinding>
+                </Rectangle.StrokeThickness>
+            </Rectangle>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
+                  Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateMenuKey}, Path=CKMenu_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Right"
-                                              Data="M0,0 L0,20 A40,40 0 0 1 -20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
-            <ContentControl>
-                <ContentControl.Style>
-                    <Style TargetType="{x:Type ContentControl}">
+                </Path.Style>
+            </Path>
+            <Path VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
+                  Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" >
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Setter Property="Fill" Value="Transparent"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Converter={StaticResource IsCommuniKateActionKey}, Path=CKMenu_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <Path Fill="{Binding Path=CKBoCo_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}" 
-                                              VerticalAlignment="Top" Stretch="Uniform" HorizontalAlignment="Left"
-                                              Data="M0,0 L0,20 A40,40 0 0 0 20,0 z" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Fill" Value="{Binding Path=CKBoCo_34, RelativeSource={RelativeSource AncestorType={x:Type controls:CK20Page}}}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </ContentControl.Style>
-            </ContentControl>
+                </Path.Style>
+            </Path>
             <ContentControl Grid.RowSpan="2">
                 <ContentControl.Style>
                     <Style TargetType="{x:Type ContentControl}">

--- a/src/JuliusSweetland.OptiKey/UI/Controls/CK20Page.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/CK20Page.xaml.cs
@@ -237,7 +237,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                                     CurrentButton = new Buttons()
                                     {
                                         background_color = "rgb(204,255,204)",
-                                        label = "BACK",
+                                        label = Properties.Resources.BACK,
                                         image_id = CKpath() + @"images\back.png",
                                         load_board = new Load_board()
                                         {

--- a/src/JuliusSweetland.OptiKey/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/KeyboardHost.cs
@@ -163,7 +163,9 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
             if (Keyboard is ViewModelKeyboards.Alpha1)
             {
-                switch (Settings.Default.KeyboardAndDictionaryLanguage)
+                if (Settings.Default.UsingCommuniKateKeyboardLayout)
+                    newContent = (object)new CommonViews.CommuniKate { DataContext = Keyboard };
+                else switch (Settings.Default.KeyboardAndDictionaryLanguage)
                 {
                     case Languages.CatalanSpain:
                         newContent = new CatalanViews.Alpha1 { DataContext = Keyboard };
@@ -230,13 +232,11 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                             : new TurkishViews.Alpha1 { DataContext = Keyboard };
                         break;
                     default:
-                        newContent = Settings.Default.UsingCommuniKateKeyboardLayout
-                            ? (object)new EnglishViews.CommuniKate { DataContext = Keyboard }
-                            : Settings.Default.UseSimplifiedKeyboardLayout
-                                ? (object)new EnglishViews.SimplifiedAlpha1 { DataContext = Keyboard }
-                                : Settings.Default.UseAlphabeticalKeyboardLayout
-                                    ? (object)new EnglishViews.AlphabeticalAlpha1 { DataContext = Keyboard }
-                                    : new EnglishViews.Alpha1 { DataContext = Keyboard };
+                        newContent = Settings.Default.UseSimplifiedKeyboardLayout
+                            ? (object)new EnglishViews.SimplifiedAlpha1 { DataContext = Keyboard }
+                            : Settings.Default.UseAlphabeticalKeyboardLayout
+                                ? (object)new EnglishViews.AlphabeticalAlpha1 { DataContext = Keyboard }
+                                : new EnglishViews.Alpha1 { DataContext = Keyboard };
                         break;
                 }
             }
@@ -256,7 +256,9 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             }
             else if (Keyboard is ViewModelKeyboards.ConversationAlpha1)
             {
-                switch (Settings.Default.KeyboardAndDictionaryLanguage)
+                if (Settings.Default.UsingCommuniKateKeyboardLayout)
+                    newContent = (object)new CommonViews.CommuniKate { DataContext = Keyboard };
+                else switch (Settings.Default.KeyboardAndDictionaryLanguage)
                 {
                     case Languages.CatalanSpain:
                         newContent = new CatalanViews.ConversationAlpha1 { DataContext = Keyboard };
@@ -321,13 +323,11 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                             : new TurkishViews.ConversationAlpha1 { DataContext = Keyboard };
                         break;
                     default:
-                        newContent = Settings.Default.UsingCommuniKateKeyboardLayout
-                            ? (object)new EnglishViews.CommuniKate { DataContext = Keyboard }
-                            : Settings.Default.UseSimplifiedKeyboardLayout
-                                ? (object)new EnglishViews.SimplifiedConversationAlpha1 { DataContext = Keyboard }
-                                : Settings.Default.UseAlphabeticalKeyboardLayout
-                                    ? (object)new EnglishViews.AlphabeticalConversationAlpha1 { DataContext = Keyboard }
-                                    : new EnglishViews.ConversationAlpha1 { DataContext = Keyboard };
+                        newContent = Settings.Default.UseSimplifiedKeyboardLayout
+                            ? (object)new EnglishViews.SimplifiedConversationAlpha1 { DataContext = Keyboard }
+                            : Settings.Default.UseAlphabeticalKeyboardLayout
+                                ? (object)new EnglishViews.AlphabeticalConversationAlpha1 { DataContext = Keyboard }
+                                : new EnglishViews.ConversationAlpha1 { DataContext = Keyboard };
                         break;
                 }
             }

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Output.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Output.xaml
@@ -39,9 +39,11 @@
                     <MultiBinding Converter="{StaticResource CalculateScratchpadWidth}" Mode="OneWay">
                         <Binding Path="ScratchpadWidthInKeys" RelativeSource="{RelativeSource AncestorType=controls:Output}" />
                         <Binding Path="EnableAttentionKey" Source="{x:Static resx:Settings.Default}" />
+                        <Binding Path="EnableCommuniKateKeyboardLayout" Source="{x:Static resx:Settings.Default}" />
                     </MultiBinding>
                 </ColumnDefinition.Width>
             </ColumnDefinition>
+            <ColumnDefinition Width="{Binding Source={x:Static resx:Settings.Default}, Path=EnableCommuniKateKeyboardLayout, Converter={StaticResource BoolToCustomValues}}" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
@@ -52,7 +54,7 @@
                       SharedSizeGroup="KeyWithSymbol"
                       Value="{x:Static models:KeyValues.PreviousSuggestionsKey}">
         </controls:Key>
-        <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="4">
+        <Grid Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
@@ -120,7 +122,7 @@
                 </controls:Key.Text>
             </controls:Key>
         </Grid>
-        <controls:Key Grid.Row="0" Grid.Column="5"
+        <controls:Key Grid.Row="0" Grid.Column="6"
                       SymbolGeometry="{StaticResource SuggestionRightIcon}"
                       Text="{x:Static resx:Resources.NEXT}"
                       SharedSizeGroup="KeyWithSymbol"
@@ -137,7 +139,7 @@
                       SharedSizeGroup="KeyWithSymbol"
                       Value="{x:Static models:KeyValues.ClearScratchpadKey}"/>
         <ContentControl Grid.Row="1" Grid.Column="2"
-                        Visibility="{Binding EnableAttentionKey, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
+                        Visibility="{Binding EnableAttentionKey, Source={x:Static resx:Settings.Default}, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
             <ContentControl.Style>
                 <Style TargetType="{x:Type ContentControl}">
                     <Setter Property="Content">
@@ -162,12 +164,36 @@
         </ContentControl>
         <controls:Scratchpad Grid.Row="1" Grid.Column="3"
                              Text="{Binding DataContext.KeyboardOutputService.Text, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=OneWay}" />
-        <controls:Key Grid.Row="1" Grid.Column="4"
+        <ContentControl Grid.Row="1" Grid.Column="4"
+                        Visibility="{Binding EnableCommuniKateKeyboardLayout, Source={x:Static resx:Settings.Default}, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" >
+            <ContentControl.Style>
+                <Style TargetType="{x:Type ContentControl}">
+                    <Setter Property="Content">
+                        <Setter.Value>
+                            <controls:Key />
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Source={x:Static resx:Settings.Default}, Path=EnableCommuniKateKeyboardLayout}" Value="True">
+                            <Setter Property="Content">
+                                <Setter.Value>
+                                    <controls:Key SymbolGeometry="{StaticResource CommuniKateIcon}"
+                                                  Text="{x:Static resx:Resources.COMMUNIKATE}"
+                                                  SharedSizeGroup="KeyWithSymbol"
+                                                  Value="{x:Static models:KeyValues.CommuniKateKeyboardKey}"/>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ContentControl.Style>
+        </ContentControl>
+        <controls:Key Grid.Row="1" Grid.Column="5"
                       SymbolGeometry="{StaticResource SpeakIcon}" 
                       Text="{x:Static resx:Resources.SPEAK}"
                       SharedSizeGroup="KeyWithSymbol"
                       Value="{x:Static models:KeyValues.SpeakKey}"/>
-        <controls:Key Grid.Row="1" Grid.Column="5"
+        <controls:Key Grid.Row="1" Grid.Column="6"
                       SymbolGeometry="{StaticResource SleepIcon}"
                       Text="{x:Static resx:Resources.SLEEP}"
                       SharedSizeGroup="KeyWithSymbol"

--- a/src/JuliusSweetland.OptiKey/UI/ValueConverters/CalculateScratchpadWidth.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ValueConverters/CalculateScratchpadWidth.cs
@@ -12,13 +12,14 @@ namespace JuliusSweetland.OptiKey.UI.ValueConverters
         
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values == null || values.Length != 2)
+            if (values == null || values.Length != 3)
             {
                 return new GridLength(DefaultGridLength, GridUnitType.Star);
             }
 
             int scratchpadWidthInKeys = (int) values[0];
             bool attentionKeyEnabled = (bool)values[1];
+            bool ckKeyEnabled = (bool)values[2];
 
             if (scratchpadWidthInKeys <= 0)
             {
@@ -26,6 +27,11 @@ namespace JuliusSweetland.OptiKey.UI.ValueConverters
             }
 
             if (attentionKeyEnabled)
+            {
+                --scratchpadWidthInKeys;
+            }
+
+            if (ckKeyEnabled)
             {
                 --scratchpadWidthInKeys;
             }

--- a/src/JuliusSweetland.OptiKey/UI/ValueConverters/CommuniKateCalculateBoarderWidth.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ValueConverters/CommuniKateCalculateBoarderWidth.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    public class CommuniKateCalculateBoarderWidth : IMultiValueConverter
+    {
+        public int DefaultGridLength { get; set; }
+        
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length != 2)
+            {
+                return (double)8;
+            }
+
+            int i = Math.Max((int)values[0], (int)values[1]);
+
+            if (i <= 0)
+            {
+                return (double)8;
+            }
+
+            return (double)72 / (i * i);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey/UI/ValueConverters/CommuniKateCalculateBoarderWidth.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ValueConverters/CommuniKateCalculateBoarderWidth.cs
@@ -16,14 +16,20 @@ namespace JuliusSweetland.OptiKey.UI.ValueConverters
                 return (double)8;
             }
 
-            int i = Math.Max((int)values[0], (int)values[1]);
+            int i = Math.Min((int)values[0], (int)values[1]);
+
+            if (i > 4) {
+                i = 4;
+            } else if (i > 1) {
+                i--;
+            }
 
             if (i <= 0)
             {
                 return (double)8;
             }
 
-            return (double)72 / (i * i);
+            return (double)8/i;
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
@@ -242,6 +242,53 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref usingCommuniKateKeyboardLayout, useCommuniKateKeyboardLayoutByDefault); }
         }
 
+        private int communiKateSoundVolume;
+        public int CommuniKateSoundVolume
+        {
+            get { return communiKateSoundVolume; }
+            set { SetProperty(ref communiKateSoundVolume, value); }
+        }
+
+        private bool communiKateSpeakSelected;
+        public bool CommuniKateSpeakSelected
+        {
+            get { return communiKateSpeakSelected; }
+            set { SetProperty(ref communiKateSpeakSelected, value); }
+        }
+
+        private int communiKateSpeakSelectedVolume;
+        public int CommuniKateSpeakSelectedVolume
+        {
+            get { return communiKateSpeakSelectedVolume; }
+            set { SetProperty(ref communiKateSpeakSelectedVolume, value); }
+        }
+
+        private int communiKateSpeakSelectedRate;
+        public int CommuniKateSpeakSelectedRate
+        {
+            get { return communiKateSpeakSelectedRate; }
+            set { SetProperty(ref communiKateSpeakSelectedRate, value); }
+        }
+
+        public bool PresageSettingsAreVisible
+        {
+            get { return SuggestionMethod == Enums.SuggestionMethods.Presage; }
+        }
+
+        private string presageDatabaseLocation;
+        public string PresageDatabaseLocation
+        {
+            get { return presageDatabaseLocation; }
+            set { SetProperty(ref presageDatabaseLocation, value); }
+        }
+
+        private int presageNumberOfSuggestions;
+        public int PresageNumberOfSuggestions
+        {
+            get { return presageNumberOfSuggestions; }
+            set { SetProperty(ref presageNumberOfSuggestions, value); }
+        }
+
         private bool forceCapsLock;
         public bool ForceCapsLock
         {
@@ -274,7 +321,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         public SuggestionMethods SuggestionMethod
         {
             get { return suggestionMethod; }
-            set { SetProperty(ref suggestionMethod, value); }
+            set
+            {
+                SetProperty(ref suggestionMethod, value);
+                OnPropertyChanged(() => PresageSettingsAreVisible);
+            }
         }
 
         private bool suggestWords;
@@ -302,7 +353,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return ForceCapsLock != Settings.Default.ForceCapsLock
                     || Settings.Default.SuggestionMethod != SuggestionMethod
-                    || Settings.Default.CommuniKatePagesetLocation != CommuniKatePagesetLocation; }
+                    || Settings.Default.CommuniKatePagesetLocation != CommuniKatePagesetLocation
+                    || Settings.Default.PresageDatabaseLocation != PresageDatabaseLocation
+                    || Settings.Default.PresageNumberOfSuggestions != PresageNumberOfSuggestions; }
         }
 
         #endregion
@@ -321,12 +374,18 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             CommuniKateStagedForDeletion = Settings.Default.CommuniKateStagedForDeletion;
             UseCommuniKateKeyboardLayoutByDefault = Settings.Default.UseCommuniKateKeyboardLayoutByDefault;
             UsingCommuniKateKeyboardLayout = Settings.Default.UseCommuniKateKeyboardLayoutByDefault;
+            CommuniKateSoundVolume = Settings.Default.CommuniKateSoundVolume;
+            CommuniKateSpeakSelected = Settings.Default.CommuniKateSpeakSelected;
+            CommuniKateSpeakSelectedVolume = Settings.Default.CommuniKateSpeakSelectedVolume;
+            CommuniKateSpeakSelectedRate = Settings.Default.CommuniKateSpeakSelectedRate;
             UseSimplifiedKeyboardLayout = Settings.Default.UseSimplifiedKeyboardLayout;
             ForceCapsLock = Settings.Default.ForceCapsLock;
             AutoAddSpace = Settings.Default.AutoAddSpace;
             AutoCapitalise = Settings.Default.AutoCapitalise;
             SuppressAutoCapitaliseIntelligently = Settings.Default.SuppressAutoCapitaliseIntelligently;
             SuggestionMethod = Settings.Default.SuggestionMethod;
+            PresageDatabaseLocation = Settings.Default.PresageDatabaseLocation;
+            PresageNumberOfSuggestions = Settings.Default.PresageNumberOfSuggestions;
             SuggestWords = Settings.Default.SuggestWords;
             MultiKeySelectionEnabled = Settings.Default.MultiKeySelectionEnabled;
             MultiKeySelectionMaxDictionaryMatches = Settings.Default.MaxDictionaryMatchesOrSuggestions;
@@ -347,12 +406,18 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.CommuniKateStagedForDeletion = CommuniKateStagedForDeletion;
             Settings.Default.UseCommuniKateKeyboardLayoutByDefault = UseCommuniKateKeyboardLayoutByDefault;
             Settings.Default.UsingCommuniKateKeyboardLayout = UseCommuniKateKeyboardLayoutByDefault;
+            Settings.Default.CommuniKateSoundVolume = CommuniKateSoundVolume;
+            Settings.Default.CommuniKateSpeakSelected = CommuniKateSpeakSelected;
+            Settings.Default.CommuniKateSpeakSelectedVolume = CommuniKateSpeakSelectedVolume;
+            Settings.Default.CommuniKateSpeakSelectedRate = CommuniKateSpeakSelectedRate;
             Settings.Default.UseSimplifiedKeyboardLayout = UseSimplifiedKeyboardLayout;
             Settings.Default.ForceCapsLock = ForceCapsLock;
             Settings.Default.AutoAddSpace = AutoAddSpace;
             Settings.Default.AutoCapitalise = AutoCapitalise;
             Settings.Default.SuppressAutoCapitaliseIntelligently = SuppressAutoCapitaliseIntelligently;
             Settings.Default.SuggestionMethod = SuggestionMethod;
+            Settings.Default.PresageDatabaseLocation = PresageDatabaseLocation;
+            Settings.Default.PresageNumberOfSuggestions = PresageNumberOfSuggestions;
             Settings.Default.SuggestWords = SuggestWords;
             Settings.Default.MultiKeySelectionEnabled = MultiKeySelectionEnabled;
             Settings.Default.MaxDictionaryMatchesOrSuggestions = MultiKeySelectionMaxDictionaryMatches;

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
@@ -68,8 +68,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             get
             {
                 var keyboardLayouts = new List<KeyValuePair<string, KeyboardLayouts>>();
-                
-                keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_DEFAULT_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Default));
+
+                if (UseDefaultKeyboardLayoutIsVisible)
+                {
+                    keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_DEFAULT_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Default));
+                }
                 if (UseAlphabeticalKeyboardLayoutIsVisible)
                 {
                     keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_ALPHABETICAL_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Alphabetic));
@@ -78,7 +81,10 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
                 {
                     keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_SIMPLIFIED_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Simplified));
                 }
-                keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_COMMUNIKATE_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Communikate));
+                if (EnableCommuniKateKeyboardLayout)
+                {
+                    keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_COMMUNIKATE_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Communikate));
+                }
 
                 return keyboardLayouts;
             }
@@ -103,7 +109,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set
             {
                 SetProperty(ref this.keyboardAndDictionaryLanguage, value);
+                OnPropertyChanged(() => UseDefaultKeyboardLayoutIsVisible);
                 OnPropertyChanged(() => UseAlphabeticalKeyboardLayoutIsVisible);
+                OnPropertyChanged(() => EnableCommuniKateKeyboardLayout);
                 OnPropertyChanged(() => UseCommuniKateKeyboardLayoutByDefault);
                 OnPropertyChanged(() => UseSimplifiedKeyboardLayoutIsVisible);
                 OnPropertyChanged(() => KeyboardLayouts);
@@ -129,6 +137,19 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return uiLanguage; }
             set { SetProperty(ref this.uiLanguage, value); }
+        }
+
+        public bool UseDefaultKeyboardLayoutIsVisible
+        {
+            get
+            {
+                return KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
+                       || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
+                       || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS
+                       || KeyboardAndDictionaryLanguage == Enums.Languages.JapaneseJapan
+                       || KeyboardAndDictionaryLanguage == Enums.Languages.TurkishTurkey
+                       || EnableCommuniKateKeyboardLayout;
+            }
         }
 
         private bool useAlphabeticalKeyboardLayout;
@@ -179,7 +200,12 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         public bool EnableCommuniKateKeyboardLayout
         {
             get { return enableCommuniKateKeyboardLayout; }
-            set { SetProperty(ref enableCommuniKateKeyboardLayout, value); }
+            set
+            {
+                SetProperty(ref enableCommuniKateKeyboardLayout, value);
+                OnPropertyChanged(() => KeyboardLayouts);
+                OnPropertyChanged(() => UseDefaultKeyboardLayoutIsVisible);
+            }
         }
 
         private string communiKatePagesetLocation;

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
@@ -143,11 +143,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get
             {
-                return KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.JapaneseJapan
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.TurkishTurkey
+                return UseAlphabeticalKeyboardLayoutIsVisible 
+                       || UseSimplifiedKeyboardLayoutIsVisible 
                        || EnableCommuniKateKeyboardLayout;
             }
         }

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/Management/WordsViewModel.cs
@@ -68,11 +68,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             get
             {
                 var keyboardLayouts = new List<KeyValuePair<string, KeyboardLayouts>>();
-
-                if (UseDefaultKeyboardLayoutIsVisible)
-                {
-                    keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_DEFAULT_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Default));
-                }
+                
+                keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_DEFAULT_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Default));
                 if (UseAlphabeticalKeyboardLayoutIsVisible)
                 {
                     keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_ALPHABETICAL_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Alphabetic));
@@ -81,10 +78,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
                 {
                     keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_SIMPLIFIED_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Simplified));
                 }
-                if (EnableCommuniKateKeyboardLayoutIsVisible)
-                {
-                    keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.COMMUNIKATE_DISABLED, Enums.KeyboardLayouts.Communikate));
-                }
+                keyboardLayouts.Add(new KeyValuePair<string, KeyboardLayouts>(Resources.USE_COMMUNIKATE_KEYBOARD_LAYOUT, Enums.KeyboardLayouts.Communikate));
 
                 return keyboardLayouts;
             }
@@ -109,9 +103,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set
             {
                 SetProperty(ref this.keyboardAndDictionaryLanguage, value);
-                OnPropertyChanged(() => UseDefaultKeyboardLayoutIsVisible);
                 OnPropertyChanged(() => UseAlphabeticalKeyboardLayoutIsVisible);
-                OnPropertyChanged(() => EnableCommuniKateKeyboardLayoutIsVisible);
                 OnPropertyChanged(() => UseCommuniKateKeyboardLayoutByDefault);
                 OnPropertyChanged(() => UseSimplifiedKeyboardLayoutIsVisible);
                 OnPropertyChanged(() => KeyboardLayouts);
@@ -137,18 +129,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return uiLanguage; }
             set { SetProperty(ref this.uiLanguage, value); }
-        }
-
-        public bool UseDefaultKeyboardLayoutIsVisible
-        {
-            get
-            {
-                return KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.JapaneseJapan
-                       || KeyboardAndDictionaryLanguage == Enums.Languages.TurkishTurkey;
-            }
         }
 
         private bool useAlphabeticalKeyboardLayout;
@@ -199,25 +179,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         public bool EnableCommuniKateKeyboardLayout
         {
             get { return enableCommuniKateKeyboardLayout; }
-            set
-            {
-                SetProperty(ref enableCommuniKateKeyboardLayout, value
-                      && useAlphabeticalKeyboardLayout == false
-                      && useSimplifiedKeyboardLayout == false
-                      && (KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
-                          || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
-                          || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS));
-            }
-        }
-
-        public bool EnableCommuniKateKeyboardLayoutIsVisible
-        {
-            get
-            {
-                return KeyboardAndDictionaryLanguage == Enums.Languages.EnglishCanada
-                    || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUK
-                    || KeyboardAndDictionaryLanguage == Enums.Languages.EnglishUS;
-            }
+            set { SetProperty(ref enableCommuniKateKeyboardLayout, value); }
         }
 
         private string communiKatePagesetLocation;

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/CommuniKate.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/CommuniKate.xaml
@@ -1,4 +1,4 @@
-<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.English.CommuniKate"
+<controls:KeyboardView x:Class="JuliusSweetland.OptiKey.UI.Views.Keyboards.Common.CommuniKate"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -16,7 +16,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
                 <ResourceDictionary>
-                    <valueConverters:BoolToCustomValues FalseValue="1" x:Key="ConvertBoolToStarGridLength" />
+                    <valueConverters:BoolToCustomValues TrueValue="1*" FalseValue="0*" x:Key="ConvertBoolToStarGridLength" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/CommuniKate.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/CommuniKate.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using JuliusSweetland.OptiKey.UI.Controls;
 
-namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.English
+namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
 {
     /// <summary>
     /// Interaction logic for CommuniKate.xaml

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/Alpha1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/Alpha1.xaml
@@ -56,27 +56,7 @@
                          NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
         <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
-        <ContentControl Grid.Row="2" Grid.Column="0">
-            <ContentControl.Style>
-                <Style TargetType="{x:Type ContentControl}">
-                    <Setter Property="Content">
-                        <Setter.Value>
-                            <controls:Key />
-                        </Setter.Value>
-                    </Setter>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Source={x:Static resx:Settings.Default}, Path=EnableCommuniKateKeyboardLayout}" Value="True">
-                            <Setter Property="Content">
-                                <Setter.Value>
-                                    <controls:Key Text="CK" SymbolGeometry="{StaticResource CommuniKateIcon}"
-                                                  Value="{x:Static models:KeyValues.CommuniKateKeyboardKey}"/>
-                                </Setter.Value>
-                            </Setter>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ContentControl.Style>
-        </ContentControl>
+        <controls:Key Grid.Row="2" Grid.Column="0"/>
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="q" ShiftDownText="Q"
                       SharedSizeGroup="KeyWithSingleLetter"

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/AlphabeticalAlpha1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/AlphabeticalAlpha1.xaml
@@ -56,27 +56,7 @@
                          NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
         <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
-        <ContentControl Grid.Row="2" Grid.Column="0">
-            <ContentControl.Style>
-                <Style TargetType="{x:Type ContentControl}">
-                    <Setter Property="Content">
-                        <Setter.Value>
-                            <controls:Key />
-                        </Setter.Value>
-                    </Setter>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Source={x:Static resx:Settings.Default}, Path=EnableCommuniKateKeyboardLayout}" Value="True">
-                            <Setter Property="Content">
-                                <Setter.Value>
-                                    <controls:Key Text="CK" SymbolGeometry="{StaticResource CommuniKateIcon}"
-                                                  Value="{x:Static models:KeyValues.CommuniKateKeyboardKey}"/>
-                                </Setter.Value>
-                            </Setter>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ContentControl.Style>
-        </ContentControl>
+        <controls:Key Grid.Row="2" Grid.Column="0"/>
         <controls:Key Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="a" ShiftDownText="A"
                       SharedSizeGroup="KeyWithSingleLetter"

--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/AlphabeticalConversationAlpha1.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/English/AlphabeticalConversationAlpha1.xaml
@@ -93,27 +93,7 @@
                       SharedSizeGroup="KeyWithSingleLetter"
                       Value="j"/>
 
-        <ContentControl Grid.Row="3" Grid.Column="0">
-            <ContentControl.Style>
-                <Style TargetType="{x:Type ContentControl}">
-                    <Setter Property="Content">
-                        <Setter.Value>
-                            <controls:Key />
-                        </Setter.Value>
-                    </Setter>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Source={x:Static properties:Settings.Default}, Path=EnableCommuniKateKeyboardLayout}" Value="True">
-                            <Setter Property="Content">
-                                <Setter.Value>
-                                    <controls:Key Text="CK" SymbolGeometry="{StaticResource CommuniKateIcon}"
-                                                  Value="{x:Static models:KeyValues.ConversationCommuniKateKeyboardKey}"/>
-                                </Setter.Value>
-                            </Setter>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ContentControl.Style>
-        </ContentControl>
+        <controls:Key Grid.Row="3" Grid.Column="0"/>
         <controls:Key Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2"
                       ShiftUpText="k" ShiftDownText="K"
                       SharedSizeGroup="KeyWithSingleLetter"

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml
@@ -45,7 +45,7 @@
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.KEYBOARD_AND_DICTIONARY_LANGUAGE_LABEL}"
                                VerticalAlignment="Center" Margin="5" />
-                    <ComboBox Grid.Row="0" Grid.Column="1"
+                    <ComboBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding Languages}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
@@ -59,7 +59,7 @@
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static resx:Resources.UI_LANGUAGE_LABEL}"
                                VerticalAlignment="Center" Margin="5" />
-                    <ComboBox Grid.Row="2" Grid.Column="1"
+                    <ComboBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding Languages}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
@@ -84,7 +84,7 @@
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-                    <ComboBox Grid.Row="4" Grid.Column="1"
+                    <ComboBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding KeyboardLayouts}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
@@ -280,9 +280,12 @@
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
@@ -338,11 +341,82 @@
 
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.SUGGESTION_METHOD}"
                                VerticalAlignment="Center" Margin="5" />
-                    <ComboBox Grid.Row="4" Grid.Column="1"
+                    <ComboBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding SuggestionMethods}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
                               SelectedValue="{Binding SuggestionMethod, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static resx:Resources.PRESAGE_DATABASE_LOCATION_LABEL}" 
+                            VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PresageSettingsAreVisible}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Left">
+                        <Button Click="btnFindPresageDatabaseLocation_Click" MinWidth="100" Margin="0,5,5,5" VerticalAlignment="Center">
+                            <x:Static Member="resx:Resources.MARYTTS_LOCATION_FIND_LABEL"/>
+                        </Button>
+                        <StackPanel.Style>
+                            <Style TargetType="{x:Type StackPanel}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PresageSettingsAreVisible}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                    </StackPanel>
+                    <TextBlock Grid.Row="5" Grid.Column="2" Name="txtPresageDatabaseLocation"
+                                Text="{Binding PresageDatabaseLocation, Mode=TwoWay}" 
+                                VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PresageSettingsAreVisible}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{x:Static resx:Resources.PRESAGE_NUMBER_OF_SUGGESTIONS_LABEL}"
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PresageSettingsAreVisible}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <controls:NumericUpDown Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                                            Minimum="1" Interval="1" Maximum="100"
+                                            Value="{Binding PresageNumberOfSuggestions, Mode=TwoWay}" >
+                        <controls:NumericUpDown.Style>
+                            <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PresageSettingsAreVisible}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </controls:NumericUpDown.Style>
+                    </controls:NumericUpDown>
                 </Grid>
             </GroupBox>
 

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml
@@ -66,32 +66,10 @@
                               SelectedValue="{Binding UiLanguage, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static resx:Resources.ENABLE_COMMUNIKATE_KEYBOARD_LAYOUT}"
-                               VerticalAlignment="Center" Margin="5" >
-                        <TextBlock.Style>
-                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding UseSimplifiedKeyboardLayout}" Value="True">
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                               VerticalAlignment="Center" Margin="5" Visibility="Visible" />
                     <CheckBox Grid.Row="3" Grid.Column="1"
-                              VerticalAlignment="Center"
-                              IsChecked="{Binding EnableCommuniKateKeyboardLayout, Mode=TwoWay}" >
-                        <CheckBox.Style>
-                            <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding UseSimplifiedKeyboardLayout}" Value="True">
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </CheckBox.Style>
-                    </CheckBox>
+                              VerticalAlignment="Center" Visibility="Visible"
+                              IsChecked="{Binding EnableCommuniKateKeyboardLayout, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.KEYBOARD_LAYOUT}"
                                VerticalAlignment="Center" Margin="5">
@@ -127,7 +105,7 @@
                             VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -142,7 +120,7 @@
                         </Button>
                         <StackPanel.Style>
                             <Style TargetType="{x:Type StackPanel}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -156,7 +134,7 @@
                                 VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -170,7 +148,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -184,7 +162,7 @@
                                             Value="{Binding CommuniKateSoundVolume, Mode=TwoWay}" >
                         <controls:NumericUpDown.Style>
                             <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -198,7 +176,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -212,7 +190,7 @@
                               IsChecked="{Binding CommuniKateSpeakSelected, Mode=TwoWay}" >
                         <CheckBox.Style>
                             <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource {x:Type CheckBox}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -226,7 +204,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -243,7 +221,7 @@
                                             Value="{Binding CommuniKateSpeakSelectedVolume, Mode=TwoWay}" >
                         <controls:NumericUpDown.Style>
                             <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -260,7 +238,7 @@
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -277,7 +255,7 @@
                                             Value="{Binding CommuniKateSpeakSelectedRate, Mode=TwoWay}" >
                         <controls:NumericUpDown.Style>
                             <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
-                                <Setter Property="Visibility" Value="{Binding EnableCommuniKateKeyboardLayoutIsVisible, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
+                                <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding EnableCommuniKateKeyboardLayout}" Value="False">
                                         <Setter Property="Visibility" Value="Collapsed" />

--- a/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Management/WordsView.xaml.cs
@@ -44,5 +44,34 @@ namespace JuliusSweetland.OptiKey.UI.Views.Management
                 }
             }
         }
+
+        private void btnFindPresageDatabaseLocation_Click(object sender, RoutedEventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog
+            {
+                Filter = "Presaage Database (*.db)|*.db"
+            };
+
+            if (openFileDialog.ShowDialog() == true)
+            {
+                string fileLocation = null;
+
+                if (openFileDialog.FileName.EndsWith(@".db"))
+                {
+                    txtPresageDatabaseLocation.Text = openFileDialog.FileName;
+                    fileLocation = txtPresageDatabaseLocation.Text;
+                }
+                else
+                {
+                    txtPresageDatabaseLocation.Text = Properties.Resources.COMMUNIKATE_TOPPAGE_LOCATION_ERROR_LABEL;
+                }
+
+                WordsViewModel viewModel = this.DataContext as WordsViewModel;
+                if (viewModel != null && !string.IsNullOrWhiteSpace(fileLocation))
+                {
+                    viewModel.PresageDatabaseLocation = fileLocation;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The CommuniKate keyboard can now be enabled and used by any language. To access it a key has been added to the Output section.

Apostrophe support has been added to Presage along with the database from ACAT which contains contractions.