### PR TITLE
Fix for resize issue related to dynamic keyboards

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
@@ -195,7 +195,11 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                 keyValueByGroup?.Clear();
                 overrideTimesByKey?.Clear();
 
-                if (!(Keyboard is ViewModelKeyboards.DynamicKeyboard))
+                if (!(Keyboard is ViewModelKeyboards.DynamicKeyboard)
+                    && !(Keyboard is ViewModelKeyboards.ConversationAlpha1)
+                    && !(Keyboard is ViewModelKeyboards.ConversationAlpha2)
+                    && !(Keyboard is ViewModelKeyboards.ConversationConfirm)
+                    && !(Keyboard is ViewModelKeyboards.ConversationNumericAndSymbols))
                    windowManipulationService.RestorePersistedState();
             }
 


### PR DESCRIPTION
I think that because we use a dispatcher to apply the saved size and position, we get in a situation where the main thread maximizes the window before it gets resized by the dispatcher thread. My fix basically says, "don't try restoring the persisted state if we're navigating a maximized keyboard."