### PR TITLE
Fixed "w" not enabled bug in the Danish keyboard.

### DIFF
--- a/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
+++ b/src/JuliusSweetland.OptiKey/Models/KeyValues.cs
@@ -277,7 +277,7 @@ namespace JuliusSweetland.OptiKey.Models
                                                 .Select(c => new KeyValue (c.ToString(CultureInfo.InvariantCulture) ))
                                                 .ToList()
                 },
-                { Languages.DanishDenmark, "abcdefghijklmnopqrstuvxyzæøå"
+                { Languages.DanishDenmark, "abcdefghijklmnopqrstuvwxyzæøå"
                                                 .ToCharArray()
                                                 .Select(c => new KeyValue (c.ToString(CultureInfo.InvariantCulture) ))
                                                 .ToList()


### PR DESCRIPTION
Hi Julius.

We hope you are doing well.

@tbafna and I (working on research project GazeIT, which helped implement the Danish localisation keyboard for OptiKey) found a bug. When enabling the multikey feature, the "w" key was Gray'ed out (not enabled). After looking through the code for a little while I found the cause for the bug: The bug was due to the fact that "w" was not part of the Danish default keys in multiKeySelectionKeys. It has now been added and the "w" bug is gone.
This is a pull request to fix that bug.

Please notify me when the commit has been released :-)

Best, Peter and Tanya from research project Gaze-IT.