### PR TITLE
Allow any virtual keycode enum for dynamic keypress

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Services/KeyboardOutputService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/KeyboardOutputService.cs
@@ -506,15 +506,28 @@ namespace JuliusSweetland.OptiKey.Services
                     publishService.KeyUp(virtualKeyCode.Value);
                 else
                     publishService.KeyDownUp(virtualKeyCode.Value);
+                return;
             }
-            else
+
+            // If not an Optikey FunctionKey, check if it matches a virtual key name
+            VirtualKeyCode vkCode;
+            if (Enum.TryParse(inKey, true, out vkCode)) // ignore case
             {
-                // Actual key presses
-                foreach (var chaKey in inKey)
-                {
-                    this.PressKey(chaKey, type);
-                }
+                if (type == KeyPressKeyValue.KeyPressType.Press)
+                    publishService.KeyDown(vkCode);
+                else if (type == KeyPressKeyValue.KeyPressType.Release)
+                    publishService.KeyUp(vkCode);
+                else
+                    publishService.KeyDownUp(vkCode);
+                return;
             }
+            
+            // Otherwise a vanilla key press
+            foreach (var chaKey in inKey)
+            {
+                this.PressKey(chaKey, type);
+            }
+        
         }
 
         private string CombineStringWithActiveDeadKeys(string input)


### PR DESCRIPTION

Currently you can specify function keys in a dynamic keyboard with things like:
`<KeyDown>Home</KeyDown>`

However, this is limited to whatever has been exposed via the FunctionKeys enum, which specifies an associated virtual key code. Today, I wanted a key to press "Return" (as opposed to typing "\n" which the alpha keyboard does) and this was not exposed as a FunctionKey since Optikey doesn't use it elsewhere. The current behaviour is that you just get "Return" typed out letter by letter. 

It would be nice to be able to specify any virtual key from `WindowsInput.Native.VirtualKeyCode`. This PR changes the `ProcessSingleKeyPress` so it first searches for a match in Optikey's `FunctionKeys` enum, and then in `WindowsInput.Native.VirtualKeyCode` before falling back to typing characters. 

I don't think there's anything controversial about this, but it would be worth @AdamRoden confirming.
