### PR TITLE
Don't allow manual resizing when collapsed

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -215,9 +215,16 @@ namespace JuliusSweetland.OptiKey.Services
             var windowState = getWindowState();
             switch (windowState)
             {
-                case WindowStates.Docked:
+                
                 case WindowStates.Floating:
                     window.ResizeMode = ResizeMode.CanResizeWithGrip;
+                    break;
+
+                case WindowStates.Docked:
+                    if (getDockSize() == DockSizes.Full)
+                        window.ResizeMode = ResizeMode.CanResizeWithGrip;
+                    else
+                        window.ResizeMode = ResizeMode.NoResize;
                     break;
 
                 case WindowStates.Maximised:


### PR DESCRIPTION
Disable grab-handle resizing when dock is collapsed (since the desired result is somewhat ambiguous)