### PR TITLE
Resizing fixes Take 2

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
@@ -195,16 +195,8 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                 keyValueByGroup?.Clear();
                 overrideTimesByKey?.Clear();
 
-                if (!(Keyboard is ViewModelKeyboards.DynamicKeyboard))
-                {
-                    if (Keyboard is ViewModelKeyboards.ConversationAlpha1 
-                        || Keyboard is ViewModelKeyboards.ConversationAlpha2
-                        || Keyboard is ViewModelKeyboards.ConversationConfirm
-                        || Keyboard is ViewModelKeyboards.ConversationNumericAndSymbols)
-                        windowManipulationService.RestorePersistedState(false);
-                    else
-                        windowManipulationService.RestorePersistedState(true);
-                }
+                bool saveState = !(Keyboard is ViewModelKeyboards.DynamicKeyboard);
+                windowManipulationService.RestorePersistedState(saveState);
             }
 
             object newContent = ErrorContent;


### PR DESCRIPTION
From what I can see, there are a few issues going on here.

Here are some requirements my end, which are being broken by recent/proposed changes:
- While a dynamic keyboard is loaded, any pending manual resizes should be temporary only and not be persisted. 
- When Optikey is minimised, any pending manual resizes should be temporary only and not be persisted. When maximised, the pending changes should be restored. 

I've been testing these things:
1) From main menu, does minimising and maximising several times result in correct sizing behaviour?
2) From dynamic keyboard "vertical function keys keyboard", does minimising and maximising several times result in correct sizing behaviour?
3) From main menu, if you drag the keyboard to a new location, then minimise & maximise, do you end up back where you were before you minimised?
4) While in a dynamic keyboard, if you drag the keyboard to a new position, and then go "back" to the main dynamic keyboards menu, the position should be unchanged (i.e. the same position as before you launched the dynamic keyboard). 

With this proposed commit, my testing shows all the above tests passing with one exception - (4) fails if the main state is Floating but the dynamic keyboard state is Docked. It looks like this is a regression introduced by 1271d771fd. I'd be happy to open this as a new issue to be dealt with separately - it's less common since people won't often be resizing their docked dynamic keyboards. 

One other concern for @AdamRoden is that I do not know why there was an additional check added for ConversationAlpha1, ConversationAlpha2, ConversationConfirm and ConversationNumeric, and this is obviously lost in my proposed change. Obviously it could be added back to the logic for `saveState = ...` if appropriate.

Thoughts?