### PR TITLE
Allow fixation point to be updated during dwell

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/PointFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/PointFixationSource.cs
@@ -133,6 +133,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
                                         //Publish a high signal if progress is 1 (100%), otherwise just publish progress (filter out 0 as this is a progress reset signal)
                                         if (progress > 0)
                                         {
+                                            fixationCentrePointAndKeyValue = point.Value;
                                             observer.OnNext(new TriggerSignal(
                                                 progress >= 1 ? 1 : (double?)null, progress >= 1 ? 1 : progress, fixationCentrePointAndKeyValue));
                                         }


### PR DESCRIPTION
This removes the lockon behaviour during a point selection, letting you continue updating the point (within the appropriate radius). 