### PR TITLE
Mouse events with primary screen on right

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Services/PublishService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PublishService.cs
@@ -104,9 +104,10 @@ namespace JuliusSweetland.OptiKey.Services
                 
                 //N.B. InputSimulator does not deal in pixels. The position should be a scaled point between 0 and 65535. 
                 //https://inputsimulator.codeplex.com/discussions/86530
-                inputSimulator.Mouse.MoveMouseToPositionOnVirtualDesktop(
-                    Math.Ceiling(65535 * (point.X / Graphics.VirtualScreenWidthInPixels)),
-                    Math.Ceiling(65535 * (point.Y / Graphics.VirtualScreenHeightInPixels)));
+
+                inputSimulator.Mouse.MoveMouseTo(
+                    Math.Ceiling(65535 * (point.X / Graphics.PrimaryScreenWidthInPixels)),
+                    Math.Ceiling(65535 * (point.Y / Graphics.PrimaryScreenHeightInPixels)));
             }
             catch (Exception exception)
             {

--- a/src/JuliusSweetland.OptiKey.Core/Static/Graphics.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Static/Graphics.cs
@@ -52,6 +52,16 @@ namespace JuliusSweetland.OptiKey.Static
             get { return SystemParameters.VirtualScreenHeight * DipScalingFactorY; }
         }
 
+        public static double PrimaryScreenWidthInPixels
+        {
+            get { return SystemParameters.PrimaryScreenWidth * DipScalingFactorX; }
+        }
+
+        public static double PrimaryScreenHeightInPixels
+        {
+            get { return SystemParameters.PrimaryScreenHeight * DipScalingFactorY; }
+        }
+
         public static Rect DipsToPixels(Rect bounds)
         {
             bounds.Scale(DipScalingFactorX, DipScalingFactorY);

--- a/src/JuliusSweetland.OptiKey.Core/app.manifest
+++ b/src/JuliusSweetland.OptiKey.Core/app.manifest
@@ -36,6 +36,19 @@
     </application>
   </compatibility>
 
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings"> PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  
+
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!-- <dependency>
     <dependentAssembly>


### PR DESCRIPTION
Two tentative contributions:
(a) Fix for #490 and part of #175, whereby mouse positions were wrong if a secondary monitor was on the left.
(b) Turned on per-monitor DPI-aware feature, which fixes Optikey's resizing when switching from hi-DPI to normal monitor or vice versa (e.g if you plug in an external screen to your Surface Pro while running Optikey). There may still be some scenarios in which you need to restart Optikey to get correct sizing, but this fixes a common situation. The fix only has an effect if you're running a recent version of Windows 10.

Some notes on (a):
- Eye trackers generally support running on a single screen, but this can be one of a multi-screen setup - e.g. on the Tobii 4C you tell it which screen the tracker is on, this seems to default to your primary screen but can be moved to your secondary screen. 
- It is possible to launch Optikey on a non-primary screen, but it does not currently behave correctly - the notifications appear on the wrong screen, and as #175 points out, docking doesn't work. 
- So far Optikey has been reported as working fine on any multi-screen setup where the primary screen was on the left, but if the primary screen was on the right, any mouse events from Optikey got carried out on the left (wrong) screen.

I would suggest that it would be reasonable that Optikey:
(i) *should* support multi-monitor setups, so long as it is running on the *primary* screen, regardless of physical setup 
(ii) should *not* support running on a non-primary screen (since a lot more would need to be fixed to support that).

With this PR, you get correct behaviour for mouse events on the primary screen, regardless of whether that's on the left or right. As far as I understand from @annakirkpatrick's reports, everything else is in place to achieve (i). **But** it did require doubling-down on the assumption that Optikey is running on the primary screen, which isn't ideal :) I don't think that's a big problem given the situation.

