### PR TITLE
Log the user's settings.

### DIFF
--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -278,7 +278,7 @@ namespace JuliusSweetland.OptiKey
 
                 foreach (SettingsProperty property in Settings.Default.Properties)
                 {
-                    Log.InfoFormat("  {0}: {1}", property.Name, Settings.Default[property.Name].ToString());
+                    Log.InfoFormat("  {0}: {1}", property.Name, Settings.Default[property.Name]);
                 }
             }
         }

--- a/src/JuliusSweetland.OptiKey/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey/App.xaml.cs
@@ -122,6 +122,9 @@ namespace JuliusSweetland.OptiKey
         {
             try
             {
+                // Output the user settings for debugging
+                logUserSettings();
+
                 Log.Info("Boot strapping the services and UI.");
 
                 //Apply theme
@@ -252,6 +255,31 @@ namespace JuliusSweetland.OptiKey
             {
                 Log.Error("Error starting up application", ex);
                 throw;
+            }
+        }
+
+        private void logUserSettings()
+        {
+
+            // If debug switched on, dump entire XML into log so we can replicate issues.
+            if (Settings.Default.Debug)
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);
+                Log.Debug(config.FilePath);
+
+                // We read into a single string so we can print without log4net preamble on each line.
+                string configText = File.ReadAllText(config.FilePath);
+                Log.DebugFormat("\r\n{0}", configText);
+            }
+            // Otherwise just key: value pairs into log
+            else
+            {
+                Log.Info("Current user settings:");
+
+                foreach (SettingsProperty property in Settings.Default.Properties)
+                {
+                    Log.InfoFormat("  {0}: {1}", property.Name, Settings.Default[property.Name].ToString());
+                }
             }
         }
 


### PR DESCRIPTION
For issue #552 

Can you please review whether:
`ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoaming);`
is safe to use to get the users' settings file, and won't somehow be different for some systems/installations?

You might also have a nicer solution for reading/logging the file incrementally without the log4net preamble on every line - I couldn't find an easy way to temporarily disable the logging conversionPattern. 