### PR TITLE
Dynamic keyboard color overrides and scratchpad control

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.csproj
+++ b/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.csproj
@@ -309,6 +309,7 @@
     <Compile Include="Models\SerializableDictionaryOfTimeSpanByKeyValues.cs" />
     <Compile Include="Models\XmlKeyboardModels\XmlKeys.cs" />
     <Compile Include="Models\XmlKeyboardModels\XmlKeyStates.cs" />
+    <Compile Include="Models\XmlKeyboardModels\XmlOutputKey.cs" />
     <Compile Include="Models\XmlKeyboardModels\XmlTextKey.cs" />
     <Compile Include="Models\XmlKeyboardModels\XmlUtils.cs" />
     <Compile Include="Native\Common\Enums\AppBarEdge.cs" />
@@ -424,6 +425,12 @@
     <Compile Include="UI\Controls\KeyboardView.cs" />
     <Compile Include="UI\Controls\DynamicKeyboard.cs" />
     <Compile Include="UI\Controls\DynamicKeyboardSelector.cs" />
+    <Compile Include="UI\Controls\XmlSuggestionRow.xaml.cs">
+      <DependentUpon>XmlSuggestionRow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UI\Controls\XmlScratchpad.xaml.cs">
+      <DependentUpon>XmlScratchpad.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\Controls\ToastNotification.cs" />
     <Compile Include="UI\Controls\Cursor.cs" />
     <Compile Include="UI\Controls\ToastNotificationPopup.cs" />
@@ -1405,6 +1412,14 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UI\Controls\CK20Page.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\Controls\XmlSuggestionRow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\Controls\XmlScratchpad.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlDynamicKey.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlDynamicKey.cs
@@ -31,6 +31,9 @@ namespace JuliusSweetland.OptiKey.Models
             set { this.ReturnToThisKeyboard = XmlUtils.ConvertToBoolean(value); }
         }
 
+        public string Scratchpad
+        { get; set; }
+
         public string Text
         { get; set; }
 

--- a/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlKey.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlKey.cs
@@ -28,5 +28,6 @@ namespace JuliusSweetland.OptiKey.Models
         public bool UsePersianCompatibilityFont { get; set; }
         public bool UseUnicodeCompatibilityFont { get; set; }
         public bool UseUrduCompatibilityFont { get; set; }
+        public string BackgroundColor { get; set; }
     }
 }

--- a/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlKeyboard.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlKeyboard.cs
@@ -3,7 +3,9 @@ using log4net;
 using System;
 using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Media;
 using System.Xml.Serialization;
 
 namespace JuliusSweetland.OptiKey.Models
@@ -79,6 +81,12 @@ namespace JuliusSweetland.OptiKey.Models
         { get; set; }
 
         protected static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public string BackgroundColor
+        { get; set; }
+
+        public string BorderColor
+        { get; set; }
 
         [XmlIgnore]
         public Thickness? BorderThickness

--- a/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlKeys.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlKeys.cs
@@ -10,20 +10,24 @@ namespace JuliusSweetland.OptiKey.Models
         public List<XmlActionKey> ActionKeys
         { get; set; }
 
-        [XmlElement(ElementName = "TextKey")]
-        public List<XmlTextKey> TextKeys
-        { get; set; }
-
         [XmlElement(ElementName = "ChangeKeyboardKey")]
         public List<XmlChangeKeyboardKey> ChangeKeyboardKeys
+        { get; set; }
+
+        [XmlElement(ElementName = "DynamicKey")]
+        public List<XmlDynamicKey> DynamicKeys
+        { get; set; }
+
+        [XmlElement(ElementName = "OutputKey")]
+        public List<XmlOutputKey> OutputKeys
         { get; set; }
 
         [XmlElement(ElementName = "PluginKey")]
         public List<XmlPluginKey> PluginKeys
         { get; set; }
 
-        [XmlElement(ElementName = "DynamicKey")]
-        public List<XmlDynamicKey> DynamicKeys
+        [XmlElement(ElementName = "TextKey")]
+        public List<XmlTextKey> TextKeys
         { get; set; }
 
         [XmlIgnore]
@@ -31,7 +35,7 @@ namespace JuliusSweetland.OptiKey.Models
         {
             get
             {
-                return ActionKeys.Count + TextKeys.Count + ChangeKeyboardKeys.Count + PluginKeys.Count + DynamicKeys.Count;
+                return ActionKeys.Count + ChangeKeyboardKeys.Count + DynamicKeys.Count + OutputKeys.Count + PluginKeys.Count + TextKeys.Count;
             }
         }
     }

--- a/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlOutputKey.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlOutputKey.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+namespace JuliusSweetland.OptiKey.Models
+{
+    public class XmlOutputKey : XmlKey
+    {
+        public string Output
+        { get; set; }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/Resources/Themes/Android_Dark.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/Resources/Themes/Android_Dark.xaml
@@ -17,6 +17,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
         <ResourceDictionary>
             <SolidColorBrush x:Key="WindowBorderBrush" Color="{StaticResource Grey}" />
+            <SolidColorBrush x:Key="KeyboardBackgroundBrush" Color="{StaticResource Black}" />
             <SolidColorBrush x:Key="KeyboardBorderBrush" Color="{StaticResource Grey}" />
 
             <SolidColorBrush x:Key="KeyDefaultForegroundBrush" Color="{StaticResource White}" />
@@ -27,7 +28,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
             <SolidColorBrush x:Key="KeySelectionProgressBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="CapturingMultiKeySelectionBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="HighlightedKeyBorderBrush" Color="{StaticResource Green}"/>
-            
+
             <StaticResource x:Key="KeySelectionForeground" ResourceKey="Blue"/>
             <StaticResource x:Key="KeySelectionBorder" ResourceKey="Grey"/>
             <StaticResource x:Key="KeySelectionBackground" ResourceKey="Grey"/>

--- a/src/JuliusSweetland.OptiKey.Core/Resources/Themes/Android_Light.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/Resources/Themes/Android_Light.xaml
@@ -11,14 +11,15 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                     xmlns:enums="clr-namespace:JuliusSweetland.OptiKey.Enums"
                     xmlns:keyboardBase="clr-namespace:JuliusSweetland.OptiKey.UI.ViewModels.Keyboards.Base"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
-    
+
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/OptiKey;component/Resources/Themes/Colours/Android.xaml" />
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
         <ResourceDictionary>
             <SolidColorBrush x:Key="WindowBorderBrush" Color="{StaticResource Grey}" />
+            <SolidColorBrush x:Key="KeyboardBackgroundBrush" Color="{StaticResource White}" />
             <SolidColorBrush x:Key="KeyboardBorderBrush" Color="{StaticResource Grey}" />
-            
+
             <SolidColorBrush x:Key="KeyDefaultForegroundBrush" Color="{StaticResource Black}" />
             <SolidColorBrush x:Key="KeyDefaultBorderBrush" Color="{StaticResource Grey}" />
             <SolidColorBrush x:Key="KeyDefaultBackgroundBrush" Color="{StaticResource White}" />
@@ -27,11 +28,11 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
             <SolidColorBrush x:Key="KeySelectionProgressBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="CapturingMultiKeySelectionBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="HighlightedKeyBorderBrush" Color="{StaticResource Green}"/>
-            
+
             <StaticResource x:Key="KeySelectionForeground" ResourceKey="Blue"/>
             <StaticResource x:Key="KeySelectionBorder" ResourceKey="Grey"/>
             <StaticResource x:Key="KeySelectionBackground" ResourceKey="Grey"/>
-            
+
             <SolidColorBrush x:Key="KeyDownStateIsDownForegroundBrush" Color="{StaticResource Blue}" />
             <SolidColorBrush x:Key="KeyDownStateIsDownBorderBrush" Color="{StaticResource Grey}" />
             <SolidColorBrush x:Key="KeyDownStateIsDownBackgroundBrush" Color="{StaticResource White}" />
@@ -48,17 +49,17 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
             <SolidColorBrush x:Key="ScratchpadForegroundBrush" Color="{StaticResource Blue}" />
             <SolidColorBrush x:Key="ScratchpadBorderBrush" Color="{StaticResource Grey}" />
             <SolidColorBrush x:Key="ScratchpadBackgroundBrush" Color="{StaticResource White}" />
-            
+
             <SolidColorBrush x:Key="ScratchpadDisabledForegroundBrush" Color="{StaticResource LightGrey}" />
             <SolidColorBrush x:Key="ScratchpadDisabledBorderBrush" Color="{StaticResource Grey}" />
             <SolidColorBrush x:Key="ScratchpadDisabledBackgroundBrush" Color="{StaticResource White}" />
 
             <SolidColorBrush x:Key="QuestionForegroundBrush" Color="{StaticResource Black}" />
             <SolidColorBrush x:Key="QuestionBackgroundBrush" Color="{StaticResource White}" />
-            
+
             <SolidColorBrush x:Key="DebugTextForegroundBrush" Color="{StaticResource Green}" />
             <SolidColorBrush x:Key="ManualModeTextForegroundBrush" Color="{StaticResource Green}" />
-            
+
             <SolidColorBrush x:Key="CursorDefaultStrokeBrush" Color="{StaticResource Black}" />
             <SolidColorBrush x:Key="CursorDefaultFillBrush" Color="{StaticResource White}" />
             <StaticResource x:Key="PointSelectionForeground" ResourceKey="Blue"/>
@@ -524,7 +525,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
-            
+
             <Style TargetType="{x:Type controls:Key}">
                 <Setter Property="Template">
                     <Setter.Value>

--- a/src/JuliusSweetland.OptiKey.Core/Resources/Themes/Android_Two_Tone.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/Resources/Themes/Android_Two_Tone.xaml
@@ -17,6 +17,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
         <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
         <ResourceDictionary>
             <SolidColorBrush x:Key="WindowBorderBrush" Color="{StaticResource Grey}" />
+            <SolidColorBrush x:Key="KeyboardBackgroundBrush" Color="{StaticResource Black}" />
             <SolidColorBrush x:Key="KeyboardBorderBrush" Color="{StaticResource Grey}" />
 
             <SolidColorBrush x:Key="KeyDefaultForegroundBrush" Color="{StaticResource White}" />
@@ -28,7 +29,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
             <SolidColorBrush x:Key="KeySelectionProgressBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="CapturingMultiKeySelectionBrush" Color="{StaticResource Red}" />
             <SolidColorBrush x:Key="HighlightedKeyBorderBrush" Color="{StaticResource Green}"/>
-            
+
             <StaticResource x:Key="KeySelectionForeground" ResourceKey="Blue"/>
             <StaticResource x:Key="KeySelectionBorder" ResourceKey="Grey"/>
             <StaticResource x:Key="KeySelectionBackground" ResourceKey="Grey"/>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlScratchpad.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlScratchpad.xaml
@@ -1,0 +1,38 @@
+﻿<!--
+Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+-->
+<UserControl x:Class="JuliusSweetland.OptiKey.UI.Controls.XmlScratchpad"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
+             xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
+             xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
+             xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+             xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300"
+             Background="{DynamicResource KeyDefaultBackgroundBrush}">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+  <Grid Grid.IsSharedSizeScope="True">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
+
+    <controls:Scratchpad Grid.Row="0" Grid.Column="0" x:Name="Scratchpad"
+                         Text="{Binding DataContext.KeyboardOutputService.Text, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=OneWay}"
+                         FlowDirection="{Binding Source={x:Static resx:Settings.Default}, Path=UiLanguageFlowDirection}" />
+    </Grid>
+</UserControl>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlScratchpad.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlScratchpad.xaml.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+
+using System.Windows.Controls;
+
+namespace JuliusSweetland.OptiKey.UI.Controls
+{
+    /// <summary>
+    /// Interaction logic for XmlScratchpad.xaml
+    /// </summary>
+    public partial class XmlScratchpad : UserControl
+    {
+        public XmlScratchpad()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlSuggestionRow.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlSuggestionRow.xaml
@@ -1,0 +1,95 @@
+﻿<!--
+Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+-->
+<UserControl x:Class="JuliusSweetland.OptiKey.UI.Controls.XmlSuggestionRow"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:system="clr-namespace:System;assembly=mscorlib"
+             xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
+             xmlns:controls="clr-namespace:JuliusSweetland.OptiKey.UI.Controls"
+             xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+             xmlns:models="clr-namespace:JuliusSweetland.OptiKey.Models"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300"
+             Background="{DynamicResource KeyDefaultBackgroundBrush}">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
+                <ResourceDictionary>
+                    <valueConverters:SuggestionsPaged x:Key="SuggestionsPaged" />
+                    <valueConverters:BoolToCustomValues TrueValue="1*" FalseValue="0*" x:Key="BoolToCustomValues" />
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid Grid.IsSharedSizeScope="True">
+
+        <Grid Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4">
+            <controls:Key Grid.Row="0" Grid.Column="0" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static models:KeyValues.Suggestion1Key}">
+                <controls:Key.Text>
+                    <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
+                        <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPerPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding>
+                            <Binding.Source>
+                                <system:Int32>0</system:Int32>
+                            </Binding.Source>
+                        </Binding>
+                    </MultiBinding>
+                </controls:Key.Text>
+            </controls:Key>
+            <controls:Key Grid.Row="0" Grid.Column="1" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static models:KeyValues.Suggestion2Key}">
+                <controls:Key.Text>
+                    <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
+                        <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPerPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding>
+                            <Binding.Source>
+                                <system:Int32>1</system:Int32>
+                            </Binding.Source>
+                        </Binding>
+                    </MultiBinding>
+                </controls:Key.Text>
+            </controls:Key>
+            <controls:Key Grid.Row="0" Grid.Column="2" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static models:KeyValues.Suggestion3Key}">
+                <controls:Key.Text>
+                    <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
+                        <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPerPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding>
+                            <Binding.Source>
+                                <system:Int32>2</system:Int32>
+                            </Binding.Source>
+                        </Binding>
+                    </MultiBinding>
+                </controls:Key.Text>
+            </controls:Key>
+            <controls:Key Grid.Row="0" Grid.Column="3" SharedSizeGroup="KeyWithSuggestion" Case="None"
+                          Value="{x:Static models:KeyValues.Suggestion4Key}">
+                <controls:Key.Text>
+                    <MultiBinding Converter="{StaticResource SuggestionsPaged}" Mode="OneWay">
+                        <Binding Path="DataContext.SuggestionService.Suggestions" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding Path="DataContext.SuggestionService.SuggestionsPerPage" RelativeSource="{RelativeSource AncestorType=controls:KeyboardHost}" />
+                        <Binding>
+                            <Binding.Source>
+                                <system:Int32>3</system:Int32>
+                            </Binding.Source>
+                        </Binding>
+                    </MultiBinding>
+                </controls:Key.Text>
+            </controls:Key>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlSuggestionRow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/XmlSuggestionRow.xaml.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Extensions;
+using JuliusSweetland.OptiKey.Properties;
+
+namespace JuliusSweetland.OptiKey.UI.Controls
+{
+    /// <summary>
+    /// Interaction logic for XmlSuggestions.xaml
+    /// </summary>
+    public partial class XmlSuggestionRow : UserControl
+    {
+        public XmlSuggestionRow()
+        {
+            InitializeComponent();
+            Loaded += (sender, args) => NumberOfSuggestionsDisplayed = 4;
+        }
+
+        public static readonly DependencyProperty NumberOfSuggestionsDisplayedProperty =
+            DependencyProperty.Register("NumberOfSuggestionsDisplayed", typeof(int), typeof(Output), new PropertyMetadata(default(int)));
+
+        public int NumberOfSuggestionsDisplayed
+        {
+            get { return (int)GetValue(NumberOfSuggestionsDisplayedProperty); }
+            set { SetValue(NumberOfSuggestionsDisplayedProperty, value); }
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
@@ -36,7 +36,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         private readonly IKeyboardOutputService keyboardOutputService;
         private readonly IMouseOutputService mouseOutputService;
         private readonly IWindowManipulationService mainWindowManipulationService;
-        private readonly List<INotifyErrors> errorNotifyingServices; 
+        private readonly List<INotifyErrors> errorNotifyingServices;
         private readonly InteractionRequest<NotificationWithCalibrationResult> calibrateRequest;
         private readonly StringBuilder pendingErrorToastNotificationContent = new StringBuilder();
 
@@ -56,7 +56,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         private Action<Point> nextPointSelectionAction;
         private Point? magnifyAtPoint;
         private Action<Point?> magnifiedPointSelectionAction;
-        
+
         #endregion
 
         #region Ctor
@@ -129,10 +129,10 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 DeactivateLookToScrollUponSwitchingKeyboards();
                 keyboard?.OnExit(); // previous keyboard
                 SetProperty(ref keyboard, value);
-                if (!(keyboard is Keyboards.DynamicKeyboard))
+                if (!(keyboard is DynamicKeyboard))
                     mainWindowManipulationService.RollbackOverride();
                 keyboard?.OnEnter(); // new keyboard
-                Log.InfoFormat("Keyboard changed to {0}", value);                
+                Log.InfoFormat("Keyboard changed to {0}", value);
             }
         }
 
@@ -250,7 +250,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             get { return pointsPerSecond; }
             set { SetProperty(ref pointsPerSecond, value); }
         }
-        
+
         public string ApplicationAndSystemInfo
         {
             get
@@ -271,7 +271,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             get { return scratchpadIsDisabled; }
             set { SetProperty(ref scratchpadIsDisabled, value); }
         }
-        
+
         public InteractionRequest<NotificationWithCalibrationResult> CalibrateRequest { get { return calibrateRequest; } }
 
         #endregion
@@ -305,23 +305,23 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     case Enums.Keyboards.ConversationAlpha:
                     case Enums.Keyboards.ConversationConfirm:
                     case Enums.Keyboards.ConversationNumericAndSymbols:
-                        SetKeyboardFromEnum(Settings.Default.StartupKeyboard, 
+                        SetKeyboardFromEnum(Settings.Default.StartupKeyboard,
                             windowManipulationService, () =>
-                        {
-                            Keyboard = new Menu(() => Keyboard = new Alpha1());
-                            windowManipulationService.Restore();
-                            windowManipulationService.ResizeDockToFull();
-                        });
+                            {
+                                Keyboard = new Menu(() => Keyboard = new Alpha1());
+                                windowManipulationService.Restore();
+                                windowManipulationService.ResizeDockToFull();
+                            });
                         break;
 
                     case Enums.Keyboards.Minimised:
                         SetKeyboardFromEnum(Settings.Default.StartupKeyboard,
                             windowManipulationService, () =>
-                        {
-                            Keyboard = new Menu(() => Keyboard = new Alpha1());
-                            windowManipulationService.Restore();
-                            windowManipulationService.ResizeDockToFull();
-                        });
+                            {
+                                Keyboard = new Menu(() => Keyboard = new Alpha1());
+                                windowManipulationService.Restore();
+                                windowManipulationService.ResizeDockToFull();
+                            });
                         break;
 
                     case Enums.Keyboards.CustomKeyboardFile:
@@ -334,9 +334,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     default:
                         SetKeyboardFromEnum(Settings.Default.StartupKeyboard,
                             windowManipulationService, () =>
-                        {
-                            Keyboard = new Alpha1(); 
-                        });
+                            {
+                                Keyboard = new Alpha1();
+                            });
                         break;
                 }
             }
@@ -431,7 +431,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     break;
 
                 default:
-                    Log.ErrorFormat("Cannot load keyboard: {0}, this is not a valid StartupKeyboard", 
+                    Log.ErrorFormat("Cannot load keyboard: {0}, this is not a valid StartupKeyboard",
                         Settings.Default.StartupKeyboard);
                     break;
             }
@@ -488,7 +488,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                     inputService.RequestSuspend();
                     audioService.PlaySound(Settings.Default.InfoSoundFile, Settings.Default.InfoSoundVolume);
-                    RaiseToastNotification(Resources.NOTHING_NEW, Resources.NO_NEW_ENTRIES_IN_SCRATCHPAD, 
+                    RaiseToastNotification(Resources.NOTHING_NEW, Resources.NO_NEW_ENTRIES_IN_SCRATCHPAD,
                         NotificationTypes.Normal, () => { inputService.RequestResume(); });
                 }
             }
@@ -506,7 +506,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 var candidate = candidates.First();
 
                 var prompt = candidate.Contains(' ')
-                    ? string.Format(Resources.ADD_PHRASE_TO_DICTIONARY_CONFIRMATION_MESSAGE, 
+                    ? string.Format(Resources.ADD_PHRASE_TO_DICTIONARY_CONFIRMATION_MESSAGE,
                         candidate, candidate.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(log: true))
                     : string.Format(Resources.ADD_WORD_TO_DICTIONARY_CONFIRMATION_MESSAGE, candidate);
 
@@ -522,7 +522,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
 
                 if (similarEntries.Any())
                 {
-                    string similarEntriesPrompt = string.Format(Resources.SIMILAR_DICTIONARY_ENTRIES_EXIST, 
+                    string similarEntriesPrompt = string.Format(Resources.SIMILAR_DICTIONARY_ENTRIES_EXIST,
                         string.Join(", ", similarEntries.Select(se => string.Format("'{0}'", se))));
 
                     prompt = string.Concat(prompt, "\n\n", similarEntriesPrompt);
@@ -616,7 +616,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             this.OnPropertyChanges(mvm => mvm.KeyboardSupportsCollapsedDock).Subscribe(resizeDockIfCollapsedDockingNotSupported);
             resizeDockIfCollapsedDockingNotSupported(KeyboardSupportsCollapsedDock);
         }
-        
+
         private void ResetSelectionProgress()
         {
             PointSelectionProgress = null;
@@ -660,7 +660,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 audioService.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume);
                 inputService.RequestSuspend();
                 ToastNotification(this, new NotificationEventArgs(
-                    Resources.STARTUP_CRASH_TITLE, 
+                    Resources.STARTUP_CRASH_TITLE,
                     pendingErrorToastNotificationContent.ToString(), NotificationTypes.Error, () =>
                     {
                         pendingErrorToastNotificationContent.Clear();

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml
@@ -12,7 +12,9 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                        xmlns:properties="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
                        mc:Ignorable="d" 
-                       d:DesignHeight="300" d:DesignWidth="300">
+                       d:DesignHeight="300" d:DesignWidth="300"
+                       Background="{DynamicResource KeyboardBackgroundBrush}"
+                       BorderBrush="{DynamicResource KeyboardBorderBrush}">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -26,8 +28,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
-          x:Name="TopGrid">
+    <Grid x:Name="TopGrid">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="2*" /> <!-- may be collapsed from code-->
@@ -43,15 +44,14 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                          ScratchpadWidthInKeys="8"
                          x:Name="OutputPanel"
                          NumberOfSuggestionsDisplayed="{Binding Path=DataContext.SuggestionService.SuggestionsPerPage, RelativeSource={RelativeSource AncestorType=controls:KeyboardHost}, Mode=TwoWay}" />
-         <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
+        <!--N.B. This MUST be TwoWay to detect changes to the DataContext used in the binding path-->
 
-        <Grid Background="{DynamicResource KeyDefaultBackgroundBrush}"
-              Grid.IsSharedSizeScope="True"
+        <Grid Grid.IsSharedSizeScope="True"
               x:Name="MainGrid"
               Grid.Row="1" Grid.Column="0"
               Grid.RowSpan="1" Grid.ColumnSpan="1" >
-        
-        <!-- Add Keys dynamically here -->
+
+            <!-- Add Keys dynamically here -->
 
         </Grid>
     </Grid>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml
@@ -17,9 +17,12 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
         AllowsTransparency="True"
         ResizeMode="NoResize"
         Style="{DynamicResource MainWindowStyle}"
-        Tag="{Binding RelativeSource={RelativeSource Mode=Self}}">
-        <!--Don't set the window's Width and Height properties on the window itself - they are loaded and applied from settings-->
-    
+        Tag="{Binding RelativeSource={RelativeSource Mode=Self}}"
+        Background="Transparent"
+        BorderBrush="Transparent">
+    <!--Set background to transparent so keyboards can have transparent backgrounds-->
+    <!--Don't set the window's Width and Height properties on the window itself - they are loaded and applied from settings-->
+
     <Window.ContextMenu>
         <ContextMenu DataContext="{Binding Path=PlacementTarget.Tag, RelativeSource={RelativeSource Self}}"
                      FlowDirection="{Binding Source={x:Static resx:Settings.Default}, Path=UiLanguageFlowDirection}">
@@ -35,7 +38,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                     <Image Source="..\..\Resources\Icons\ManualMode.ico" />
                 </MenuItem.Icon>
             </MenuItem>
-	    <MenuItem Header="{x:Static resx:Resources.BACK_TITLE_CASE}" 
+            <MenuItem Header="{x:Static resx:Resources.BACK_TITLE_CASE}" 
                       Command="{Binding BackCommand}">
                 <MenuItem.Icon>
                     <Image Source="..\..\Resources\Icons\Back.ico" />
@@ -55,13 +58,13 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
             </MenuItem>
         </ContextMenu>
     </Window.ContextMenu>
-    
+
     <i:Interaction.Triggers>
         <interactionRequest:InteractionRequestTrigger 
             SourceObject="{Binding Path=ManagementWindowRequest, RelativeSource={RelativeSource AncestorType=Window}, Mode=OneWay}">
             <triggerActions:OpenManagementWindowAction />
         </interactionRequest:InteractionRequestTrigger>
     </i:Interaction.Triggers>
-    
+
     <views:MainView x:Name="MainView" />
 </Window>


### PR DESCRIPTION
Enable dynamic keyboard background and border color overrides.
Add an OutputKey to dynamic keyboards and a stand-alone scratchpad control.