### PR TITLE
Resizing fixes

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
@@ -30,7 +30,7 @@ namespace JuliusSweetland.OptiKey.Services
         void SetOpacity(double opacity);
         void Shrink(ShrinkFromDirections direction, double amountInPx);
         void OverridePersistedState(bool inPersistNewState, string inWindowState, string inPosition, string inDockSize, string inWidth, string inHeight, string inHorizontalOffset, string inVerticalOffset);
-        void RestorePersistedState(bool saveState);
+        void RestorePersistedState();
         void DisableResize();
         void SetResizeState();
     }

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -443,10 +443,14 @@ namespace JuliusSweetland.OptiKey.Services
         public void Maximise()
         {
             Log.Info("Maximise called");
+            var persistedState = getPersistedState();
 
             var windowState = getWindowState();
             if (windowState != WindowStates.Maximised)
             {
+                // make sure current state has been saved
+                if (persistedState)
+                    PersistSizeAndPosition();
                 savePreviousWindowState(windowState);
             }
             if (getWindowState() == WindowStates.Docked)
@@ -473,6 +477,8 @@ namespace JuliusSweetland.OptiKey.Services
 
             if (getWindowState() != WindowStates.Minimised)
             {
+                if (persistedState)
+                    PersistSizeAndPosition();
                 savePreviousWindowState(getWindowState());
             }
             if (getWindowState() == WindowStates.Docked)
@@ -530,6 +536,9 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.InfoFormat("OverridePersistedState called with PersistNewState {0}, WindowState {1}, Position {2}, Width {3}, Height {4}, horizontalOffset {5}, verticalOffset {6}", inPersistNewState, inWindowState, inPosition, inWidth, inHeight, inHorizontalOffset, inVerticalOffset);
 
+            // make sure current state has been saved before overriding
+            if (GetPersistedState())
+                PersistSizeAndPosition();
 
             WindowStates oldWindowState = getWindowState();
             WindowStates newWindowState = Enum.TryParse(inWindowState, out newWindowState) ? newWindowState : getWindowState();

--- a/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/WindowManipulationService.cs
@@ -443,14 +443,10 @@ namespace JuliusSweetland.OptiKey.Services
         public void Maximise()
         {
             Log.Info("Maximise called");
-            var persistedState = getPersistedState();
 
             var windowState = getWindowState();
             if (windowState != WindowStates.Maximised)
             {
-                // make sure current state has been saved
-                if (persistedState)
-                    PersistSizeAndPosition();
                 savePreviousWindowState(windowState);
             }
             if (getWindowState() == WindowStates.Docked)
@@ -477,8 +473,6 @@ namespace JuliusSweetland.OptiKey.Services
 
             if (getWindowState() != WindowStates.Minimised)
             {
-                if (persistedState)
-                    PersistSizeAndPosition();
                 savePreviousWindowState(getWindowState());
             }
             if (getWindowState() == WindowStates.Docked)
@@ -536,9 +530,6 @@ namespace JuliusSweetland.OptiKey.Services
         {
             Log.InfoFormat("OverridePersistedState called with PersistNewState {0}, WindowState {1}, Position {2}, Width {3}, Height {4}, horizontalOffset {5}, verticalOffset {6}", inPersistNewState, inWindowState, inPosition, inWidth, inHeight, inHorizontalOffset, inVerticalOffset);
 
-            // make sure current state has been saved before overriding
-            if (GetPersistedState())
-                PersistSizeAndPosition();
 
             WindowStates oldWindowState = getWindowState();
             WindowStates newWindowState = Enum.TryParse(inWindowState, out newWindowState) ? newWindowState : getWindowState();
@@ -669,7 +660,7 @@ namespace JuliusSweetland.OptiKey.Services
             SetAppBarSizeAndPosition(getDockPosition(), dockSizeAndPositionInPx); //PersistSizeAndPosition() is called indirectly by SetAppBarSizeAndPosition - no need to call explicitly
         }
 
-        public void RestorePersistedState(bool saveState = false)
+        public void RestorePersistedState()
         {
             Log.Info("RestorePersistedState called");
 
@@ -678,15 +669,11 @@ namespace JuliusSweetland.OptiKey.Services
             if (getPreviousWindowState() != WindowStates.Docked && getWindowState() == WindowStates.Docked)
                 UnRegisterAppBar();
 
-            savePersistedState(saveState);
+            savePersistedState(true);
+            Log.Info("Restoring keyboard to default values");
 
-            if (saveState)
-            {
-                Log.Info("Restoring keyboard to default values");
-
-                ApplySavedState();
-                ResizeDockToFull();
-            }
+            ApplySavedState();
+            ResizeDockToFull();
         }
 
         public void Restore()

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
@@ -196,15 +196,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                 overrideTimesByKey?.Clear();
 
                 if (!(Keyboard is ViewModelKeyboards.DynamicKeyboard))
-                {
-                    if (Keyboard is ViewModelKeyboards.ConversationAlpha1 
-                        || Keyboard is ViewModelKeyboards.ConversationAlpha2
-                        || Keyboard is ViewModelKeyboards.ConversationConfirm
-                        || Keyboard is ViewModelKeyboards.ConversationNumericAndSymbols)
-                        windowManipulationService.RestorePersistedState(false);
-                    else
-                        windowManipulationService.RestorePersistedState(true);
-                }
+                   windowManipulationService.RestorePersistedState();
             }
 
             object newContent = ErrorContent;


### PR DESCRIPTION
This is a proposed edit to PR#707

As far as I can tell, the changes to `RestorePersistedState` (both the function and the calling code) do not break anything in the resizing logic, but removing the `PersistSizeAndPosition` calls within `Maximise` and `Minimise` do cause problems - they are there to make sure any pending manual changes to size/position aren't lost when you minimise / re-maximise. 

I've reverted half of @AdamRoden's commit and it still seems to fix the issue with the Minimised size decreasing each time, but without breaking the resizing. If @AdamRoden's happy after testing this, I'm happy with it.