### PR TITLE
Smoothing Concept

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Extensions/DoubleExtensions.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Extensions/DoubleExtensions.cs
@@ -14,5 +14,10 @@ namespace JuliusSweetland.OptiKey.Extensions
         {
             return Math.Max(value, lowerLimit);
         }
+
+        public static double Clamp(this double value, double lowerLimit, double upperLimit)
+        {
+            return Math.Min(Math.Max(value, lowerLimit), upperLimit);
+        }
     }
 }

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/MagnifyPopup.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/MagnifyPopup.cs
@@ -72,7 +72,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
                         try
                         {
-                            DisplayScaledScreenshot(sourcePoint.Value);
+                            DisplayScaledScreenshot();
                         }
                         catch (System.ComponentModel.Win32Exception ex)
                         {
@@ -122,36 +122,52 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
         private void SetSizeAndPosition(Point point)
         {
+            point = new Point(point.X.Clamp(screen.Bounds.Left, screen.Bounds.Right), point.Y.Clamp(screen.Bounds.Top, screen.Bounds.Bottom));
+
+            var centerOnScreen = Settings.Default.MagnifierCenterOnScreen;
+            var magnifySourcePercentage = Settings.Default.MagnifySourcePercentageOfScreen / 100d;
+            var destinationPercentage = Settings.Default.MagnifyDestinationPercentageOfScreen / 100d;
+
+            var captureWidth = magnifySourcePercentage * screen.Bounds.Width;
+            var captureHeight = magnifySourcePercentage * screen.Bounds.Height;
+            var captureX = (point.X - (captureWidth / 2d)).Clamp(screen.Bounds.Left, screen.Bounds.Right - captureWidth);
+            var captureY = (point.Y - (captureHeight / 2d)).Clamp(screen.Bounds.Top, screen.Bounds.Bottom - captureHeight);
+
+            //Calculate source area
+            sourceArea = new Rect(captureX, captureY, captureWidth, captureHeight);
+
+            //Get WPF coords in order to calculate the magnified size and position
+            var pointInWpfCoords = window.GetTransformFromDevice().Transform(new Point(point.X, point.Y));
             var screenTopLeftInWpfCoords = window.GetTransformFromDevice().Transform(new Point(screen.Bounds.Left, screen.Bounds.Top));
             var screenBottomRightInWpfCoords = window.GetTransformFromDevice().Transform(new Point(screen.Bounds.Right, screen.Bounds.Bottom));
 
             var screenWidth = (screenBottomRightInWpfCoords.X - screenTopLeftInWpfCoords.X);
             var screenHeight = (screenBottomRightInWpfCoords.Y - screenTopLeftInWpfCoords.Y);
-
-            var destinationPercentage = Settings.Default.MagnifyDestinationPercentageOfScreen / 100d;
-            var centerOnScreen = Settings.Default.MagnifierCenterOnScreen;
-
             var width = destinationPercentage * screenWidth;
             var height = destinationPercentage * screenHeight;
 
-            MaxWidth = MinWidth = Width = width;
-            MaxHeight = MinHeight = Height = height;
-
-            // Screen-centered version (TODO: use Popup Placement="Centre" instead?)
+            // Screen-centered version
             var distanceFromLeftBoundary = screenTopLeftInWpfCoords.X + ((1d - destinationPercentage) / 2d) * screenWidth;
             var distanceFromTopBoundary = screenTopLeftInWpfCoords.Y + ((1d - destinationPercentage) / 2d) * screenHeight;
-            var pointInWpfCoords = window.GetTransformFromDevice().Transform(new Point(point.X, point.Y));
 
             // Point-centered version 
             if (!centerOnScreen)
             {
-                distanceFromLeftBoundary = (pointInWpfCoords.X - (width / 2d)).CoerceToLowerLimit(0);
-                distanceFromLeftBoundary.CoerceToUpperLimit(screenWidth - width);
+                var croppedWidth = 2 * Math.Min(pointInWpfCoords.X - screenTopLeftInWpfCoords.X, screenBottomRightInWpfCoords.X - pointInWpfCoords.X);
+                var croppedHeight = 2 * Math.Min(pointInWpfCoords.Y - screenTopLeftInWpfCoords.Y, screenBottomRightInWpfCoords.Y - pointInWpfCoords.Y);
 
-                distanceFromTopBoundary = (pointInWpfCoords.Y - (height / 2d)).CoerceToLowerLimit(0);
-                distanceFromTopBoundary.CoerceToUpperLimit(screenHeight - height);
+                destinationPercentage = Math.Min(Math.Min(destinationPercentage, croppedWidth / screenWidth), croppedHeight / screenHeight)
+                    .CoerceToLowerLimit(destinationPercentage / 2d);
+                
+                width = destinationPercentage * screenWidth;
+                height = destinationPercentage * screenHeight;
+
+                distanceFromLeftBoundary = (pointInWpfCoords.X - (width / 2d) - screenTopLeftInWpfCoords.X).CoerceToLowerLimit(0);
+                distanceFromTopBoundary = (pointInWpfCoords.Y - (height / 2d) - screenTopLeftInWpfCoords.Y).CoerceToLowerLimit(0);
             }
 
+            MaxWidth = MinWidth = Width = width;
+            MaxHeight = MinHeight = Height = height;
             HorizontalOffset = distanceFromLeftBoundary;
             VerticalOffset = distanceFromTopBoundary;
 
@@ -162,39 +178,14 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
         #region Capture & Display Scaled Screenshot
 
-        private void DisplayScaledScreenshot(Point point)
+        private void DisplayScaledScreenshot()
         {
-            var bitmap = CaptureScreenshot(point);
+            var bitmap = CaptureScreenshot();
             Child = new Image { Source = bitmap.ToBitmapImage() };
         }
 
-        private Bitmap CaptureScreenshot(Point point)
+        private Bitmap CaptureScreenshot()
         {
-            var magnifySourcePercentage = Settings.Default.MagnifySourcePercentageOfScreen / 100d;
-
-            var captureWidth = magnifySourcePercentage * screen.Bounds.Width;
-            captureWidth = captureWidth.CoerceToUpperLimit(screen.Bounds.Width);
-
-            var captureHeight = magnifySourcePercentage * screen.Bounds.Height;
-            captureHeight = captureHeight.CoerceToUpperLimit(screen.Bounds.Height);
-
-            var captureX = point.X - (captureWidth / 2d);
-            captureX = captureX.CoerceToLowerLimit(screen.Bounds.Left);
-            if (captureX + captureWidth > screen.Bounds.Right)
-            {
-                captureX = screen.Bounds.Right - captureWidth;
-            }
-
-            var captureY = point.Y - (captureHeight / 2d);
-            captureY = captureY.CoerceToLowerLimit(screen.Bounds.Top);
-            if (captureY + captureHeight > screen.Bounds.Bottom)
-            {
-                captureY = screen.Bounds.Bottom - captureHeight;
-            }
-
-            //Calculate source area
-            sourceArea = new Rect(captureX, captureY, captureWidth, captureHeight);
-
             if (sourceArea.Width <= 0)
                 throw new ArgumentOutOfRangeException(nameof(sourceArea.Width), $"SourceArea.Width was {sourceArea.Width}, which is invalid");
 
@@ -202,7 +193,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                 throw new ArgumentOutOfRangeException(nameof(sourceArea.Height), $"SourceArea.Height was {sourceArea.Height}, which is invalid");
 
             //Create the bitmap to copy the screen shot into
-            var bitmap = new Bitmap(Convert.ToInt32(captureWidth), Convert.ToInt32(captureHeight));
+            var bitmap = new Bitmap(Convert.ToInt32(sourceArea.Width), Convert.ToInt32(sourceArea.Height));
 
             //Copy the screen image to the bitmap
             using (var graphic = Graphics.FromImage(bitmap))


### PR DESCRIPTION
@JuliusSweetland @kmcnaught 
At this point, this is more of a concept than a finished product; meant to show how we could implement it and for you to be able to try it out and see how well it works.

First, I piggybacked off the data stream processing level setting to also impact my smoothing level. Then, I repurposed the Point Selection's Lock On and Fixation Radius values to be used in my algorithm. Lock On is now the "deadzone" that will freeze the gaze point on your screen and hold it still. Fixation is now the distance over which the gaze point on your screen will accelerate from zero up to the full-speed of your eye movement. By adjusting the values you can get a very slow, steady cursor that you could trace with, or a swift but controlled cursor for rapid cursor movement. I recommend using the magnetic cursor to test; with the settings tuned properly, it is oddly satisfying. 

In this figure, you will see the optimal initial Pointing settings, Point Lock On and Completion times, and Point Lock On and Fixation radius.

![image](https://user-images.githubusercontent.com/45572061/92829557-f7bb1400-f399-11ea-9790-57bb2a062fbf.png)
