### PR TITLE
Symbol orientation fix for #581

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.csproj
@@ -445,6 +445,7 @@
     <Compile Include="UI\ValueConverters\EnumToVisibilityConverter.cs" />
     <Compile Include="UI\ValueConverters\InsertNewlinesBetweenWords.cs" />
     <Compile Include="UI\ValueConverters\BoolToCustomValues.cs" />
+    <Compile Include="UI\ValueConverters\DockPositionToSymbolOrientation.cs" />
     <Compile Include="UI\ValueConverters\TestConverter.cs" />
     <Compile Include="UI\ValueConverters\ListNotEmpty.cs" />
     <Compile Include="UI\ValueConverters\IsGreaterThan.cs" />

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/DockPositionToSymbolOrientation.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/DockPositionToSymbolOrientation.cs
@@ -11,14 +11,13 @@ namespace JuliusSweetland.OptiKey.UI.ValueConverters
     /*
      * Computes symbol orientation for a symbol, based on current dock position     
      */
-    public class DockPositionToSymbolOrientation : IMultiValueConverter
+    public class DockPositionToSymbolOrientation : IValueConverter
     {
-        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values.Length == 1
-                && values.All(v => v != DependencyProperty.UnsetValue))
+            if (value != null)
             {
-                var dockPosition = (DockEdges)values[0];
+                var dockPosition = (DockEdges) value;
                 switch (dockPosition)
                 {
                     case DockEdges.Right:
@@ -33,13 +32,12 @@ namespace JuliusSweetland.OptiKey.UI.ValueConverters
                     default: //case DockEdges.Top:
                         return SymbolOrientations.Top;
                 }
-        
             }
-            
+
             return SymbolOrientations.Top; //Default
         }
 
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/DockPositionToSymbolOrientation.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/DockPositionToSymbolOrientation.cs
@@ -9,33 +9,31 @@ using JuliusSweetland.OptiKey.Enums;
 namespace JuliusSweetland.OptiKey.UI.ValueConverters
 {
     /*
-     * Computes symbol orientation for a 'Minimise' symbol, based on current dock position
-     * and the preference for Optikey gets minimis
+     * Computes symbol orientation for a symbol, based on current dock position     
      */
-    public class MinimiseAndDockPositionToSymbolOrientation : IMultiValueConverter
+    public class DockPositionToSymbolOrientation : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values.Length == 2
+            if (values.Length == 1
                 && values.All(v => v != DependencyProperty.UnsetValue))
             {
-                var minimisedPosition = (MinimisedEdges)values[0];
-                var dockPosition = (DockEdges)values[1];
-
-                switch (minimisedPosition == MinimisedEdges.SameAsDockedPosition ? dockPosition.ToMinimisedEdge() : minimisedPosition)
+                var dockPosition = (DockEdges)values[0];
+                switch (dockPosition)
                 {
-                    case MinimisedEdges.Right:
+                    case DockEdges.Right:
                         return SymbolOrientations.Right;
 
-                    case MinimisedEdges.Bottom:
+                    case DockEdges.Bottom:
                         return SymbolOrientations.Bottom;
 
-                    case MinimisedEdges.Left:
+                    case DockEdges.Left:
                         return SymbolOrientations.Left;
 
-                    default: //case MinimisedEdges.Top:
+                    default: //case DockEdges.Top:
                         return SymbolOrientations.Top;
                 }
+        
             }
             
             return SymbolOrientations.Top; //Default

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/Mouse.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/Mouse.xaml
@@ -233,14 +233,8 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                               SymbolGeometry="{StaticResource CollapseDockIcon}"
                                                               Text="{x:Static resx:Resources.COLLAPSE_DOCK_SPLIT_WITH_NEWLINE}"
                                                               SharedSizeGroup="KeyWithSymbolAndText"
+                                                              SymbolOrientation="{Binding Source={x:Static properties:Settings.Default}, Path=MainWindowDockPosition, Converter={StaticResource DockPositionToSymbolOrientation}}"
                                                               Value="{x:Static models:KeyValues.CollapseDockKey}">
-                                                    <controls:Key.SymbolOrientation>
-                                                        <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
-                                                            <MultiBinding.Bindings>
-                                                                <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                            </MultiBinding.Bindings>
-                                                        </MultiBinding>
-                                                    </controls:Key.SymbolOrientation>
                                                 </controls:Key>
                                                 <controls:Key Grid.Row="8" Grid.Column="7" Grid.RowSpan="2"
                                                               SymbolGeometry="{StaticResource BackIcon}"
@@ -333,14 +327,8 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                                       SymbolGeometry="{StaticResource ExpandDockIcon}"
                                                                       Text="{x:Static resx:Resources.EXPAND_DOCK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      SymbolOrientation="{Binding Source={x:Static properties:Settings.Default}, Path=MainWindowDockPosition, Converter={StaticResource DockPositionToSymbolOrientation}}"
                                                                       Value="{x:Static models:KeyValues.ExpandDockKey}">
-                                                            <controls:Key.SymbolOrientation>
-                                                                <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
-                                                                    <MultiBinding.Bindings>
-                                                                        <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                    </MultiBinding.Bindings>
-                                                                </MultiBinding>
-                                                            </controls:Key.SymbolOrientation>
                                                         </controls:Key>
                                                         <controls:Key Grid.Row="0" Grid.Column="9"
                                                                       SymbolGeometry="{StaticResource BackIcon}"
@@ -572,14 +560,8 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                                       SymbolGeometry="{StaticResource CollapseDockIcon}"
                                                                       Text="{x:Static resx:Resources.COLLAPSE_DOCK_SPLIT_WITH_NEWLINE}"
                                                                       SharedSizeGroup="KeyWithSymbolAndText"
+                                                                      SymbolOrientation="{Binding Source={x:Static properties:Settings.Default}, Path=MainWindowDockPosition, Converter={StaticResource DockPositionToSymbolOrientation}}"
                                                                       Value="{x:Static models:KeyValues.CollapseDockKey}">
-                                                            <controls:Key.SymbolOrientation>
-                                                                <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
-                                                                    <MultiBinding.Bindings>
-                                                                        <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                    </MultiBinding.Bindings>
-                                                                </MultiBinding>
-                                                            </controls:Key.SymbolOrientation>
                                                         </controls:Key>
                                                         <controls:Key Grid.Row="16" Grid.Column="3" Grid.RowSpan="2"
                                                                       SymbolGeometry="{StaticResource BackIcon}"
@@ -672,14 +654,8 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                                               SymbolGeometry="{StaticResource ExpandDockIcon}"
                                                                               Text="{x:Static resx:Resources.EXPAND_DOCK_SPLIT_WITH_NEWLINE}"
                                                                               SharedSizeGroup="KeyWithSymbolAndText"
+                                                                              SymbolOrientation="{Binding Source={x:Static properties:Settings.Default}, Path=MainWindowDockPosition, Converter={StaticResource DockPositionToSymbolOrientation}}"
                                                                               Value="{x:Static models:KeyValues.ExpandDockKey}">
-                                                                    <controls:Key.SymbolOrientation>
-                                                                        <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
-                                                                            <MultiBinding.Bindings>
-                                                                                <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                            </MultiBinding.Bindings>
-                                                                        </MultiBinding>
-                                                                    </controls:Key.SymbolOrientation>
                                                                 </controls:Key>
                                                                 <controls:Key Grid.Row="9" Grid.Column="0"
                                                                               SymbolGeometry="{StaticResource BackIcon}"

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/Mouse.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/Mouse.xaml
@@ -22,7 +22,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                 <ResourceDictionary>
                     <valueConverters:IntToSingularPluralStringFormatter x:Key="IntToSingularPluralStringFormatter" />
                     <valueConverters:WidthGreaterThanHeight DefaultValue="True" x:Key="WidthGreaterThanHeight" />
-                    <valueConverters:MinimiseAndDockPositionToSymbolOrientation x:Key="DockPositionToSymbolOrientation" />
+                    <valueConverters:DockPositionToSymbolOrientation x:Key="DockPositionToSymbolOrientation" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -238,7 +238,6 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                         <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                             <MultiBinding.Bindings>
                                                                 <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                <Binding Path="MainWindowState" Source="{x:Static properties:Settings.Default}" />
                                                             </MultiBinding.Bindings>
                                                         </MultiBinding>
                                                     </controls:Key.SymbolOrientation>
@@ -339,7 +338,6 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                                 <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                     <MultiBinding.Bindings>
                                                                         <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                        <Binding Path="MainWindowState" Source="{x:Static properties:Settings.Default}" />
                                                                     </MultiBinding.Bindings>
                                                                 </MultiBinding>
                                                             </controls:Key.SymbolOrientation>
@@ -579,7 +577,6 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                                 <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                     <MultiBinding.Bindings>
                                                                         <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                        <Binding Path="MainWindowState" Source="{x:Static properties:Settings.Default}" />
                                                                     </MultiBinding.Bindings>
                                                                 </MultiBinding>
                                                             </controls:Key.SymbolOrientation>
@@ -680,7 +677,6 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                                                         <MultiBinding Converter="{StaticResource DockPositionToSymbolOrientation}">
                                                                             <MultiBinding.Bindings>
                                                                                 <Binding Path="MainWindowDockPosition" Source="{x:Static properties:Settings.Default}" />
-                                                                                <Binding Path="MainWindowState" Source="{x:Static properties:Settings.Default}" />
                                                                             </MultiBinding.Bindings>
                                                                         </MultiBinding>
                                                                     </controls:Key.SymbolOrientation>


### PR DESCRIPTION
The converter previously used was intended for minimising optikey, i.e. a combination of current dock position and minimised position (which may be different). The mouse keyboard's contract/expand functionality is only related to the dock position. In addition there was a bug in the wrong enums being passed into the converter. 

I've made a new converter just for dock position, which solves issue #581 