### PR TITLE
Make sure changes in resolution are picked up.

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -723,6 +723,10 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.InfoFormat("CalculateDockSizeAndPositionInPx called with position:{0}, size:{1}", position, size);
 
+            // Check if screen bounds have changed (e.g. change in resolution)
+            screen = window.GetScreen();
+            screenBoundsInPx = new Rect(screen.Bounds.Left, screen.Bounds.Top, screen.Bounds.Width, screen.Bounds.Height);
+
             double x, y, width, height;
             double thicknessAsPercentage;
             if (overrideThicknessAsPercentage.HasValue)


### PR DESCRIPTION
There are a few scenarios in which optikey doesn't pick up changes in resolution - generally optikey shrinks correctly but doesn't grow back. This is a problem if you e.g. unplug your monitor while running optikey, or if you are running on a tablet that gets accidentally rotated (this is a common problem with EyeMine which is often run on Tobii tablets).

If we query `window.GetScreen` in `CalculateDockSizeAndPositionInPx` all seems fixed.