### PR TITLE
Fix #672 ReturnToHere parsing.

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlDynamicKey.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/XmlKeyboardModels/XmlDynamicKey.cs
@@ -43,7 +43,7 @@ namespace JuliusSweetland.OptiKey.Models
 
         [XmlIgnore]
         public bool BackReturnsHere
-        { get; set; }
+        { get; set; } = true;
 
         [XmlAttribute("BackReturnsHere")]
         public string BackReturnsHereAsString

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
@@ -642,8 +642,8 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
                         else
                         {
                             commandKeyValue = Enum.TryParse(dynamicLink.Value, out Enums.Keyboards keyboardEnum)
-                                ? new ChangeKeyboardKeyValue(keyboardEnum, dynamicLink.BackReturnsHere)
-                                : new ChangeKeyboardKeyValue(Path.Combine(rootDir, dynamicLink.Value), dynamicLink.BackReturnsHere);
+                                ? new ChangeKeyboardKeyValue(keyboardEnum, !dynamicLink.BackReturnsHere)
+                                : new ChangeKeyboardKeyValue(Path.Combine(rootDir, dynamicLink.Value), !dynamicLink.BackReturnsHere);
                             
                             commandList.Add(new KeyCommand(KeyCommands.ChangeKeyboard, commandKeyValue));
                         }


### PR DESCRIPTION
The default was wrong, *and* the parsed values got flipped, so it
seemed that the default was correct :)

@AdamRoden, I don't know if any built-in example keyboards need amending? 