### PR TITLE
Adds a green border to the first letter of word in multi-key selectionn, visible till the word ends

### DIFF
--- a/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey/JuliusSweetland.OptiKey.csproj
@@ -348,6 +348,7 @@
     <Compile Include="Services\Audio\SoundPlayerEx.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Services\InstanceGetter.cs" />
     <Compile Include="Services\Suggestions\IManagedSuggestions.cs" />
     <Compile Include="Services\Suggestions\BasicAutoComplete.cs" />
     <Compile Include="Services\Suggestions\ISuggestions.cs" />

--- a/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Dark.xaml
+++ b/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Dark.xaml
@@ -22,7 +22,8 @@
             <SolidColorBrush x:Key="KeyHoverForegroundBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="KeySelectionProgressBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="CapturingMultiKeySelectionBrush" Color="{StaticResource Red}" />
-
+            <SolidColorBrush x:Key="FirstMultiKeySelectionBorderBrush" Color="{StaticResource Green}"/>
+            
             <StaticResource x:Key="KeySelectionForeground" ResourceKey="Blue"/>
             <StaticResource x:Key="KeySelectionBorder" ResourceKey="Grey"/>
             <StaticResource x:Key="KeySelectionBackground" ResourceKey="Grey"/>
@@ -444,6 +445,34 @@
                 </Style.Triggers>
             </Style>
 
+            <!--Style triggers for Green border around first typed MultiKey-->
+            <Style x:Key="MultiKeyBorderHighlightStyle" TargetType="{x:Type Border}">
+                <Setter Property="BorderThickness" Value="5" />
+                <Setter Property="BorderBrush" Value="{StaticResource FirstMultiKeySelectionBorderBrush}" />
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <BlurEffect Radius="5.0" KernelType="Gaussian"/>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <!--This key has a Hover Foreground Colour Override-->
+                    <DataTrigger Binding="{Binding Path=HoverForegroundColourOverride, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Converter={StaticResource OverrideHasValue}, Mode=OneWay}" Value="True">
+                        <Setter Property="BorderBrush" Value="{Binding Path=HoverForegroundColourOverride, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Converter={StaticResource CloneBrush}, Mode=OneWay}" />
+                    </DataTrigger>
+
+                    <!--Is Key Enabled-->
+                    <DataTrigger Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="False">
+                        <Setter Property="BorderBrush" Value="{StaticResource KeyDisabledForegroundBrush}" />
+                    </DataTrigger>
+
+                    <!--Make visible when this key is current-->
+                    <DataTrigger Binding="{Binding Path=IsFirstMultiKey, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
             <Style TargetType="{x:Type controls:Key}">
                 <Setter Property="Template">
                     <Setter.Value>
@@ -511,6 +540,8 @@
                                     </Grid>
                                 </Border>
                                 <Border Style="{StaticResource KeyBorderHighlightStyle}" />
+                                <!--Custom border style for multiKey-->
+                                <Border Style="{StaticResource MultiKeyBorderHighlightStyle}" />
                             </Grid>
                         </ControlTemplate>
                     </Setter.Value>

--- a/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Light.xaml
+++ b/src/JuliusSweetland.OptiKey/Resources/Themes/Android_Light.xaml
@@ -22,7 +22,8 @@
             <SolidColorBrush x:Key="KeyHoverForegroundBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="KeySelectionProgressBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="CapturingMultiKeySelectionBrush" Color="{StaticResource Red}" />
-
+            <SolidColorBrush x:Key="FirstMultiKeySelectionBorderBrush" Color="{StaticResource Green}"/>
+            
             <StaticResource x:Key="KeySelectionForeground" ResourceKey="Blue"/>
             <StaticResource x:Key="KeySelectionBorder" ResourceKey="Grey"/>
             <StaticResource x:Key="KeySelectionBackground" ResourceKey="Grey"/>
@@ -444,6 +445,34 @@
                 </Style.Triggers>
             </Style>
 
+            <!--Style triggers for Green border around first typed MultiKey-->
+            <Style x:Key="MultiKeyBorderHighlightStyle" TargetType="{x:Type Border}">
+                <Setter Property="BorderThickness" Value="5" />
+                <Setter Property="BorderBrush" Value="{StaticResource FirstMultiKeySelectionBorderBrush}" />
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <BlurEffect Radius="5.0" KernelType="Gaussian"/>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <!--This key has a Hover Foreground Colour Override-->
+                    <DataTrigger Binding="{Binding Path=HoverForegroundColourOverride, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Converter={StaticResource OverrideHasValue}, Mode=OneWay}" Value="True">
+                        <Setter Property="BorderBrush" Value="{Binding Path=HoverForegroundColourOverride, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Converter={StaticResource CloneBrush}, Mode=OneWay}" />
+                    </DataTrigger>
+
+                    <!--Is Key Enabled-->
+                    <DataTrigger Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="False">
+                        <Setter Property="BorderBrush" Value="{StaticResource KeyDisabledForegroundBrush}" />
+                    </DataTrigger>
+
+                    <!--Make visible when this key is current-->
+                    <DataTrigger Binding="{Binding Path=IsFirstMultiKey, RelativeSource={RelativeSource AncestorType={x:Type controls:Key}}, Mode=OneWay}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            
             <Style TargetType="{x:Type controls:Key}">
                 <Setter Property="Template">
                     <Setter.Value>
@@ -511,6 +540,8 @@
                                     </Grid>
                                 </Border>
                                 <Border Style="{StaticResource KeyBorderHighlightStyle}" />
+                                <!--Custom border style for multiKey-->
+                                <Border Style="{StaticResource MultiKeyBorderHighlightStyle}" />
                             </Grid>
                         </ControlTemplate>
                     </Setter.Value>

--- a/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
+++ b/src/JuliusSweetland.OptiKey/Services/InputService.subscriptions.cs
@@ -30,6 +30,7 @@ namespace JuliusSweetland.OptiKey.Services
 
         private TriggerSignal? startMultiKeySelectionTriggerSignal;
         private TriggerSignal? stopMultiKeySelectionTriggerSignal;
+        private UI.Controls.Key firstMultiKeyTyped;
 
         #endregion
 
@@ -177,6 +178,14 @@ namespace JuliusSweetland.OptiKey.Services
 
                                 PublishSelection(triggerSignal.PointAndKeyValue);
 
+                                //Identifying the Controls.Key that is pressed, and setting the IsFirstMultiKey property to true in order to show the green border:
+                                UI.Controls.Key firstKeyInMultiKeySelection = InstanceGetter.Instance.allKeys.Find(k => k.ShiftUpText == triggerSignal.PointAndKeyValue.KeyValue.String);
+                                if (firstKeyInMultiKeySelection != null)
+                                {
+                                    firstKeyInMultiKeySelection.IsFirstMultiKey = true;
+                                    firstMultiKeyTyped = firstKeyInMultiKeySelection;
+                                }
+
                                 multiKeySelectionSubscription =
                                     CreateMultiKeySelectionSubscription()
                                         .ObserveOnDispatcher()
@@ -195,6 +204,10 @@ namespace JuliusSweetland.OptiKey.Services
 
                                                 stopMultiKeySelectionTriggerSignal = null;
                                                 CapturingMultiKeySelection = false;
+
+                                                //Set IsFirstMultiKey to false in order to remove the green border:
+                                                firstMultiKeyTyped.IsFirstMultiKey = false;
+                                                firstMultiKeyTyped = null;
                                             });
                             }
                             else

--- a/src/JuliusSweetland.OptiKey/Services/InstanceGetter.cs
+++ b/src/JuliusSweetland.OptiKey/Services/InstanceGetter.cs
@@ -1,0 +1,25 @@
+﻿using JuliusSweetland.OptiKey.UI.Controls;
+using System.Collections.Generic;
+
+namespace JuliusSweetland.OptiKey.Services
+{
+    public class InstanceGetter
+    {
+        public List<Key> allKeys { get; set; }
+
+        private static InstanceGetter instance;
+
+        public static InstanceGetter Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new InstanceGetter();
+                }
+                return instance;
+            }
+        }
+    }
+}
+

--- a/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/Key.cs
@@ -174,6 +174,16 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             set { SetValue(IsCurrentProperty, value); }
         }
 
+        //Should be true when key is the first selected key in multiKey sequence, and false otherwise.
+        public static readonly DependencyProperty IsFirstMultiKeyProperty =
+            DependencyProperty.Register("IsFirstMultiKey", typeof(bool), typeof(Key), new PropertyMetadata(default(bool)));
+
+        public bool IsFirstMultiKey
+        {
+            get { return (bool)GetValue(IsFirstMultiKeyProperty); }
+            set { SetValue(IsFirstMultiKeyProperty, value); }
+        }
+
         public static readonly DependencyProperty SelectionProgressProperty =
             DependencyProperty.Register("SelectionProgress", typeof(double), typeof(Key), new PropertyMetadata(default(double)));
 

--- a/src/JuliusSweetland.OptiKey/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Controls/KeyboardHost.cs
@@ -2,6 +2,7 @@
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.UI.Utilities;
 using JuliusSweetland.OptiKey.UI.ViewModels.Keyboards.Base;
 using log4net;
@@ -502,6 +503,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
         private void TraverseAllKeysAndBuildPointToKeyValueMap()
         {
             var allKeys = VisualAndLogicalTreeHelper.FindVisualChildren<Key>(this).ToList();
+            InstanceGetter.Instance.allKeys = allKeys;
 
             var pointToKeyValueMap = new Dictionary<Rect, KeyValue>();
 


### PR DESCRIPTION
A copy of the instance of allKeys is created using InstanceGetter, and retrieved when processing multi-key selection, to find the first letter of the word. A boolean is set to true, which is also checked in the UI, in order to add the green border, and is set to false, once the last letter of the word is typed. 