### PR TITLE
Use Position=Absolute for magnify popup

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/MagnifyPopup.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/MagnifyPopup.cs
@@ -131,21 +131,19 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             MaxWidth = MinWidth = Width = width;
             MaxHeight = MinHeight = Height = height;
 
+            // Screen-centered version (TODO: use Popup Placement="Centre" instead?)
             var distanceFromLeftBoundary = screenTopLeftInWpfCoords.X + ((1d - destinationPercentage) / 2d) * screenWidth;
             var distanceFromTopBoundary = screenTopLeftInWpfCoords.Y + ((1d - destinationPercentage) / 2d) * screenHeight;
             var pointInWpfCoords = window.GetTransformFromDevice().Transform(new Point(point.X, point.Y));
 
+            // Point-centered version 
             if (!centerOnScreen)
             {
-                if (pointInWpfCoords.X - (width / 2d) < 0)
-                    distanceFromLeftBoundary = 0;
-                else
-                    distanceFromLeftBoundary = pointInWpfCoords.X + (width / 2d);
+                distanceFromLeftBoundary = (pointInWpfCoords.X - (width / 2d)).CoerceToLowerLimit(0);
+                distanceFromLeftBoundary.CoerceToUpperLimit(screenWidth - width);
 
-                if (pointInWpfCoords.Y + (height / 2d) > screenHeight)
-                    distanceFromTopBoundary = screenHeight + (height / 2d);
-                else
-                    distanceFromTopBoundary = pointInWpfCoords.Y - (height / 2d);
+                distanceFromTopBoundary = (pointInWpfCoords.Y - (height / 2d)).CoerceToLowerLimit(0);
+                distanceFromTopBoundary.CoerceToUpperLimit(screenHeight - height);
             }
 
             HorizontalOffset = distanceFromLeftBoundary;

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/MainView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/MainView.xaml
@@ -71,7 +71,7 @@ Copyright (c) 2020 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
             <controls:Cursor IsHitTestVisible="False" />
         </controls:CursorPopup>
 
-        <controls:MagnifyPopup IsHitTestVisible="False" Placement="AbsolutePoint" AllowsTransparency="True" />
+        <controls:MagnifyPopup IsHitTestVisible="False" Placement="Absolute" AllowsTransparency="True" />
         
         <controls:ToastNotificationPopup x:Name="ToastNotificationPopup"
             Placement="AbsolutePoint"  AllowsTransparency="True" IsOpen="False">


### PR DESCRIPTION
This seems to fix both #711 and #670 and makes the popup placement much easier to reason about. Having said that, I still don't understand why there was an interaction between `Placement=AbsolutePoint` and `ResizeMode`, so this PR should face some testing/scrutiny. I'm also unsure whether there was some extra reasoning behind using `AbsolutePoint` in the first place. You can read the explanations at [Placement Mode enums](https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.primitives.placementmode?view=netcore-3.1#System_Windows_Controls_Primitives_PlacementMode_Absolute).

I've tested on my Surface Pro with (a) extended desktop, (b) hi-DPI surface screen only, (c) normal-DPI monitor only and (d) surface screen in "tablet mode". 