### PR TITLE
Add extra precaution to avoid NaNs

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/DataFilters/KalmanFilter.cs
+++ b/src/JuliusSweetland.OptiKey.Core/DataFilters/KalmanFilter.cs
@@ -55,6 +55,8 @@ namespace JuliusSweetland.OptiKey.DataFilters
 
             // == KALMAN FILTER:  Standard update equations from the KF framework - these shouldn't be changed == //
             EstimationNoise += currentProcessNoise;
+            EstimationNoise = Math.Min(currentProcessNoise, 1e100); // Prevent saturation to Inf
+
             Gain = (EstimationNoise) / (EstimationNoise + MeasurementNoise);
             EstimationNoise = (1.0 - Gain) * EstimationNoise;
             EstimatedPoint += (measurement - EstimatedPoint) * Gain;


### PR DESCRIPTION
This potential failure mode has been bothering me... 

With really high deltas, the exponential function _could_ saturate to Inf which
would lead to NaNs later in the calculations. 

We never seem to hit this in practise, but we could if resolutions got really 
high, or the tuning of the filter was modified. Best to cap it to stay safe.