### PR TITLE
Fix possible null pointer #679

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
@@ -191,9 +191,9 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                 mainWindow.BorderBrushOverride = null;
 
                 //Clear the dictionaries
-                keyFamily.Clear();
-                keyValueByGroup.Clear();
-                overrideTimesByKey.Clear();
+                keyFamily?.Clear();
+                keyValueByGroup?.Clear();
+                overrideTimesByKey?.Clear();
 
                 if (!(Keyboard is ViewModelKeyboards.DynamicKeyboard))
                     windowManipulationService.RestorePersistedState();

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -2422,8 +2422,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 commandList.AddRange(singleKeyValue.Commands);
                 keyStateService.KeyRunningStates[singleKeyValue].Value = true;
 
-                TimeSpanOverrides timeSpanOverrides = 
-                    inputService.OverrideTimesByKey.TryGetValue(singleKeyValue, out timeSpanOverrides) ? timeSpanOverrides : null;
+                TimeSpanOverrides timeSpanOverrides = null;
+                inputService.OverrideTimesByKey?.TryGetValue(singleKeyValue, out timeSpanOverrides);
 
                 //if there is an override lock down time then do not set the key to LockedDown
                 keyStateService.KeyDownStates[singleKeyValue].Value = timeSpanOverrides != null && timeSpanOverrides.TimeRequiredToLockDown > TimeSpan.Zero 


### PR DESCRIPTION
In particular, overrideTimesByKey was null when a trigger other than
dwell fixation is being used