### PR TITLE
Add missing resource

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
@@ -1497,18 +1497,16 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("ENTRY_ADDED_TO_DICTIONARY", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error has occurred during the handling of a key selection.
         /// </summary>
-        public static string ERROR_HANDLING_INPUT_SERVICE_SELECTION_RESULT
-        {
-            get
-            {
+        public static string ERROR_HANDLING_INPUT_SERVICE_SELECTION_RESULT {
+            get {
                 return ResourceManager.GetString("ERROR_HANDLING_INPUT_SERVICE_SELECTION_RESULT", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error has occurred during the magnification process. Please disable magnification and contact OptiKey for further support..
         /// </summary>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -2378,4 +2378,7 @@ Would you like OptiKey to automatically set the font to Nazli?</value>
 Magyar
 (Magyarország)</value>
   </data>
+  <data name="ERROR_HANDLING_INPUT_SERVICE_SELECTION_RESULT" xml:space="preserve">
+    <value>An error has occurred during the handling of a key selection</value>
+  </data>
 </root>


### PR DESCRIPTION
I've been merging master (42fa9786) into my own feature branch, and it looks like the resource ERROR_HANDLING_INPUT_SERVICE_SELECTION_RESULT is missing from Resources.resx. It's present in Resources.Designer.cs only.

This adds it to Resources.resx based on the comment saying what it should be in Resources.Designer.cs

@AdamRoden for comment/approval (his commit d511b1786 introduced the string)
