### PR TITLE
Dynamic keyboard row and column validation

### DIFF
--- a/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
@@ -113,7 +113,8 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
 
 		private string GetKeyString(XmlKey xmlKey)
 		{
-			if (xmlKey is XmlTextKey textKey)
+			var textKey = xmlKey as XmlTextKey;
+			if (textKey != null)
 				return textKey.Text;
 			else
 				return xmlKey.Label ?? xmlKey.Symbol;


### PR DESCRIPTION
Issue https://github.com/OptiKey/OptiKey/issues/475. Shows the error keyboard if any keys in the dynamic keyboard have matching row and column numbers. In the error keyboard content, it shows the offending keys grouped by row/column. An example of the output might look something like this: A, B (1, 2), +, =, C (3, 3)