### PR TITLE
Address Issue #504: Toggle Off Multikey Selection When Using Simplified Keyboard

### DIFF
--- a/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
@@ -137,12 +137,22 @@ namespace JuliusSweetland.OptiKey.Services
         private void AddSettingChangeHandlers()
         {
             Log.Info("Adding setting change handlers.");
-            
-            Settings.Default.OnPropertyChanges(s => s.MultiKeySelectionEnabled && s.KeyboardLayout != KeyboardLayouts.Simplified)
+
+            Settings.Default
+                .OnPropertyChanges(s => s.MultiKeySelectionEnabled)
                 .Where(mkse => !mkse)
                 .Subscribe(_ =>
                 {
                     //Release multi-key selection key if multi-key selection is disabled from the settings
+                    KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.Up;
+                });
+
+            Settings.Default
+                .OnPropertyChanges(s => s.KeyboardLayout)
+                .Where(layout => layout == KeyboardLayouts.Simplified)
+                .Subscribe(_ =>
+                {
+                    //Release multi-key selection key if using simplified keyboard
                     KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.Up;
                 });
         }

--- a/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
+++ b/src/JuliusSweetland.OptiKey/Services/KeyStateService.cs
@@ -127,6 +127,7 @@ namespace JuliusSweetland.OptiKey.Services
         {
             KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value =
                 Settings.Default.MultiKeySelectionEnabled &&
+                Settings.Default.KeyboardLayout != KeyboardLayouts.Simplified &&
                 ((SimulateKeyStrokes && Settings.Default.MultiKeySelectionLockedDownWhenSimulatingKeyStrokes)
                 || (!SimulateKeyStrokes && Settings.Default.MultiKeySelectionLockedDownWhenNotSimulatingKeyStrokes))
                     ? Enums.KeyDownStates.LockedDown
@@ -137,11 +138,13 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.Info("Adding setting change handlers.");
             
-            Settings.Default.OnPropertyChanges(s => s.MultiKeySelectionEnabled).Where(mkse => !mkse).Subscribe(_ =>
-            {
-                //Release multi-key selection key if multi-key selection is disabled from the settings
-                KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.Up;
-            });
+            Settings.Default.OnPropertyChanges(s => s.MultiKeySelectionEnabled && s.KeyboardLayout != KeyboardLayouts.Simplified)
+                .Where(mkse => !mkse)
+                .Subscribe(_ =>
+                {
+                    //Release multi-key selection key if multi-key selection is disabled from the settings
+                    KeyDownStates[KeyValues.MultiKeySelectionIsOnKey].Value = Enums.KeyDownStates.Up;
+                });
         }
 
         private void AddSimulateKeyStrokesChangeHandler()

--- a/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -283,7 +283,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             }
         }
       
-	private void KeySelectionResult(KeyValue singleKeyValue, List<string> multiKeySelection)
+	    private void KeySelectionResult(KeyValue singleKeyValue, List<string> multiKeySelection)
         {
             // Pass single key to appropriate processing function
             if (singleKeyValue != null)


### PR DESCRIPTION
As stated in issue #504 , the multikey selection feature will remain active if it's toggled in the alpha keyboard and then switching to the simplified keyboard. This behavior won't make sense because it's not supported in the simplified keyboard.

This PR will update this behavior: 
1. When multikey selection is on when switching to the simplified keyboard, its state will be reset (i.e. turned off), such that it's de facto toggled off when using the simplified keyboard. This patch will stand because there's no multikey selection on/off key on the simplified keyboard.
2. When switching back to the alpha keyboard, the multikey selection key will remain off regardless of its previous state (the state before switching to the simplified keyboard). Though the "remembered" key state won't be affected if user close the keyboard.

Please let me know if you have any questions or comments. 