### PR TITLE
Add build dependency for plugins

### DIFF
--- a/OptiKey.sln
+++ b/OptiKey.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JuliusSweetland.OptiKey", "src\JuliusSweetland.OptiKey.Core\JuliusSweetland.OptiKey.csproj", "{6865C5AF-C6F0-4BDA-BA1C-7AE8BC225234}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0C8F0372-2D55-41BC-9730-4ACE3ED67452} = {0C8F0372-2D55-41BC-9730-4ACE3ED67452}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{117E0D45-AA2F-4A2B-AAD5-C3101E1CBCA8}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
I noticed the currect master branch doesn't have a build dependency set up to make sure the plugins are built (and copied across) before the main Optikey project is built, which means the build fails if you haven't built it all before. 