### PR TITLE
Resizing

### DIFF
--- a/src/JuliusSweetland.OptiKey.Chat/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Chat/App.xaml.cs
@@ -199,6 +199,12 @@ namespace JuliusSweetland.OptiKey.Chat
                 {
                     mainWindowManipulationService.SizeAndPositionInitialised += sizeAndPositionInitialised;
                 }
+
+                Current.Exit += (o, args) =>
+                {
+                    mainWindowManipulationService.PersistSizeAndPosition();
+                    Settings.Default.Save();
+                };
             }
             catch (Exception ex)
             {

--- a/src/JuliusSweetland.OptiKey.Chat/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Chat/Properties/Settings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 
+using JuliusSweetland.OptiKey.Enums;
+
 namespace JuliusSweetland.OptiKey.Chat.Properties
 {
 
@@ -10,6 +12,11 @@ namespace JuliusSweetland.OptiKey.Chat.Properties
         {
             Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
             InitialiseWithDerivedSettings(defaultInstance);
+        }
+
+        public override AppType GetApp()
+        {
+            return AppType.Chat;
         }
 
         /*

--- a/src/JuliusSweetland.OptiKey.Core/Enums/AppType.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Enums/AppType.cs
@@ -6,6 +6,7 @@ namespace JuliusSweetland.OptiKey.Enums
         Pro,
         Mouse,
         Chat,
-        Symbol
+        Symbol,
+        Tests
     }
 }

--- a/src/JuliusSweetland.OptiKey.Core/Enums/AppType.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Enums/AppType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) 2020 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+namespace JuliusSweetland.OptiKey.Enums
+{
+    public enum AppType
+    {
+        Pro,
+        Mouse,
+        Chat,
+        Symbol
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
+++ b/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
@@ -222,6 +222,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enums\AppType.cs" />
     <Compile Include="Enums\KeyboardLayouts.cs" />
     <Compile Include="Enums\LookToScrollBounds.cs" />
     <Compile Include="Enums\LookToScrollModes.cs" />

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
@@ -6180,6 +6180,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Top.
+        /// </summary>
+        public static string TOP {
+            get {
+                return ResourceManager.GetString("TOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Trigger button/key pressed again.
         /// </summary>
         public static string TRIGGER_PRESSED_AGAIN {

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
@@ -1285,6 +1285,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dock position.
+        /// </summary>
+        public static string DOCK_POSITION_LABEL {
+            get {
+                return ResourceManager.GetString("DOCK_POSITION_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DOWN ARROW.
         /// </summary>
         public static string DOWN_ARROW {

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -2447,4 +2447,7 @@ Magyar
   <data name="TOP" xml:space="preserve">
     <value>Top</value>
   </data>
+  <data name="DOCK_POSITION_LABEL" xml:space="preserve">
+    <value>Dock position</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -2444,4 +2444,7 @@ Magyar
   <data name="ALLOW_MULTIPLE_INSTANCES" xml:space="preserve">
     <value>Allow multiple instances of this Optikey app to run simultaneously</value>
   </data>
+  <data name="TOP" xml:space="preserve">
+    <value>Top</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 
+using JuliusSweetland.OptiKey.Enums;
 using log4net;
 
 namespace JuliusSweetland.OptiKey.Properties {
@@ -7,6 +8,9 @@ namespace JuliusSweetland.OptiKey.Properties {
     public abstract class Settings : global::System.Configuration.ApplicationSettingsBase {
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        // Derived classes must specify what app they are
+        public abstract AppType GetApp();
 
         private static Settings defaultInstance;
         

--- a/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
@@ -20,6 +20,7 @@ namespace JuliusSweetland.OptiKey.Services
         void Maximise();
         void Minimise();
         void Move(MoveToDirections direction, double? amountInPx);
+        void PersistSizeAndPosition();
         void ResizeDockToCollapsed();
         void ResizeDockToFull();
         void Restore();

--- a/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
@@ -13,6 +13,7 @@ namespace JuliusSweetland.OptiKey.Services
         Rect WindowBounds { get; }
         WindowStates WindowState { get; }
 
+        void ChangeState(WindowStates state, DockEdges dockPosition);
         void Expand(ExpandToDirections direction, double amountInPx);
         double GetOpacity();
         void Hide();

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -1035,32 +1035,38 @@ namespace JuliusSweetland.OptiKey.Services
             return new Rect(x, y, width, height);
         }
 
-        // TODO: For optikey proper, call this from the resizing functions where appropriate
         public void ChangeState(WindowStates newState, DockEdges dockPosition)
         {
             var windowState = getWindowState();
             var dockPos = getDockPosition();
 
+            bool changeCurrentState = !(windowState == WindowStates.Minimised || windowState == WindowStates.Hidden);
             if (newState == WindowStates.Docked)
             {
                 if (windowState != WindowStates.Docked)
                 {  
                     RegisterAppBar(true);
-                }
-                saveWindowState(WindowStates.Docked);
+                }   
                 savePreviousWindowState(WindowStates.Docked);
                 saveDockPosition(dockPosition);
-                ResizeDockToFull();
+                if (changeCurrentState)
+                {
+                    saveWindowState(WindowStates.Docked);
+                    ResizeDockToFull();
+                }
             }
             else
             {
+                ResizeDockToFull(); // in case we're in Collapsed state
                 UnRegisterAppBar();
-                saveWindowState(WindowStates.Floating);
                 savePreviousWindowState(WindowStates.Floating);
-                Restore();
+                if (changeCurrentState)
+                {
+                    saveWindowState(WindowStates.Floating);
+                    Restore();
+                }
             }
         }
-
 
         private void CoerceSavedStateAndApply()
         {

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -818,14 +818,23 @@ namespace JuliusSweetland.OptiKey.Services
         private void CoerceDockSizeAndPosition()
         {
             Log.InfoFormat("CoerceDockSizeAndPosition called");
+            
+            // If app has been manually resized in a way that doesn't respect the docking, recompute appropriate dock position 
+            DockEdges dockEdge = getDockPosition();
+            if (dockEdge == DockEdges.Bottom || dockEdge == DockEdges.Top) {
+                double thicknessAsPercentage = screenBoundsInPx.Height / window.Height;
 
-            double thicknessAsPercentage = screenBoundsInPx.Height / window.Height;
+                var distanceToBottomBoundary = screenBoundsInDp.Bottom - (window.Top + window.ActualHeight);
+                var yAdjustmentToBottom = distanceToBottomBoundary < 0 ? distanceToBottomBoundary : 0;
+                saveFullDockThicknessAsPercentageOfScreen(((window.ActualHeight + yAdjustmentToBottom) / screenBoundsInDp.Height) * 100);
+            }
+            else
+            {
+                var distanceToLeftBoundary = window.Left - screenBoundsInDp.Left;
+                var xAdjustmentToLeft = distanceToLeftBoundary < 0 ? distanceToLeftBoundary : 0;
 
-            // this only allows change in height, not width (since we only dock at top/bottom this is ok)
-            var distanceToBottomBoundary = screenBoundsInDp.Bottom - (window.Top + window.ActualHeight);
-            var yAdjustmentToBottom = distanceToBottomBoundary < 0 ? distanceToBottomBoundary : 0;
-            saveFullDockThicknessAsPercentageOfScreen(((window.ActualHeight + yAdjustmentToBottom) / screenBoundsInDp.Height) * 100);
-
+                saveFullDockThicknessAsPercentageOfScreen(((window.ActualWidth + xAdjustmentToLeft) / screenBoundsInDp.Width) * 100);
+            }
             UpdateAppBarPosition();
         }
 

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -135,19 +135,25 @@ namespace JuliusSweetland.OptiKey.Services
 
         private const Int32 WM_ENTERSIZEMOVE = 0x0231;
         private const Int32 WM_EXITSIZEMOVE = 0x0232;
-        
+        private const Int32 WM_NCLBUTTONDBLCLK = 0x00A3; 
+
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
-            if (msg == WM_ENTERSIZEMOVE)
+            switch (msg)
             {
-                mouseResizeUnderway = true;
-            }
-            if (msg == WM_EXITSIZEMOVE)
-            {
-                // This message is sent at the end of a user-resize (via window drag handles)
-                Log.Info("WM_EXITSIZEMOVE called");
-                mouseResizeUnderway = false;
-                CoerceDockSizeAndPosition();
+                case WM_ENTERSIZEMOVE:
+                    mouseResizeUnderway = true;
+                    break;
+                case WM_EXITSIZEMOVE:
+
+                    // This message is sent at the end of a user-resize (via window drag handles)
+                    Log.Info("WM_EXITSIZEMOVE called");
+                    mouseResizeUnderway = false;
+                    CoerceDockSizeAndPosition();
+                    break;
+                case WM_NCLBUTTONDBLCLK:
+                    handled = true;  //prevent double click from maximizing the window.
+                    break;
             }
             return IntPtr.Zero;
         }

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -956,6 +956,42 @@ namespace JuliusSweetland.OptiKey.Services
             return new Rect(x, y, width, height);
         }
 
+        // TODO: For optikey proper, call this from the resizing functions where appropriate
+        public void ChangeState(WindowStates newState, DockEdges dockPosition)
+        {
+            var windowState = getWindowState();
+            var dockPos = getDockPosition();
+
+            if (windowState == newState && dockPosition == dockPos)
+            {
+                return;
+            }
+
+            if (newState == WindowStates.Docked)
+            {
+                if (windowState != WindowStates.Docked)
+                {  
+                    RegisterAppBar();
+                }
+                saveWindowState(WindowStates.Docked);
+                savePreviousWindowState(WindowStates.Docked);
+                saveDockPosition(dockPosition);
+                
+                window.ResizeMode = ResizeMode.NoResize;
+
+                ResizeDockToFull();
+            }
+            else
+            {
+                UnRegisterAppBar();
+                saveWindowState(WindowStates.Floating);
+                savePreviousWindowState(WindowStates.Floating);
+                window.ResizeMode = ResizeMode.CanResizeWithGrip;
+                Restore();
+            }
+        }
+
+
         private void CoerceSavedStateAndApply()
         {
             Log.Info("CoerceSavedStateAndApply called.");

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -1384,7 +1384,7 @@ namespace JuliusSweetland.OptiKey.Services
             }
         }
 
-        private void PersistSizeAndPosition()
+        public void PersistSizeAndPosition()
         {
             Log.Info("PersistSizeAndPosition called");
 

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -874,29 +874,29 @@ namespace JuliusSweetland.OptiKey.Services
             switch (windowState)
             {
                 case WindowStates.Docked:
-                    window.WindowState = System.Windows.WindowState.Normal;
                     window.ResizeMode = ResizeMode.CanResizeWithGrip;
+                    window.WindowState = System.Windows.WindowState.Normal;
                     var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(dockPosition, getDockSize());
                     RegisterAppBar();
                     SetAppBarSizeAndPosition(dockPosition, dockSizeAndPositionInPx, isInitialising);
                     break;
 
                 case WindowStates.Floating:
-                    window.WindowState = System.Windows.WindowState.Normal;
                     window.ResizeMode = ResizeMode.CanResizeWithGrip;
+                    window.WindowState = System.Windows.WindowState.Normal;
                     window.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle,
                         new ApplySizeAndPositionDelegate(ApplyAndPersistSizeAndPosition), getFloatingSizeAndPosition());
                     break;
 
                 case WindowStates.Maximised:
-                    window.WindowState = System.Windows.WindowState.Maximized;
                     window.ResizeMode = ResizeMode.NoResize;
+                    window.WindowState = System.Windows.WindowState.Maximized;
                     PublishSizeAndPositionInitialised();
                     break;
 
                 case WindowStates.Minimised:
-                    window.WindowState = System.Windows.WindowState.Normal;
                     window.ResizeMode = ResizeMode.NoResize;
+                    window.WindowState = System.Windows.WindowState.Normal;
                     var minimisedSizeAndPosition = CalculateMinimisedSizeAndPosition();
                     window.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle,
                         new ApplySizeAndPositionDelegate(ApplyAndPersistSizeAndPosition), minimisedSizeAndPosition);

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -971,7 +971,7 @@ namespace JuliusSweetland.OptiKey.Services
             {
                 if (windowState != WindowStates.Docked)
                 {  
-                    RegisterAppBar();
+                    RegisterAppBar(true);
                 }
                 saveWindowState(WindowStates.Docked);
                 savePreviousWindowState(WindowStates.Docked);
@@ -1457,11 +1457,12 @@ namespace JuliusSweetland.OptiKey.Services
             }
 
         }
-        private void RegisterAppBar()
+
+        private void RegisterAppBar(bool force=false)
         {
             Log.Info("RegisterAppBar called");
 
-            if (getWindowState() != WindowStates.Docked) return;
+            if (!force && getWindowState() != WindowStates.Docked) return;
 
             Log.Debug("WindowState is Docked, continuing to register app bar");
 

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -574,6 +574,10 @@ namespace JuliusSweetland.OptiKey.Services
             Log.Info("ResizeDockToCollapsed called");
 
             if (getWindowState() != WindowStates.Docked) return;
+
+            // Turn off grab handles, to avoid ambiguous requests
+            window.ResizeMode = ResizeMode.NoResize;
+
             saveDockSize(DockSizes.Collapsed);
             var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(getDockPosition(), DockSizes.Collapsed);
             SetAppBarSizeAndPosition(getDockPosition(), dockSizeAndPositionInPx); //PersistSizeAndPosition() is called indirectly by SetAppBarSizeAndPosition - no need to call explicitly
@@ -584,6 +588,10 @@ namespace JuliusSweetland.OptiKey.Services
             Log.Info("ResizeDockToFull called");
             
             if (getWindowState() != WindowStates.Docked) return;
+
+            // Turn grab handles back on
+            window.ResizeMode = ResizeMode.CanResizeWithGrip;
+
             saveDockSize(DockSizes.Full);
             var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(getDockPosition(), DockSizes.Full);
             SetAppBarSizeAndPosition(getDockPosition(), dockSizeAndPositionInPx); //PersistSizeAndPosition() is called indirectly by SetAppBarSizeAndPosition - no need to call explicitly
@@ -818,7 +826,9 @@ namespace JuliusSweetland.OptiKey.Services
         private void CoerceDockSizeAndPosition()
         {
             Log.InfoFormat("CoerceDockSizeAndPosition called");
-            
+
+            if (getWindowState() != WindowStates.Docked) return;
+
             // If app has been manually resized in a way that doesn't respect the docking, recompute appropriate dock position 
             DockEdges dockEdge = getDockPosition();
             if (dockEdge == DockEdges.Bottom || dockEdge == DockEdges.Top) {
@@ -865,6 +875,7 @@ namespace JuliusSweetland.OptiKey.Services
             {
                 case WindowStates.Docked:
                     window.WindowState = System.Windows.WindowState.Normal;
+                    window.ResizeMode = ResizeMode.CanResizeWithGrip;
                     var dockSizeAndPositionInPx = CalculateDockSizeAndPositionInPx(dockPosition, getDockSize());
                     RegisterAppBar();
                     SetAppBarSizeAndPosition(dockPosition, dockSizeAndPositionInPx, isInitialising);
@@ -872,17 +883,20 @@ namespace JuliusSweetland.OptiKey.Services
 
                 case WindowStates.Floating:
                     window.WindowState = System.Windows.WindowState.Normal;
+                    window.ResizeMode = ResizeMode.CanResizeWithGrip;
                     window.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle,
                         new ApplySizeAndPositionDelegate(ApplyAndPersistSizeAndPosition), getFloatingSizeAndPosition());
                     break;
 
                 case WindowStates.Maximised:
                     window.WindowState = System.Windows.WindowState.Maximized;
+                    window.ResizeMode = ResizeMode.NoResize;
                     PublishSizeAndPositionInitialised();
                     break;
 
                 case WindowStates.Minimised:
                     window.WindowState = System.Windows.WindowState.Normal;
+                    window.ResizeMode = ResizeMode.NoResize;
                     var minimisedSizeAndPosition = CalculateMinimisedSizeAndPosition();
                     window.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle,
                         new ApplySizeAndPositionDelegate(ApplyAndPersistSizeAndPosition), minimisedSizeAndPosition);

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -601,7 +601,15 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             DynamicKeyboardsLocation = Settings.Default.DynamicKeyboardsLocation;
             StartupKeyboardFile = Settings.Default.StartupKeyboardFile;
             DockPosition = Settings.Default.MainWindowDockPosition;
-            MainWindowState = Settings.Default.MainWindowState;
+            if (Settings.Default.MainWindowState == WindowStates.Docked ||
+                Settings.Default.MainWindowState == WindowStates.Floating)
+            {
+                MainWindowState = Settings.Default.MainWindowState;
+            }
+            else
+            {
+                MainWindowState = Settings.Default.MainWindowPreviousState;
+            }
         }
 
         public void ApplyChanges()

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -35,8 +35,10 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         #endregion
-        
+
         #region Ctor
+
+        private IWindowManipulationService windowManipulationService;
 
         public VisualsViewModel(IWindowManipulationService windowManipulationService)
         {
@@ -301,6 +303,31 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             }
         }
 
+        public List<KeyValuePair<string, Enums.DockEdges>> DockPositions
+        {
+            get
+            {
+                return new List<KeyValuePair<string, Enums.DockEdges>>
+                {
+                    new KeyValuePair<string, Enums.DockEdges>(Resources.TOP, Enums.DockEdges.Top),
+                    new KeyValuePair<string, Enums.DockEdges>(Resources.BOTTOM, Enums.DockEdges.Bottom),
+                    new KeyValuePair<string, Enums.DockEdges>(Resources.LEFT, Enums.DockEdges.Left),
+                    new KeyValuePair<string, Enums.DockEdges>(Resources.RIGHT, Enums.DockEdges.Right),
+                };
+            }
+        }
+
+        public List<KeyValuePair<string, Enums.WindowStates>> MainWindowStates
+        {
+            get
+            {
+                return new List<KeyValuePair<string, Enums.WindowStates>>
+                {
+                    new KeyValuePair<string, Enums.WindowStates>("Floating", Enums.WindowStates.Floating),
+                    new KeyValuePair<string, Enums.WindowStates>("Docked", Enums.WindowStates.Docked),
+                };
+            }
+        }
         public List<KeyValuePair<string, Enums.MinimisedEdges>> MinimisedPositions
         {
             get
@@ -371,6 +398,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get { return keyCase; }
             set { SetProperty(ref keyCase, value); }
+        }
+
+        private Enums.DockEdges dockPosition;
+        public Enums.DockEdges DockPosition
+        {
+            get { return dockPosition; }
+            set { SetProperty(ref dockPosition, value); }
         }
 
         private int scratchpadNumberOfLines;
@@ -510,12 +544,17 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         }
 
         private string startupKeyboardFile;
-        private IWindowManipulationService windowManipulationService;
-
         public string StartupKeyboardFile
         {
             get { return startupKeyboardFile; }
             set { SetProperty(ref startupKeyboardFile, value); }
+        }
+
+        private WindowStates mainWindowState;
+        public WindowStates MainWindowState
+        {
+            get { return mainWindowState; }
+            set { SetProperty(ref mainWindowState, value); }
         }
 
         #endregion
@@ -549,6 +588,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             ConversationBorderThickness = Settings.Default.ConversationBorderThickness;
             DynamicKeyboardsLocation = Settings.Default.DynamicKeyboardsLocation;
             StartupKeyboardFile = Settings.Default.StartupKeyboardFile;
+            DockPosition = Settings.Default.MainWindowDockPosition;
+            MainWindowState = Settings.Default.MainWindowState;
         }
 
         public void ApplyChanges()
@@ -578,9 +619,12 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.ConversationBorderThickness = ConversationBorderThickness;
             Settings.Default.DynamicKeyboardsLocation = DynamicKeyboardsLocation;
             Settings.Default.StartupKeyboardFile = StartupKeyboardFile;
-
-            // Apply opacity to window
-            windowManipulationService.SetOpacity(Settings.Default.MainWindowOpacity);
+            if (Settings.Default.MainWindowState != MainWindowState || Settings.Default.MainWindowDockPosition != DockPosition)
+            {
+                // this also saves the changes
+                windowManipulationService.ChangeState(MainWindowState, DockPosition);
+            }
+            // TODO: deal with currently-minimised state?? necessary for Optikey proper
         }
 
         #endregion

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -558,13 +558,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref mainWindowState, value); }
         }
 
-        private double mainWindowOpacity;
-        public double MainWindowOpacity
-        {
-            get { return mainWindowOpacity; }
-            set { SetProperty(ref mainWindowOpacity, value); }
-        }
-
         #endregion
 
         #region Methods
@@ -598,7 +591,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             StartupKeyboardFile = Settings.Default.StartupKeyboardFile;
             DockPosition = Settings.Default.MainWindowDockPosition;
             MainWindowState = Settings.Default.MainWindowState;
-            MainWindowOpacity = Settings.Default.MainWindowOpacity;
         }
 
         public void ApplyChanges()
@@ -637,7 +629,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
                 // this also saves the changes
                 windowManipulationService.ChangeState(MainWindowState, DockPosition);
             }
-            windowManipulationService.SetOpacity(MainWindowOpacity);
+            windowManipulationService.SetOpacity(Settings.Default.MainWindowOpacity);
 
             // TODO: deal with currently-minimised state?? necessary for Optikey proper
         }

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -558,6 +558,17 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref mainWindowState, value); }
         }
 
+        public bool MaximisedApp
+        {
+            get
+            {
+                // Is this an always-maximised app?
+                AppType appType = Settings.Default.GetApp();
+                return (appType == AppType.Chat || appType == AppType.Symbol);
+            }
+        }
+
+
         #endregion
 
         #region Methods

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -557,6 +557,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref mainWindowState, value); }
         }
 
+        private double mainWindowOpacity;
+        public double MainWindowOpacity
+        {
+            get { return mainWindowOpacity; }
+            set { SetProperty(ref mainWindowOpacity, value); }
+        }
+
         #endregion
 
         #region Methods
@@ -590,6 +597,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             StartupKeyboardFile = Settings.Default.StartupKeyboardFile;
             DockPosition = Settings.Default.MainWindowDockPosition;
             MainWindowState = Settings.Default.MainWindowState;
+            MainWindowOpacity = Settings.Default.MainWindowOpacity;
         }
 
         public void ApplyChanges()
@@ -619,11 +627,15 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.ConversationBorderThickness = ConversationBorderThickness;
             Settings.Default.DynamicKeyboardsLocation = DynamicKeyboardsLocation;
             Settings.Default.StartupKeyboardFile = StartupKeyboardFile;
+            
+            // Changes to window state, these methods will save the new values also
             if (Settings.Default.MainWindowState != MainWindowState || Settings.Default.MainWindowDockPosition != DockPosition)
             {
                 // this also saves the changes
                 windowManipulationService.ChangeState(MainWindowState, DockPosition);
             }
+            windowManipulationService.SetOpacity(MainWindowOpacity);
+
             // TODO: deal with currently-minimised state?? necessary for Optikey proper
         }
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -6,6 +6,7 @@ using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Services;
 using log4net;
+using MahApps.Metro.Controls;
 using Prism.Mvvm;
 using FontStretches = JuliusSweetland.OptiKey.Enums.FontStretches;
 using FontWeights = JuliusSweetland.OptiKey.Enums.FontWeights;
@@ -629,7 +630,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.StartupKeyboardFile = StartupKeyboardFile;
             
             // Changes to window state, these methods will save the new values also
-            if (Settings.Default.MainWindowState != MainWindowState || Settings.Default.MainWindowDockPosition != DockPosition)
+            if (Settings.Default.MainWindowState != MainWindowState || 
+                Settings.Default.MainWindowDockPosition != DockPosition ||
+                Settings.Default.MainWindowFullDockThicknessAsPercentageOfScreen.IsCloseTo(MainWindowFullDockThicknessAsPercentageOfScreen))
             {
                 // this also saves the changes
                 windowManipulationService.ChangeState(MainWindowState, DockPosition);

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
@@ -58,6 +58,10 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.THEME_LABEL}" 
@@ -303,6 +307,75 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                 <x:Static Member="resx:Resources.MARYTTS_LOCATION_FIND_LABEL"/>
                             </Button>
                      </StackPanel>
+
+
+                    <TextBlock Grid.Row="17" Grid.Column="0" Text="Window state" 
+                               VerticalAlignment="Center" Margin="5" />
+                    <ComboBox Grid.Row="17" Grid.Column="1" 
+                              ItemsSource="{Binding MainWindowStates}"
+                              DisplayMemberPath="Key"
+                              SelectedValuePath="Value"
+                              SelectedValue="{Binding MainWindowState, Mode=TwoWay}" />
+
+
+                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.DOCK_POSITION_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainWindowState}" Value="Docked">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <ComboBox Grid.Row="18" Grid.Column="1" 
+                              ItemsSource="{Binding DockPositions}"
+                              DisplayMemberPath="Key"
+                              SelectedValuePath="Value"
+                              SelectedValue="{Binding DockPosition, Mode=TwoWay}" >
+                        <ComboBox.Style>
+                            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainWindowState}" Value="Docked">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ComboBox.Style>
+                    </ComboBox>
+
+                    <TextBlock Grid.Row="19" Grid.Column="0" Text="Dock height (as % of screen)" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainWindowState}" Value="Docked">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <controls:NumericUpDown Grid.Row="19" Grid.Column="1" TextAlignment="Left"
+                                            Minimum="10" Maximum="70" Interval="1"
+                                            StringFormat="{}{0:N1} %"
+                                            Value="{Binding MainWindowFullDockThicknessAsPercentageOfScreen, Mode=TwoWay}">
+                        <controls:NumericUpDown.Style>
+                            <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainWindowState}" Value="Docked">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </controls:NumericUpDown.Style>
+                    </controls:NumericUpDown>
                 </Grid>
             </GroupBox>
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
@@ -75,6 +75,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static resx:Resources.OPACITY_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="1" Grid.Column="1" TextAlignment="Left"
+                                            StringFormat="{}{0:N1} %"
                                             Minimum="10" Maximum="100" Interval="10"
                                             Value="{Binding Opacity, Mode=TwoWay}" />
 
@@ -284,12 +285,14 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="14" Grid.Column="1" TextAlignment="Left"
                                             Minimum="10" Maximum="90" Interval="10"
+                                            StringFormat="{}{0:N1} %"
                                             Value="{Binding MainWindowFullDockThicknessAsPercentageOfScreen, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="15" Grid.Column="0" Text="{x:Static resx:Resources.COLLAPSED_DOCK_THICKNESS}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="15" Grid.Column="1" TextAlignment="Left"
                                             Minimum="10" Maximum="90" Interval="10"
+                                            StringFormat="{}{0:N1} %"
                                             Value="{Binding MainWindowCollapsedDockThicknessAsPercentageOfFullDockThickness, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.DYNAMIC_KEYBOARDS_LOCATION_LABEL}" 
@@ -437,12 +440,14 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.HORIZONTAL_FILL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="0" Grid.Column="1" TextAlignment="Left"
+                                            StringFormat="{}{0:N1} %"
                                             Minimum="1" Maximum="100" Interval="5"
                                             Value="{Binding ToastNotificationHorizontalFillPercentage, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static resx:Resources.VERTICAL_FILL_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
                     <controls:NumericUpDown Grid.Row="1" Grid.Column="1" TextAlignment="Left"
+                                            StringFormat="{}{0:N1} %"
                                             Minimum="1" Maximum="100" Interval="5"
                                             Value="{Binding ToastNotificationVerticalFillPercentage, Mode=TwoWay}" />
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
@@ -282,23 +282,9 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                               SelectedValuePath="Value"
                               SelectedValue="{Binding MinimisedPosition, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{x:Static resx:Resources.FULL_DOCK_THICKNESS_LABEL}" 
+                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{x:Static resx:Resources.DYNAMIC_KEYBOARDS_LOCATION_LABEL}" 
                                VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="14" Grid.Column="1" TextAlignment="Left"
-                                            Minimum="10" Maximum="90" Interval="10"
-                                            StringFormat="{}{0:N1} %"
-                                            Value="{Binding MainWindowFullDockThicknessAsPercentageOfScreen, Mode=TwoWay}" />
-
-                    <TextBlock Grid.Row="15" Grid.Column="0" Text="{x:Static resx:Resources.COLLAPSED_DOCK_THICKNESS}" 
-                               VerticalAlignment="Center" Margin="5" />
-                    <controls:NumericUpDown Grid.Row="15" Grid.Column="1" TextAlignment="Left"
-                                            Minimum="10" Maximum="90" Interval="10"
-                                            StringFormat="{}{0:N1} %"
-                                            Value="{Binding MainWindowCollapsedDockThicknessAsPercentageOfFullDockThickness, Mode=TwoWay}" />
-
-                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.DYNAMIC_KEYBOARDS_LOCATION_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" />
-                    <StackPanel Grid.Row="16" Grid.Column="1" Orientation="Horizontal">
+                    <StackPanel Grid.Row="14" Grid.Column="1" Orientation="Horizontal">
                         <TextBlock Name="txtKeyboardsLocation"
                                    Text="{Binding DynamicKeyboardsLocation, Mode=TwoWay}" 
                                    HorizontalAlignment="Left" 
@@ -313,10 +299,10 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                      </StackPanel>
 
 
-                    <TextBlock Grid.Row="17" Grid.Column="0" Text="Window state" 
+                    <TextBlock Grid.Row="15" Grid.Column="0" Text="Window state" 
                                Visibility="{Binding MaximisedApp, Converter={StaticResource InverseBooleanToVisibilityConverter}}"
                                VerticalAlignment="Center" Margin="5" />
-                    <ComboBox Grid.Row="17" Grid.Column="1" 
+                    <ComboBox Grid.Row="15" Grid.Column="1" 
                               ItemsSource="{Binding MainWindowStates}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
@@ -324,7 +310,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                               SelectedValue="{Binding MainWindowState, Mode=TwoWay}" />
 
 
-                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.DOCK_POSITION_LABEL}" 
+                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.DOCK_POSITION_LABEL}" 
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -337,7 +323,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-                    <ComboBox Grid.Row="18" Grid.Column="1" 
+                    <ComboBox Grid.Row="16" Grid.Column="1" 
                               ItemsSource="{Binding DockPositions}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
@@ -354,7 +340,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                         </ComboBox.Style>
                     </ComboBox>
 
-                    <TextBlock Grid.Row="19" Grid.Column="0" Text="Dock height (as % of screen)" 
+                    <TextBlock Grid.Row="17" Grid.Column="0" Text="{x:Static resx:Resources.FULL_DOCK_THICKNESS_LABEL}" 
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -367,10 +353,10 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-                    <controls:NumericUpDown Grid.Row="19" Grid.Column="1" TextAlignment="Left"
-                                            Minimum="10" Maximum="70" Interval="1"
+                    <controls:NumericUpDown Grid.Row="17" Grid.Column="1" TextAlignment="Left"
+                                            Minimum="10" Maximum="90" Interval="10"
                                             StringFormat="{}{0:N1} %"
-                                            Value="{Binding MainWindowFullDockThicknessAsPercentageOfScreen, Mode=TwoWay}">
+                                            Value="{Binding MainWindowFullDockThicknessAsPercentageOfScreen, Mode=TwoWay}" >
                         <controls:NumericUpDown.Style>
                             <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -382,6 +368,36 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                             </Style>
                         </controls:NumericUpDown.Style>
                     </controls:NumericUpDown>
+
+                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{x:Static resx:Resources.COLLAPSED_DOCK_THICKNESS}" 
+                               VerticalAlignment="Center" Margin="5" >
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainWindowState}" Value="Docked">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <controls:NumericUpDown Grid.Row="18" Grid.Column="1" TextAlignment="Left"
+                                            Minimum="10" Maximum="90" Interval="10"
+                                            StringFormat="{}{0:N1} %"
+                                            Value="{Binding MainWindowCollapsedDockThicknessAsPercentageOfFullDockThickness, Mode=TwoWay}" >
+                        <controls:NumericUpDown.Style>
+                            <Style TargetType="{x:Type controls:NumericUpDown}" BasedOn="{StaticResource {x:Type controls:NumericUpDown}}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding MainWindowState}" Value="Docked">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </controls:NumericUpDown.Style>
+                    </controls:NumericUpDown>
+
                 </Grid>
             </GroupBox>
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/VisualsView.xaml
@@ -18,6 +18,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                 <ResourceDictionary Source="/OptiKey;component/Resources/Icons/KeySymbols.xaml" />
                 <ResourceDictionary>
                     <valueConverters:EnabledIfNotOverridden x:Key="EnabledIfNotOverridden" />
+                    <valueConverters:BoolToCustomValues x:Key="InverseBooleanToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -313,11 +314,13 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
 
 
                     <TextBlock Grid.Row="17" Grid.Column="0" Text="Window state" 
+                               Visibility="{Binding MaximisedApp, Converter={StaticResource InverseBooleanToVisibilityConverter}}"
                                VerticalAlignment="Center" Margin="5" />
                     <ComboBox Grid.Row="17" Grid.Column="1" 
                               ItemsSource="{Binding MainWindowStates}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
+                              Visibility="{Binding MaximisedApp, Converter={StaticResource InverseBooleanToVisibilityConverter}}"
                               SelectedValue="{Binding MainWindowState, Mode=TwoWay}" />
 
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml
@@ -64,4 +64,9 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
     </i:Interaction.Triggers>
 
     <views:MainView x:Name="MainView" />
+        <WindowChrome.WindowChrome>
+            <WindowChrome 
+                CaptionHeight="0"
+                ResizeBorderThickness="5" />
+        </WindowChrome.WindowChrome>
 </Window>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml
@@ -14,7 +14,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
         Title="OptiKey"
         Topmost="True"
         AllowsTransparency="True"
-        ResizeMode="NoResize"
+        ResizeMode="CanResizeWithGrip"
         Style="{DynamicResource MainWindowStyle}"
         Tag="{Binding RelativeSource={RelativeSource Mode=Self}}">
     <!--Set background to transparent so keyboards can have transparent backgrounds-->

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml.cs
@@ -46,6 +46,11 @@ namespace JuliusSweetland.OptiKey.UI.Windows
         {
             InitializeComponent();
 
+            if (Settings.Default.MainWindowState == WindowStates.Floating ||
+                Settings.Default.MainWindowPreviousState == WindowStates.Floating)
+            {
+                this.ResizeMode = ResizeMode.CanResizeWithGrip;
+            }
             this.audioService = audioService;
             this.dictionaryService = dictionaryService;
             this.inputService = inputService;

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/ManagementWindow.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/ManagementWindow.xaml
@@ -10,6 +10,7 @@ Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                      Title="{x:Static resx:Resources.MANAGEMENT_CONSOLE_TITLE}"
                      WindowStartupLocation="CenterOwner"
                      WindowState="Maximized"
+                     ResizeMode="CanResizeWithGrip"
                      MinWidth="300" MinHeight="200"
                      Icon="..\..\Resources\Icons\Management.ico"
                      FlowDirection="{Binding Source={x:Static resx:Settings.Default}, Path=UiLanguageFlowDirection}">

--- a/src/JuliusSweetland.OptiKey.Mouse/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Mouse/App.xaml.cs
@@ -199,6 +199,12 @@ namespace JuliusSweetland.OptiKey.Mouse
                 {
                     mainWindowManipulationService.SizeAndPositionInitialised += sizeAndPositionInitialised;
                 }
+
+                Current.Exit += (o, args) =>
+                {
+                    mainWindowManipulationService.PersistSizeAndPosition();
+                    Settings.Default.Save();
+                };
             }
             catch (Exception ex)
             {

--- a/src/JuliusSweetland.OptiKey.Mouse/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Mouse/Properties/Settings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 
+using JuliusSweetland.OptiKey.Enums;
+
 namespace JuliusSweetland.OptiKey.Mouse.Properties
 {
 
@@ -10,6 +12,11 @@ namespace JuliusSweetland.OptiKey.Mouse.Properties
         {
             Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
             InitialiseWithDerivedSettings(defaultInstance);
+        }
+
+        public override AppType GetApp()
+        {
+            return AppType.Mouse;
         }
 
         #region App-specific settings

--- a/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
@@ -213,6 +213,12 @@ namespace JuliusSweetland.OptiKey.Pro
                 {
                     mainWindowManipulationService.SizeAndPositionInitialised += sizeAndPositionInitialised;
                 }
+
+                Current.Exit += (o, args) =>
+                {
+                    mainWindowManipulationService.PersistSizeAndPosition();
+                    Settings.Default.Save();
+                };
             }
             catch (Exception ex)
             {

--- a/src/JuliusSweetland.OptiKey.Pro/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Pro/Properties/Settings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 
+using JuliusSweetland.OptiKey.Enums;
+
 namespace JuliusSweetland.OptiKey.Pro.Properties {
 
     class Settings : JuliusSweetland.OptiKey.Properties.Settings
@@ -9,6 +11,11 @@ namespace JuliusSweetland.OptiKey.Pro.Properties {
         {
             Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
             InitialiseWithDerivedSettings(defaultInstance);            
+        }
+
+        public override AppType GetApp()
+        {
+            return AppType.Pro;
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.Symbol/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Symbol/App.xaml.cs
@@ -199,6 +199,12 @@ namespace JuliusSweetland.OptiKey.Symbol
                 {
                     mainWindowManipulationService.SizeAndPositionInitialised += sizeAndPositionInitialised;
                 }
+
+                Current.Exit += (o, args) =>
+                {
+                    mainWindowManipulationService.PersistSizeAndPosition();
+                    Settings.Default.Save();
+                };
             }
             catch (Exception ex)
             {

--- a/src/JuliusSweetland.OptiKey.Symbol/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Symbol/Properties/Settings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 
+using JuliusSweetland.OptiKey.Enums;
+
 namespace JuliusSweetland.OptiKey.Symbol.Properties
 {
 
@@ -10,6 +12,11 @@ namespace JuliusSweetland.OptiKey.Symbol.Properties
         {
             Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
             InitialiseWithDerivedSettings(defaultInstance);
+        }
+
+        public override AppType GetApp()
+        {
+            return AppType.Symbol;
         }
 
         /*

--- a/src/JuliusSweetland.OptiKey.UnitTests/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Properties/Settings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2019 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 
+using JuliusSweetland.OptiKey.Enums;
+
 namespace JuliusSweetland.OptiKey.UnitTests.Properties {
 
     class Settings : JuliusSweetland.OptiKey.Properties.Settings
@@ -9,6 +11,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.Properties {
         {
             Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
             InitialiseWithDerivedSettings(defaultInstance);            
+        }
+
+        public override AppType GetApp()
+        {
+            return AppType.Tests;
         }
     }
 }


### PR DESCRIPTION
Optikey apps can now be re-sized by hand, by dragging the edges/corners.

Notes:
- Can also change from floating/docked in management console, as well as dock position
- Management console is also now resizable, which helps you get out of awkward situations where it doesn't sit well with a floating Optikey.
- Some tidying up of formatting in visuals view

