### PR TITLE
Crash restart

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
@@ -2773,6 +2773,37 @@ namespace JuliusSweetland.OptiKey.Properties {
             }
         }
 
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("false")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public virtual bool CleanShutdown
+        {
+            get
+            {
+                return ((bool)(this["CleanShutdown"]));
+            }
+            set
+            {
+                this["CleanShutdown"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public virtual bool AttemptRestartUponCrash
+        {
+            get
+            {
+                return ((bool)(this["AttemptRestartUponCrash"]));
+            }
+            set
+            {
+                this["AttemptRestartUponCrash"] = value;
+            }
+        }
 
         public bool IsOverridden(string propName)
         {

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -2169,6 +2169,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     Keyboard = new YesNoQuestion(Resources.REFRESH_MESSAGE,
                         () =>
                         {
+                            Settings.Default.CleanShutdown = true;
                             OptiKeyApp.RestartApp();
                             Application.Current.Shutdown();
                         },

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/ManagementViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/ManagementViewModel.cs
@@ -213,6 +213,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                             Settings.Default.Save();
                             try
                             {
+                                Settings.Default.CleanShutdown = true;
                                 OptiKeyApp.RestartApp();
                             }
                             catch { } //Swallow any exceptions (e.g. DispatcherExceptions) - we're shutting down so it doesn't matter.

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/CrashWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/CrashWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace JuliusSweetland.OptiKey.UI.Windows
                 dt.Tick += (o, eventArgs) =>
                 {
                     this.Close();
+                    OptiKeyApp.RestartApp();
                 };
                 dt.Start();
             };

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/CrashWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/CrashWindow.xaml.cs
@@ -21,7 +21,14 @@ namespace JuliusSweetland.OptiKey.UI.Windows
                 dt.Tick += (o, eventArgs) =>
                 {
                     this.Close();
-                    OptiKeyApp.RestartApp();
+
+                    // The first crash might attempt a restart, but subsequent crashes shouldn't
+                    if (Settings.Default.AttemptRestartUponCrash && Settings.Default.CleanShutdown)
+                    {
+                        Settings.Default.CleanShutdown = false;
+                        Settings.Default.Save();
+                        OptiKeyApp.RestartApp();
+                    }
                 };
                 dt.Start();
             };

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml.cs
@@ -249,6 +249,7 @@ namespace JuliusSweetland.OptiKey.UI.Windows
         {
             if (MessageBox.Show(Properties.Resources.QUIT_MESSAGE, Properties.Resources.QUIT, MessageBoxButton.YesNo) == MessageBoxResult.Yes)
             {
+                Settings.Default.CleanShutdown = true;
                 Application.Current.Shutdown();
             }
         }


### PR DESCRIPTION
Tentative proposal for now, wouldn't mind another pair of eyes on the logic. 

2 new settings:
- `AttemptRestartUponCrash`, defaults true, might be exposed to the user in management console at some point (but I haven't added that yet)
- `CleanShutdown`, used internally by app. Set to true any time a normal shutdown/restart is requested by a user (e.g. quit buttons, quit through contextmenu, restart through contextmenu). Set to false when crash occurs, prior to the app either exiting or attempting a restart.

End result should be that by default, the app automatically restarts one time upon a crash. If it crashes again in the startup process, it won't attempt another restart. If it crashes again later during app usage (e.g. the user tries the same things again and triggers the same crash) it also won't attempt another restart. Once a full app cycle (launch -> clean shutdown) has occurred, this behaviour gets reset. 

This avoids any subtlety in "when has the app completely loaded correctly", but loses some usability in that a user could inadvertently trigger the same behaviour again, much later in their session, and then be locked out of Optikey if they don't have another way to relaunch with gaze.

If this approach is deemed acceptable, then please sanity check my logic and let me know if there are other "clean shutdown" paths that I've missed. 


