### PR TITLE
Multiple asserts and use of NUnit 3.0's Constraint Model of assertions

### DIFF
--- a/src/JuliusSweetland.OptiKey.UnitTests/Extensions/CharExtensionsTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Extensions/CharExtensionsTests.cs
@@ -19,37 +19,46 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
         [Test]
         public void TestToCharCategory()
         {
-            Assert.AreEqual(CharCategories.NewLine, '\n'.ToCharCategory());
-            Assert.AreEqual(CharCategories.Space, ' '.ToCharCategory());
-            Assert.AreEqual(CharCategories.Tab, '\t'.ToCharCategory());
-            Assert.AreEqual(CharCategories.LetterOrDigitOrSymbolOrPunctuation, 's'.ToCharCategory());
-            Assert.AreEqual(CharCategories.LetterOrDigitOrSymbolOrPunctuation, '5'.ToCharCategory());
-            Assert.AreEqual(CharCategories.LetterOrDigitOrSymbolOrPunctuation, '!'.ToCharCategory());
-            Assert.AreEqual(CharCategories.SomethingElse, '\a'.ToCharCategory());
-            Assert.AreEqual(CharCategories.SomethingElse, '\r'.ToCharCategory());
+            Assert.Multiple(() =>
+            {
+                Assert.That('\n'.ToCharCategory(), Is.EqualTo(CharCategories.NewLine));
+                Assert.That(' '.ToCharCategory(), Is.EqualTo(CharCategories.Space));
+                Assert.That('\t'.ToCharCategory(), Is.EqualTo(CharCategories.Tab));
+                Assert.That('s'.ToCharCategory(), Is.EqualTo(CharCategories.LetterOrDigitOrSymbolOrPunctuation));
+                Assert.That('5'.ToCharCategory(), Is.EqualTo(CharCategories.LetterOrDigitOrSymbolOrPunctuation));
+                Assert.That('!'.ToCharCategory(), Is.EqualTo(CharCategories.LetterOrDigitOrSymbolOrPunctuation));
+                Assert.That('\a'.ToCharCategory(), Is.EqualTo(CharCategories.SomethingElse));
+                Assert.That('\r'.ToCharCategory(), Is.EqualTo(CharCategories.SomethingElse));
+            });            
         }
 
         [Test]
         public void TestConvertEscapedCharToLiteral()
         {
-            Assert.AreEqual(@"[Char:\0|Unicode:U+0000]", '\0'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\a|Unicode:U+0007]", '\a'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\b|Unicode:U+0008]", '\b'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\t|Unicode:U+0009]", '\t'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\f|Unicode:U+000c]", '\f'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\n|Unicode:U+000a]", '\n'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\r|Unicode:U+000d]", '\r'.ToPrintableString());
-            Assert.AreEqual(@"[Char:s|Unicode:U+0073]", 's'.ToPrintableString());
-            Assert.AreEqual(@"[Char: |Unicode:U+0020]", ' '.ToPrintableString());
+            Assert.Multiple(() =>
+            {
+                Assert.That('\0'.ToPrintableString(), Is.EqualTo(@"[Char:\0|Unicode:U+0000]"));
+                Assert.That('\a'.ToPrintableString(), Is.EqualTo(@"[Char:\a|Unicode:U+0007]"));
+                Assert.That('\b'.ToPrintableString(), Is.EqualTo(@"[Char:\b|Unicode:U+0008]"));
+                Assert.That('\t'.ToPrintableString(), Is.EqualTo(@"[Char:\t|Unicode:U+0009]"));
+                Assert.That('\f'.ToPrintableString(), Is.EqualTo(@"[Char:\f|Unicode:U+000c]"));
+                Assert.That('\n'.ToPrintableString(), Is.EqualTo(@"[Char:\n|Unicode:U+000a]"));
+                Assert.That('\r'.ToPrintableString(), Is.EqualTo(@"[Char:\r|Unicode:U+000d]"));
+                Assert.That('s'.ToPrintableString(), Is.EqualTo(@"[Char:s|Unicode:U+0073]"));
+                Assert.That(' '.ToPrintableString(), Is.EqualTo(@"[Char: |Unicode:U+0020]"));
+            });            
         }
 
         [Test]
         public void TestToVirtualKeyCode()
         {
-            Assert.AreEqual(VirtualKeyCode.SPACE, ' '.ToVirtualKeyCode());
-            Assert.AreEqual(VirtualKeyCode.TAB, '\t'.ToVirtualKeyCode());
-            Assert.AreEqual(VirtualKeyCode.RETURN, '\n'.ToVirtualKeyCode());
-            Assert.IsNull('Z'.ToVirtualKeyCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(' '.ToVirtualKeyCode(), Is.EqualTo(VirtualKeyCode.SPACE));
+                Assert.That('\t'.ToVirtualKeyCode(), Is.EqualTo(VirtualKeyCode.TAB));
+                Assert.That('\n'.ToVirtualKeyCode(), Is.EqualTo(VirtualKeyCode.RETURN));
+                Assert.That('Z'.ToVirtualKeyCode(), Is.Null);
+            });           
 
         }
 

--- a/src/JuliusSweetland.OptiKey.UnitTests/Extensions/DoubleExtensionsTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Extensions/DoubleExtensionsTests.cs
@@ -17,15 +17,21 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
         [Test]
         public void TestCoerceToUpperLimit()
         {
-            Assert.AreEqual(10, 100.5.CoerceToUpperLimit(10));
-            Assert.AreEqual(50.5, 50.5.CoerceToUpperLimit(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(100.5.CoerceToUpperLimit(10), Is.EqualTo(10));
+                Assert.That(50.5.CoerceToUpperLimit(100), Is.EqualTo(50.5));
+            });            
         }
 
         [Test]
         public void TestCoerceToLowerLimit()
         {
-            Assert.AreEqual(100.5, 100.5.CoerceToLowerLimit(10));
-            Assert.AreEqual(100, 50.5.CoerceToLowerLimit(100));
+            Assert.Multiple(() =>
+            {
+                Assert.That(100.5.CoerceToLowerLimit(10), Is.EqualTo(100.5));
+                Assert.That(50.5.CoerceToLowerLimit(100), Is.EqualTo(100));
+            });
         }
 
     }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Extensions/KeyDownStatesExtensionsTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Extensions/KeyDownStatesExtensionsTests.cs
@@ -19,9 +19,12 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
         [Test]
         public void TestIsDownOrLockedDown()
         {
-            Assert.AreEqual(true, KeyDownStates.Down.IsDownOrLockedDown());
-            Assert.AreEqual(true, KeyDownStates.LockedDown.IsDownOrLockedDown());
-            Assert.AreEqual(false, KeyDownStates.Up.IsDownOrLockedDown());
+            Assert.Multiple(() =>
+            {
+                Assert.That(KeyDownStates.Down.IsDownOrLockedDown(), Is.True);
+                Assert.That(KeyDownStates.LockedDown.IsDownOrLockedDown(), Is.True);
+                Assert.That(KeyDownStates.Up.IsDownOrLockedDown(), Is.False);
+            });            
         }
 
 

--- a/src/JuliusSweetland.OptiKey.UnitTests/Extensions/PointExtensionsTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Extensions/PointExtensionsTests.cs
@@ -27,8 +27,12 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
             };
 
             var centrePoint = points.CalculateCentrePoint();
-            Assert.AreEqual(6, centrePoint.X);
-            Assert.AreEqual(6, centrePoint.Y);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(centrePoint.X, Is.EqualTo(6));
+                Assert.That(centrePoint.Y, Is.EqualTo(6));
+            });            
         }
 
     }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Extensions/StringExtensionsTests.cs
@@ -14,41 +14,50 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
         [Test]
         public void TestFirstCharToUpper()
         {
-            Assert.AreEqual("Optikey", "optikey".FirstCharToUpper());
-            Assert.AreEqual("Optikey", "Optikey".FirstCharToUpper());
-            Assert.AreEqual("OptiKey", "OptiKey".FirstCharToUpper());
-            Assert.AreEqual("Sam Was Here", "sam Was Here".FirstCharToUpper());
-            Assert.AreEqual("%$%@$#%#@#$&^%$&#$", "%$%@$#%#@#$&^%$&#$".FirstCharToUpper());
-            Assert.AreEqual("  ", "  ".FirstCharToUpper());
-            Assert.AreEqual(null, NullString.FirstCharToUpper());
+            Assert.Multiple(() =>
+            {
+                Assert.That("optikey".FirstCharToUpper(), Is.EqualTo("Optikey"));
+                Assert.That("Optikey".FirstCharToUpper(), Is.EqualTo("Optikey"));
+                Assert.That("OptiKey".FirstCharToUpper(), Is.EqualTo("OptiKey"));
+                Assert.That("sam Was Here".FirstCharToUpper(), Is.EqualTo("Sam Was Here"));
+                Assert.That("%$%@$#%#@#$&^%$&#$".FirstCharToUpper(), Is.EqualTo("%$%@$#%#@#$&^%$&#$"));
+                Assert.That("  ".FirstCharToUpper(), Is.EqualTo("  "));
+                Assert.That(NullString.FirstCharToUpper(), Is.Null);
+            });            
         }
 
         [Test]
         public void TestConvertEscapedCharToLiteral()
         {
-            Assert.AreEqual(@"[Char:\0|Unicode:U+0000]", '\0'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\a|Unicode:U+0007]", '\a'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\b|Unicode:U+0008]", '\b'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\t|Unicode:U+0009]", '\t'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\f|Unicode:U+000c]", '\f'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\n|Unicode:U+000a]", '\n'.ToPrintableString());
-            Assert.AreEqual(@"[Char:\r|Unicode:U+000d]", '\r'.ToPrintableString());
-            Assert.AreEqual(@"[Char:s|Unicode:U+0073]", 's'.ToPrintableString());
-            Assert.AreEqual(@"[Char: |Unicode:U+0020]", ' '.ToPrintableString());
-            Assert.AreEqual(null, NullString.ToPrintableString());
+            Assert.Multiple(() =>
+            {
+                Assert.That('\0'.ToPrintableString(), Is.EqualTo(@"[Char:\0|Unicode:U+0000]"));
+                Assert.That('\a'.ToPrintableString(), Is.EqualTo(@"[Char:\a|Unicode:U+0007]"));
+                Assert.That('\b'.ToPrintableString(), Is.EqualTo(@"[Char:\b|Unicode:U+0008]"));
+                Assert.That('\t'.ToPrintableString(), Is.EqualTo(@"[Char:\t|Unicode:U+0009]"));
+                Assert.That('\f'.ToPrintableString(), Is.EqualTo(@"[Char:\f|Unicode:U+000c]"));
+                Assert.That('\n'.ToPrintableString(), Is.EqualTo(@"[Char:\n|Unicode:U+000a]"));
+                Assert.That('\r'.ToPrintableString(), Is.EqualTo(@"[Char:\r|Unicode:U+000d]"));
+                Assert.That('s'.ToPrintableString(), Is.EqualTo(@"[Char:s|Unicode:U+0073]"));
+                Assert.That(' '.ToPrintableString(), Is.EqualTo(@"[Char: |Unicode:U+0020]"));
+                Assert.That(NullString.ToPrintableString(), Is.Null);
+            });            
         }
         
         [Test]
         public void TestNextCharacterWouldBeStartOfNewSentence()
         {
-            Assert.AreEqual(true, NullString.NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(true, "".NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(true, "This is a sentence. ".NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(true, "This is a sentence! ".NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(true, "This is a sentence? ".NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(true, "This is a sentence\n".NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(false, "This is a sentence where i forgot my punctuation ".NextCharacterWouldBeStartOfNewSentence());
-            Assert.AreEqual(false, "This is a sentence.".NextCharacterWouldBeStartOfNewSentence()); //Does not have trailing space
+            Assert.Multiple(() =>
+            {
+                Assert.That(NullString.NextCharacterWouldBeStartOfNewSentence(), Is.True);
+                Assert.That("".NextCharacterWouldBeStartOfNewSentence(), Is.True);
+                Assert.That("This is a sentence. ".NextCharacterWouldBeStartOfNewSentence(), Is.True);
+                Assert.That("This is a sentence! ".NextCharacterWouldBeStartOfNewSentence(), Is.True);
+                Assert.That("This is a sentence? ".NextCharacterWouldBeStartOfNewSentence(), Is.True);
+                Assert.That("This is a sentence\n".NextCharacterWouldBeStartOfNewSentence(), Is.True);
+                Assert.That("This is a sentence where i forgot my punctuation ".NextCharacterWouldBeStartOfNewSentence(), Is.False);
+                Assert.That("This is a sentence.".NextCharacterWouldBeStartOfNewSentence(), Is.False); //Does not have trailing space
+            });           
 
         }
         
@@ -56,36 +65,46 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
         public void TestInProgressWord()
         {
             var sentence = "This is a sentence.";
-            Assert.AreEqual(null, sentence.InProgressWord(0));
-            Assert.AreEqual("This", sentence.InProgressWord(1));
-            Assert.AreEqual("This", sentence.InProgressWord(2));
-            Assert.AreEqual("This", sentence.InProgressWord(3));
-            Assert.AreEqual("This", sentence.InProgressWord(4));
-            Assert.AreEqual(null, sentence.InProgressWord(5));
-            Assert.AreEqual("is", sentence.InProgressWord(6));
-            Assert.AreEqual("is", sentence.InProgressWord(7));
-            Assert.AreEqual(null, sentence.InProgressWord(8));
-            Assert.AreEqual("a", sentence.InProgressWord(9));
-            Assert.AreEqual(null, sentence.InProgressWord(10));
-            Assert.AreEqual("sentence.", sentence.InProgressWord(11));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sentence.InProgressWord(0), Is.Null);
+                Assert.That(sentence.InProgressWord(1), Is.EqualTo("This"));
+                Assert.That(sentence.InProgressWord(2), Is.EqualTo("This"));
+                Assert.That(sentence.InProgressWord(3), Is.EqualTo("This"));
+                Assert.That(sentence.InProgressWord(4), Is.EqualTo("This"));
+                Assert.That(sentence.InProgressWord(5), Is.Null);
+                Assert.That(sentence.InProgressWord(6), Is.EqualTo("is"));
+                Assert.That(sentence.InProgressWord(7), Is.EqualTo("is"));
+                Assert.That(sentence.InProgressWord(8), Is.Null);
+                Assert.That(sentence.InProgressWord(9), Is.EqualTo("a"));
+                Assert.That(sentence.InProgressWord(10), Is.Null);
+                Assert.That(sentence.InProgressWord(11), Is.EqualTo("sentence."));
+            });            
         }
 
         [Test]
         public void TestRemoveDiacritics()
         {
-            Assert.AreEqual("aAa", "aÀå".RemoveDiacritics());
-            Assert.AreEqual("CEISe", "ČĔĨŞē".RemoveDiacritics());
-            Assert.AreEqual("CEISe", "ČĔĨŞē".RemoveDiacritics(false));
+            Assert.Multiple(() =>
+            {
+                Assert.That("aÀå".RemoveDiacritics(), Is.EqualTo("aAa"));
+                Assert.That("ČĔĨŞē".RemoveDiacritics(), Is.EqualTo("CEISe"));
+                Assert.That("ČĔĨŞē".RemoveDiacritics(false), Is.EqualTo("CEISe"));
+            });            
            
         }
 
         [Test]
         public void TestLongestCommonSubsequence()
         {
-            Assert.AreEqual(19, "This is a sentence.".LongestCommonSubsequence("This is another sentence."));
-            Assert.AreEqual(7, "cat hat".LongestCommonSubsequence("cat in the hat"));
-            Assert.AreEqual(3, "cat".LongestCommonSubsequence("cat in the hat"));
-            Assert.AreEqual(0, "CAT".LongestCommonSubsequence("cat in the hat"));
+            Assert.Multiple(() =>
+            {
+                Assert.That("This is a sentence.".LongestCommonSubsequence("This is another sentence."), Is.EqualTo(19));
+                Assert.That("cat hat".LongestCommonSubsequence("cat in the hat"), Is.EqualTo(7));
+                Assert.That("cat".LongestCommonSubsequence("cat in the hat"), Is.EqualTo(3));
+                Assert.That("CAT".LongestCommonSubsequence("cat in the hat"), Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -104,11 +123,15 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
 
             var emptyStringCollection = new List<string>();
             List<string> nullStringCollection = null;
-            Assert.AreEqual("This,is,a,comma,seperated,list", stringCollection.ToString(""));
-            Assert.AreEqual("This,is,a,comma,seperated,list", stringCollection.ToString("Base string: "));
-            Assert.AreEqual("", emptyStringCollection.ToString("EMPTY"));
-            // ReSharper disable once ExpressionIsAlwaysNull
-            Assert.AreEqual("EMPTY", nullStringCollection.ToString("EMPTY"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(stringCollection.ToString(""), Is.EqualTo("This,is,a,comma,seperated,list"));
+                Assert.That(stringCollection.ToString("Base string: "), Is.EqualTo("This,is,a,comma,seperated,list"));
+                Assert.That(emptyStringCollection.ToString("EMPTY"), Is.EqualTo(""));
+                // ReSharper disable once ExpressionIsAlwaysNull
+                Assert.That(nullStringCollection.ToString("EMPTY"), Is.EqualTo("EMPTY"));
+            });            
         }
 
         [Test]
@@ -122,53 +145,65 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
                 "This is a sentence"
             };
 
-            Assert.AreEqual(null, "  ".ExtractWordsAndLines());
-            Assert.AreEqual(null, NullString.ExtractWordsAndLines());
+            Assert.Multiple(() =>
+            {
+                Assert.That("  ".ExtractWordsAndLines(), Is.Null);
+                Assert.That(NullString.ExtractWordsAndLines(), Is.Null);
+            });            
 
             var list = "This is a sentence".ExtractWordsAndLines();
-            Assert.AreEqual(4, list.Count);
-            CollectionAssert.AreEqual(finalList, list);
+            Assert.That(list.Count, Is.EqualTo(4));
+            Assert.That(list, Is.EqualTo(finalList));
 
             var list2 = "This is a sentence\nThis is a sentence".ExtractWordsAndLines();
-            Assert.AreEqual(4, list2.Count);
-            CollectionAssert.AreEqual(finalList, list2);
+            Assert.That(list2.Count, Is.EqualTo(4));
+            Assert.That(list2, Is.EqualTo(finalList));
         }
 
         [Test]
         public void TestCreateDictionaryEntryHash()
         {
-            Assert.AreEqual(null, "  ".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
-            Assert.AreEqual(null, NullString.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
-            Assert.AreEqual("ENTRYWITHSPACEATEND", "EntryWithSpaceAtEnd   ".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
-            Assert.AreEqual("CEISE", "ČĔĨŞē".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
-            Assert.AreEqual("THS", "This has spaces".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
-            Assert.AreEqual("THS", "This has spaces".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false));
-            Assert.AreEqual(null, "5Cats 6dogs 7Goats".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
-            Assert.AreEqual("OIAIWC", "Optikey is awesome. I want 2 copies".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases());
+            Assert.Multiple(() =>
+            {
+                Assert.That("  ".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.Null);
+                Assert.That(NullString.NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.Null);
+                Assert.That("EntryWithSpaceAtEnd   ".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.EqualTo("ENTRYWITHSPACEATEND"));
+                Assert.That("ČĔĨŞē".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.EqualTo("CEISE"));
+                Assert.That("This has spaces".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.EqualTo("THS"));
+                Assert.That("This has spaces".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(false), Is.EqualTo("THS"));
+                Assert.That("5Cats 6dogs 7Goats".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.Null);
+                Assert.That("Optikey is awesome. I want 2 copies".NormaliseAndRemoveRepeatingCharactersAndHandlePhrases(), Is.EqualTo("OIAIWC"));
+            });          
         }
         
         [Test]
         public void TestCreateAutoCompleteDictionaryEntryHash()
         {
-            Assert.AreEqual(null, "  ".Normalise());
-            Assert.AreEqual(null, NullString.Normalise());
-            Assert.AreEqual("ENTRYWITHSPACEATEND", "EntryWithSpaceAtEnd   ".Normalise());
-            Assert.AreEqual("CEISE", "ČĔĨŞē".Normalise());
-            Assert.AreEqual("THIS HAS SPACES", "This has spaces".Normalise());
-            Assert.AreEqual("THIS HAS SPACES", "This has spaces".Normalise(false));
-            Assert.AreEqual("5CATS 6DOGS 7GOATS", "5Cats 6dogs 7Goats".Normalise());
-            Assert.AreEqual("OPTIKEY IS AWESOME. I WANT 2 COPIES", "Optikey is awesome. I want 2 copies".Normalise());
+            Assert.Multiple(() =>
+            {
+                Assert.That("  ".Normalise(), Is.Null);
+                Assert.That(NullString.Normalise(), Is.Null);
+                Assert.That("EntryWithSpaceAtEnd   ".Normalise(), Is.EqualTo("ENTRYWITHSPACEATEND"));
+                Assert.That("ČĔĨŞē".Normalise(), Is.EqualTo("CEISE"));
+                Assert.That("This has spaces".Normalise(), Is.EqualTo("THIS HAS SPACES"));
+                Assert.That("This has spaces".Normalise(false), Is.EqualTo("THIS HAS SPACES"));
+                Assert.That("5Cats 6dogs 7Goats".Normalise(), Is.EqualTo("5CATS 6DOGS 7GOATS"));
+                Assert.That("Optikey is awesome. I want 2 copies".Normalise(), Is.EqualTo("OPTIKEY IS AWESOME. I WANT 2 COPIES"));
+            });            
         }
 
         [Test]
         public void TestCleanupPossibleDictionaryEntry()
         {
-            Assert.AreEqual(null, "  ".CleanupPossibleDictionaryEntry());
-            Assert.AreEqual(null, NullString.CleanupPossibleDictionaryEntry());
-            Assert.AreEqual("Word", "Word!".CleanupPossibleDictionaryEntry());
-            Assert.AreEqual("Cat", "Cat".CleanupPossibleDictionaryEntry());
-            Assert.AreEqual("This is a sentence", "This is a sentence".CleanupPossibleDictionaryEntry());
-            Assert.AreEqual("Čats", "Čats!".CleanupPossibleDictionaryEntry());
+            Assert.Multiple(() =>
+            {
+                Assert.That("  ".CleanupPossibleDictionaryEntry(), Is.Null);
+                Assert.That(NullString.CleanupPossibleDictionaryEntry(), Is.Null);
+                Assert.That("Word!".CleanupPossibleDictionaryEntry(), Is.EqualTo("Word"));
+                Assert.That("Cat".CleanupPossibleDictionaryEntry(), Is.EqualTo("Cat"));
+                Assert.That("This is a sentence".CleanupPossibleDictionaryEntry(), Is.EqualTo("This is a sentence"));
+                Assert.That("Čats!".CleanupPossibleDictionaryEntry(), Is.EqualTo("Čats"));
+            });            
         }
 
         [Test]
@@ -183,7 +218,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
             };
 
           var charListWithCounts = strings.ToCharListWithCounts();
-          Assert.AreEqual(charListWithCounts.Count,4);
+          Assert.That(4, Is.EqualTo(charListWithCounts.Count));
           AssertCharTuple(charListWithCounts[0], 'C', 'Č', 1);
           AssertCharTuple(charListWithCounts[1], 'W', 'W', 1);
           AssertCharTuple(charListWithCounts[2], 'T', 'T', 1);
@@ -193,9 +228,12 @@ namespace JuliusSweetland.OptiKey.UnitTests.Extensions
 
         private void AssertCharTuple(Tuple<char,char,int> tuple, char expectedItem1, char expectedItem2, int expectedItem3)
         {
-            Assert.AreEqual(expectedItem1, tuple.Item1);
-            Assert.AreEqual(expectedItem2, tuple.Item2);
-            Assert.AreEqual(expectedItem3, tuple.Item3);
+            Assert.Multiple(() =>
+            {
+                Assert.That(tuple.Item1, Is.EqualTo(expectedItem1));
+                Assert.That(tuple.Item2, Is.EqualTo(expectedItem2));
+                Assert.That(tuple.Item3, Is.EqualTo(expectedItem3));
+            });            
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/AutoComplete/AutoCompleteTestsBase.cs
@@ -29,7 +29,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
             var suggestions = autoComplete.GetSuggestions("t");
 
-            Assert.AreNotEqual("these", suggestions.First());
+            Assert.That(suggestions.First(), Is.Not.EqualTo("these"));
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
 
             var suggestions = autoComplete.GetSuggestions("z");
 
-            CollectionAssert.Contains(suggestions, "zoo");
+            Assert.That(suggestions, Contains.Item("zoo"));
         }
 
         [Test]
@@ -145,14 +145,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.AutoComplete
         {
             var suggestions = autoComplete.GetSuggestions(root);
 
-            CollectionAssert.IsEmpty(suggestions);
+            Assert.That(suggestions, Is.Empty);
         }
 
         private void TestGetSuggestions(string root, IEnumerable<string> expectedSuggestions)
         {
             var suggestions = autoComplete.GetSuggestions(root);
-
-            CollectionAssert.AreEqual(expectedSuggestions, suggestions);
+                        
+            Assert.That(suggestions, Is.EqualTo(expectedSuggestions));
         }
 
         #region Setup/Teardown

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/KeyboardOutputServiceTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/KeyboardOutputServiceTests.cs
@@ -39,7 +39,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services
             keyboardOutputService.ProcessFunctionKey(FunctionKeys.Suggestion2);
 
             //Assert
-            Assert.AreEqual(multiCodePointString, keyboardOutputService.Text);
+            Assert.That(keyboardOutputService.Text, Is.EqualTo(multiCodePointString));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services
             keyboardOutputService.ProcessFunctionKey(FunctionKeys.Suggestion1);
 
             //Assert
-            Assert.AreEqual(singleCodePointString, keyboardOutputService.Text);
+            Assert.That(keyboardOutputService.Text, Is.EqualTo(singleCodePointString));
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/Services/Translation/TranslationServiceTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/Services/Translation/TranslationServiceTests.cs
@@ -7,19 +7,19 @@ using System.Threading.Tasks;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Services.Translation;
 using JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifications;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;
+using NUnit.Framework;
 
 namespace JuliusSweetland.OptiKey.UnitTests.Services.Translation
 {
-    [TestClass]
+    [TestFixture]
     public class TranslationServiceTests : MainViewModelTestBase
     {
         /*
          * Tests the correct request is sent and mocked response is converted properly
          */
-        [TestMethod]
+        [Test]
         public async Task TestTranslateAsync()
         {
             base.BaseSetUp();
@@ -54,11 +54,15 @@ namespace JuliusSweetland.OptiKey.UnitTests.Services.Translation
             TranslationService.Response result = await subjectUnderTest.Translate("hello");
 
             // ASSERT
-            Assert.IsNotNull(result);
-            // Mocked Http response should be converted into the response struct within TranslationService
-            Assert.AreEqual("", result.ExceptionMessage);
-            Assert.AreEqual("Success", result.Status);
-            Assert.AreEqual("Hallo", result.TranslatedText);
+            Assert.That(result, Is.Not.Null);
+            // Mocked Http response should be converted into the response struct within TranslationService     
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExceptionMessage, Is.EqualTo(""));
+                Assert.That(result.Status, Is.EqualTo("Success"));
+                Assert.That(result.TranslatedText, Is.EqualTo("Hallo"));
+            });            
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri("https://translate.yandex.net/api/v1.5/tr.json/translate?" +

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/Models/KeyValueTest.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/Models/KeyValueTest.cs
@@ -23,8 +23,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.Models
             KeyValue valBreak2 = new KeyValue(FunctionKeys.Break);
             KeyValue valDelete = new KeyValue(FunctionKeys.Delete);
 
-            Assert.AreEqual(valBreak1, valBreak2);        
-            Assert.AreNotEqual(valBreak1, valDelete);
+            Assert.Multiple(() =>
+            {
+                Assert.That(valBreak1, Is.EqualTo(valBreak2));
+                Assert.That(valBreak1, Is.Not.EqualTo(valDelete));
+            });            
         }
 
         [Test]
@@ -35,8 +38,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.Models
 
             KeyValue valGoodbye = new KeyValue("Goodbye");
 
-            Assert.AreEqual(valHello1, valHello2);
-            Assert.AreNotEqual(valHello1, valGoodbye);
+            Assert.Multiple(() =>
+            {
+                Assert.That(valHello1, Is.EqualTo(valHello2));
+                Assert.That(valHello1, Is.Not.EqualTo(valGoodbye));
+            });            
         }
 
         [Test]
@@ -48,10 +54,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.Models
             KeyValue valBreakGoodbye = new KeyValue(FunctionKeys.Break, "Goodbye");
             KeyValue valDeleteGoodbye = new KeyValue(FunctionKeys.Delete, "Goodbye");
 
-            Assert.AreEqual(valBreakHello1, valBreakHello2);
-            Assert.AreNotEqual(valBreakHello1, valBreakGoodbye);
-            Assert.AreNotEqual(valBreakGoodbye, valDeleteGoodbye);
-            Assert.AreNotEqual(valBreakHello1, valDeleteGoodbye);
+            Assert.Multiple(() =>
+            {
+                Assert.That(valBreakHello1, Is.EqualTo(valBreakHello2));
+                Assert.That(valBreakHello1, Is.Not.EqualTo(valBreakGoodbye));
+                Assert.That(valBreakGoodbye, Is.Not.EqualTo(valDeleteGoodbye));
+                Assert.That(valBreakHello1, Is.Not.EqualTo(valDeleteGoodbye));
+            });            
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/Utilities/DrawingUtilsTests.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/Utilities/DrawingUtilsTests.cs
@@ -10,9 +10,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.Utilities
         private static void AssertHsl2RbgColor(double h, double s, double l, int expectedR, int expectedG, int expectedB)
         {
             var color = DrawingUtils.HSL2RGB(h, s, l);
-            Assert.AreEqual(expectedR, color.R, "Expected R + " + expectedR + " but was " + color.R);
-            Assert.AreEqual(expectedG, color.G, "Expected G: " + expectedG + " but was " + color.G);
-            Assert.AreEqual(expectedB, color.B, "Expected B: " + expectedB + " but was " + color.B);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(color.R, Is.EqualTo(expectedR), "Expected R + " + expectedR + " but was " + color.R);
+                Assert.That(color.G, Is.EqualTo(expectedG), "Expected G: " + expectedG + " but was " + color.G);
+                Assert.That(color.B, Is.EqualTo(expectedB), "Expected B: " + expectedB + " but was " + color.B);
+            });
         }
 
         [Test]

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
@@ -42,17 +42,21 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
             InputService.Verify(s => s.RequestSuspend(), Times.Once());
             AudioService.Verify(s => s.PlaySound(Settings.Default.ErrorSoundFile, Settings.Default.ErrorSoundVolume), Times.Once());
 
-            Assert.IsNotNull(NotificationEvent);
-            Assert.AreEqual(Resources.CRASH_TITLE, NotificationEvent.Title);
-            Assert.AreEqual(ex.Message, NotificationEvent.Content);
-            Assert.AreEqual(NotificationTypes.Error, NotificationEvent.NotificationType);
+            Assert.That(NotificationEvent, Is.Not.Null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(NotificationEvent.Title, Is.EqualTo(Resources.CRASH_TITLE));
+                Assert.That(NotificationEvent.Content, Is.EqualTo(ex.Message));
+                Assert.That(NotificationEvent.NotificationType, Is.EqualTo(NotificationTypes.Error));
+            });            
         }
 
         [Test]
         public void ThenPointsPerSecondEventHandlerShouldBeAttachedToInputService()
         {
             InputService.Raise(s => s.PointsPerSecond += null, this, 123);
-            Assert.AreEqual(123, MainViewModel.PointsPerSecond);
+            Assert.That(MainViewModel.PointsPerSecond, Is.EqualTo(123));
         }
 
         [Test]
@@ -88,8 +92,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
             var keyValue = new KeyValue();
             InputService.Raise(s => s.CurrentPosition += null, this, new Tuple<Point, KeyValue>(point, keyValue));
 
-            Assert.AreEqual(point, MainViewModel.CurrentPositionPoint);
-            Assert.AreEqual(keyValue, MainViewModel.CurrentPositionKey);
+            Assert.Multiple(() =>
+            {
+                Assert.That(MainViewModel.CurrentPositionPoint, Is.EqualTo(point));
+                Assert.That(MainViewModel.CurrentPositionKey, Is.EqualTo(keyValue));
+            });            
 
             MouseOutputService.Verify(s => s.MoveTo(point), Times.Once());
         }
@@ -114,8 +121,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
             var keyValue = new KeyValue();
             InputService.Raise(s => s.CurrentPosition += null, this, new Tuple<Point, KeyValue>(point, keyValue));
 
-            Assert.AreEqual(point, MainViewModel.CurrentPositionPoint);
-            Assert.AreEqual(keyValue, MainViewModel.CurrentPositionKey);
+            Assert.Multiple(() =>
+            {
+                Assert.That(MainViewModel.CurrentPositionPoint, Is.EqualTo(point));
+                Assert.That(MainViewModel.CurrentPositionKey, Is.EqualTo(keyValue));
+            });            
 
             MouseOutputService.Verify(s => s.MoveTo(point), Times.Never());
         }
@@ -142,11 +152,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
             InputService.Raise(s => s.SelectionProgress += null, this, new Tuple<PointAndKeyValue, double>(null, 0));
 
-            Assert.IsNull(MainViewModel.PointSelectionProgress);
+            Assert.That(MainViewModel.PointSelectionProgress, Is.Null);
 
             KeySelectionProgress.Keys
                 .ToList()
-                .ForEach(k => Assert.AreEqual(default(double), KeySelectionProgress[k].Value));
+                .ForEach(k => Assert.That(KeySelectionProgress[k].Value, Is.EqualTo(default(double))));
         }
     }
 
@@ -175,7 +185,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
             InputService.Raise(s => s.SelectionProgress += null, this, new Tuple<PointAndKeyValue, double>(
                 new PointAndKeyValue(new Point(), KeyValueToAssert), 14));
 
-            Assert.AreEqual(14, KeySelectionProgress[KeyValueToAssert].Value);
+            Assert.That(KeySelectionProgress[KeyValueToAssert].Value, Is.EqualTo(14));
         }
     }
 
@@ -197,9 +207,13 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
             InputService.Raise(s => s.SelectionProgress += null, this, new Tuple<PointAndKeyValue, double>(
                 pointAndKeyValue, 83));
 
-            Assert.IsNotNull(MainViewModel.PointSelectionProgress);
-            Assert.AreEqual(pointAndKeyValue.Point, MainViewModel.PointSelectionProgress.Item1);
-            Assert.AreEqual(83, MainViewModel.PointSelectionProgress.Item2);
+            Assert.That(MainViewModel.PointSelectionProgress, Is.Not.Null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(MainViewModel.PointSelectionProgress.Item1, Is.EqualTo(pointAndKeyValue.Point));
+                Assert.That(MainViewModel.PointSelectionProgress.Item2, Is.EqualTo(83));
+            });            
         }
     }
 
@@ -223,11 +237,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
             InputService.Raise(s => s.Selection += null, this, pointAndKeyValue);
 
-            Assert.IsNull(MainViewModel.SelectionResultPoints);
+            Assert.That(MainViewModel.SelectionResultPoints, Is.Null);
 
             AudioService.Verify(s => s.PlaySound(Settings.Default.KeySelectionSoundFile, Settings.Default.KeySelectionSoundVolume));
 
-            Assert.IsTrue(IsKeySelectionEventHandlerCalled);
+            Assert.That(IsKeySelectionEventHandlerCalled, Is.True);
         }
     }
 
@@ -248,9 +262,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
             InputService.Raise(s => s.Selection += null, this, pointAndKeyValue);
 
-            Assert.IsNull(MainViewModel.SelectionResultPoints);
-
-            Assert.IsTrue(IsPointSelectionEventHandlerCalled);
+            Assert.Multiple(() =>
+            {
+                Assert.That(MainViewModel.SelectionResultPoints, Is.Null);
+                Assert.That(IsPointSelectionEventHandlerCalled, Is.True);
+            });            
         }
     }
 
@@ -266,7 +282,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
             InputService.Raise(s => s.SelectionResult += null, this, selection);
 
-            Assert.AreEqual(points, MainViewModel.SelectionResultPoints);
+            Assert.That(MainViewModel.SelectionResultPoints, Is.EqualTo(points));
 
             KeyboardOutputService.Verify(s => s.ProcessSingleKeyText("SingleKeyValueIsString"), Times.Once());
         }
@@ -280,7 +296,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
             InputService.Raise(s => s.SelectionResult += null, this, selection);
 
-            Assert.AreEqual(points, MainViewModel.SelectionResultPoints);
+            Assert.That(MainViewModel.SelectionResultPoints, Is.EqualTo(points));
 
             KeyStateService.Verify(s => s.ProgressKeyDownState(It.IsAny<KeyValue>()), Times.Once());
 
@@ -299,7 +315,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
             InputService.Raise(s => s.SelectionResult += null, this, selection);
 
-            Assert.AreEqual(points, MainViewModel.SelectionResultPoints);
+            Assert.That(MainViewModel.SelectionResultPoints, Is.EqualTo(points));
 
             KeyboardOutputService.Verify(s => s.ProcessMultiKeyTextAndSuggestions(multiKeySelection), Times.Once());
         }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenConstruct.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenConstruct.cs
@@ -20,9 +20,9 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
 
         protected override void Act()
         {
-            MainViewModel = new MainViewModel(AudioService.Object, CalibrationService.Object, DictionaryService.Object, 
-                KeyStateService.Object, SuggestionService.Object, CapturingStateManager.Object, LastMouseActionStateManager.Object, 
-                InputService.Object, KeyboardOutputService.Object, MouseOutputService.Object, MainWindowManipulationService.Object, 
+            MainViewModel = new MainViewModel(AudioService.Object, CalibrationService.Object, DictionaryService.Object,
+                KeyStateService.Object, SuggestionService.Object, CapturingStateManager.Object, LastMouseActionStateManager.Object,
+                InputService.Object, KeyboardOutputService.Object, MouseOutputService.Object, MainWindowManipulationService.Object,
                 ErrorNotifyingServices);
         }
 
@@ -68,8 +68,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeAlpha()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Alpha1), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Alpha1)));
         }
 
         [Test]
@@ -98,11 +98,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeConversationAlphaWithA_BackAction()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.ConversationAlpha1), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.ConversationAlpha1)));
 
             var conversationAlpha = MainViewModel.Keyboard as OptiKey.UI.ViewModels.Keyboards.ConversationAlpha1;
-            Assert.AreEqual(typeof(Action), conversationAlpha.BackAction.GetType());
+            Assert.That(conversationAlpha.BackAction.GetType(), Is.EqualTo(typeof(Action)));
         }
 
         [Test]
@@ -125,11 +125,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeConversationNumericAndSymbolsWithA_BackAction()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.ConversationNumericAndSymbols), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.ConversationNumericAndSymbols)));
 
             var conversationAlpha = MainViewModel.Keyboard as OptiKey.UI.ViewModels.Keyboards.ConversationNumericAndSymbols;
-            Assert.AreEqual(typeof(Action), conversationAlpha.BackAction.GetType());
+            Assert.That(conversationAlpha.BackAction.GetType(), Is.EqualTo(typeof(Action)));
         }
 
         [Test]
@@ -152,8 +152,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeCurrencies1()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Currencies1), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Currencies1)));
         }
 
         [Test]
@@ -182,8 +182,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeCurrencies2()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Currencies2), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Currencies2)));
         }
 
         [Test]
@@ -212,8 +212,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeDiacritics1()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Diacritics1), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Diacritics1)));
         }
 
         [Test]
@@ -242,8 +242,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeDiacritics1()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Diacritics2), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Diacritics2)));
         }
 
         [Test]
@@ -272,8 +272,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeDiacritics1()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Diacritics3), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Diacritics3)));
         }
 
         [Test]
@@ -302,8 +302,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeMenu()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Menu), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Menu)));
         }
 
         [Test]
@@ -332,11 +332,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeMinimisedWithA_BackAction()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Minimised), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Minimised)));
 
             var alpha = MainViewModel.Keyboard as OptiKey.UI.ViewModels.Keyboards.Minimised;
-            Assert.AreEqual(typeof(Action), alpha.BackAction.GetType());
+            Assert.That(alpha.BackAction.GetType(), Is.EqualTo(typeof(Action)));
         }
 
         [Test]
@@ -360,11 +360,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeMouseWithA_BackAction()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Mouse), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Mouse)));
 
             var alpha = MainViewModel.Keyboard as OptiKey.UI.ViewModels.Keyboards.Mouse;
-            Assert.AreEqual(typeof(Action), alpha.BackAction.GetType());
+            Assert.That(alpha.BackAction.GetType(), Is.EqualTo(typeof(Action)));
         }
 
         [Test]
@@ -394,11 +394,11 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeMouseWithA_BackAction()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.Mouse), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.Mouse)));
 
             var alpha = MainViewModel.Keyboard as OptiKey.UI.ViewModels.Keyboards.Mouse;
-            Assert.AreEqual(typeof(Action), alpha.BackAction.GetType());
+            Assert.That(alpha.BackAction.GetType(), Is.EqualTo(typeof(Action)));
         }
 
         [Test]
@@ -427,8 +427,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeNumericAndSymbols1()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.NumericAndSymbols1), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.NumericAndSymbols1)));
         }
 
         [Test]
@@ -457,8 +457,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeNumericAndSymbols2()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.NumericAndSymbols2), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.NumericAndSymbols2)));
         }
 
         [Test]
@@ -487,8 +487,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeNumericAndSymbols3()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.NumericAndSymbols3), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.NumericAndSymbols3)));
         }
 
         [Test]
@@ -517,8 +517,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBePhysicalKeys()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.PhysicalKeys), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.PhysicalKeys)));
         }
 
         [Test]
@@ -547,8 +547,8 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeyboardShouldBeSizeAndPosition()
         {
-            Assert.IsNotNull(MainViewModel.Keyboard);
-            Assert.AreEqual(typeof(OptiKey.UI.ViewModels.Keyboards.SizeAndPosition), MainViewModel.Keyboard.GetType());
+            Assert.That(MainViewModel.Keyboard, Is.Not.Null);
+            Assert.That(MainViewModel.Keyboard.GetType(), Is.EqualTo(typeof(OptiKey.UI.ViewModels.Keyboards.SizeAndPosition)));
         }
 
         [Test]

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenFireKeySelectionEvent.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenFireKeySelectionEvent.cs
@@ -18,7 +18,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenKeySelectionEventHandlerShouldBeTriggered()
         {
-            Assert.IsTrue(IsKeySelectionEventHandlerCalled);
+            Assert.That(IsKeySelectionEventHandlerCalled, Is.True);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenPointToKeyValueMap.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenPointToKeyValueMap.cs
@@ -48,7 +48,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenSelectionResultPointsShouldNotBeReset()
         {
-            Assert.IsNotNull(MainViewModel.SelectionResultPoints);
+            Assert.That(MainViewModel.SelectionResultPoints, Is.Not.Null);
         }
     }
 
@@ -70,7 +70,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenSelectionResultPointsShouldBeReset()
         {
-            Assert.IsNull(MainViewModel.SelectionResultPoints);
+            Assert.That(MainViewModel.SelectionResultPoints, Is.Null);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenRaiseToastNotification.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenRaiseToastNotification.cs
@@ -29,7 +29,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenToastNotificationEventHandlerShouldBeTriggered()
         {
-            Assert.IsTrue(IsToastNotificationEventHandlerCalled);
+            Assert.That(IsToastNotificationEventHandlerCalled, Is.True);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenSelectionMode.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenSelectionMode.cs
@@ -55,7 +55,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.MainViewModelSpecifica
         [Test]
         public void ThenSelectionProgressShouldBeReset()
         {
-            Assert.IsNull(MainViewModel.PointSelectionProgress);
+            Assert.That(MainViewModel.PointSelectionProgress, Is.Null);
             KeyStateService.VerifyGet(s => s.KeySelectionProgress, Times.Once());
         }
 

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/Management/DictionaryViewModelSpecifications/WhenConstruct.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/Management/DictionaryViewModelSpecifications/WhenConstruct.cs
@@ -37,17 +37,20 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.Management.DictionaryV
         [Test]
         public void ThenCommandsShouldBeConstructed()
         {
-            Assert.IsNotNull(DictionaryViewModel.AddCommand);
-            Assert.IsNotNull(DictionaryViewModel.ToggleDeleteCommand);
-            Assert.IsNotNull(DictionaryViewModel.LoadCommand);
+            Assert.Multiple(() =>
+            {
+                Assert.That(DictionaryViewModel.AddCommand, Is.Not.Null);
+                Assert.That(DictionaryViewModel.ToggleDeleteCommand, Is.Not.Null);
+                Assert.That(DictionaryViewModel.LoadCommand, Is.Not.Null);
+            });            
         }
 
         [Test]
         public void ThenEntriesShouldBeLoaded()
         {
             DictionaryViewModel.Load();
-            Assert.IsNotNull(DictionaryViewModel.Entries);
-            Assert.AreEqual(DictionaryEntries.Count, DictionaryViewModel.Entries.Count);
+            Assert.That(DictionaryViewModel.Entries, Is.Not.Null);
+            Assert.That(DictionaryViewModel.Entries.Count, Is.EqualTo(DictionaryEntries.Count));
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenCancelCommand.cs
@@ -53,9 +53,12 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         [Test]
         public void ThenWindowShouldBeClosedWithoutSaving()
         {
-            Assert.IsTrue(IsWindowClosed);
-            Assert.AreEqual(Settings.Default.CommuniKatePagesetLocation, defaultCommuniKatePagesetLocation);
-            Assert.AreEqual(Settings.Default.MaryTTSLocation, defaultMaryTTSLocation);
+            Assert.Multiple(() =>
+            {
+                Assert.That(IsWindowClosed, Is.True);
+                Assert.That(defaultCommuniKatePagesetLocation, Is.EqualTo(Settings.Default.CommuniKatePagesetLocation));
+                Assert.That(defaultMaryTTSLocation, Is.EqualTo(Settings.Default.MaryTTSLocation));
+            });            
         }
     }    
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenChangesRequireRestart.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenChangesRequireRestart.cs
@@ -22,14 +22,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         public void GivenOtherViewModelRequiresRestart()
         {
             Settings.Default.Debug = true;
-            Assert.IsTrue(ManagementViewModel.ChangesRequireRestart);
+            Assert.That(ManagementViewModel.ChangesRequireRestart, Is.True);
         }
 
         [Test]
         public void GivenPointingAndSelectingViewModelRequiresRestart()
         {
             Settings.Default.MultiKeySelectionMaxDuration = TimeSpan.FromSeconds(42);
-            Assert.IsTrue(ManagementViewModel.ChangesRequireRestart);
+            Assert.That(ManagementViewModel.ChangesRequireRestart, Is.True);
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         {
             ManagementViewModel.VisualsViewModel.ConversationOnlyMode = false;
             Settings.Default.ConversationOnlyMode = true;
-            Assert.IsTrue(ManagementViewModel.ChangesRequireRestart);
+            Assert.That(ManagementViewModel.ChangesRequireRestart, Is.True);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenConstruct.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenConstruct.cs
@@ -23,20 +23,26 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         [Test]
         public void ThenChildViewModelShouldBeConstructed()
         {
-            Assert.IsNotNull(ManagementViewModel.DictionaryViewModel);
-            Assert.IsNotNull(ManagementViewModel.OtherViewModel);
-            Assert.IsNotNull(ManagementViewModel.PointingAndSelectingViewModel);
-            Assert.IsNotNull(ManagementViewModel.SoundsViewModel);
-            Assert.IsNotNull(ManagementViewModel.VisualsViewModel);
-            Assert.IsNotNull(ManagementViewModel.WordsViewModel);
+            Assert.Multiple(() => 
+            { 
+                Assert.That(ManagementViewModel.DictionaryViewModel, Is.Not.Null); 
+                Assert.That(ManagementViewModel.OtherViewModel, Is.Not.Null); 
+                Assert.That(ManagementViewModel.PointingAndSelectingViewModel, Is.Not.Null); 
+                Assert.That(ManagementViewModel.SoundsViewModel, Is.Not.Null); 
+                Assert.That(ManagementViewModel.VisualsViewModel, Is.Not.Null); 
+                Assert.That(ManagementViewModel.WordsViewModel, Is.Not.Null); 
+            });
         }
 
         [Test]
         public void ThenInteractionRequestsAndCommandsShouldBeConstructed()
         {
-            Assert.IsNotNull(ManagementViewModel.ConfirmationRequest);
-            Assert.IsNotNull(ManagementViewModel.OkCommand);
-            Assert.IsNotNull(ManagementViewModel.CancelCommand);
+            Assert.Multiple(() => 
+            {
+                Assert.That(ManagementViewModel.ConfirmationRequest, Is.Not.Null); 
+                Assert.That(ManagementViewModel.OkCommand, Is.Not.Null);
+                Assert.That(ManagementViewModel.CancelCommand, Is.Not.Null);
+            });
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenOkCommand.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/ManagementViewModelSpecifications/WhenOkCommand.cs
@@ -57,11 +57,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         [Test]
         public void ThenWindowShouldNotBeClosedOrSaved()
         {
-            Assert.IsFalse(IsWindowClosed);
+            Assert.Multiple(() =>
+            {
+                Assert.That(IsWindowClosed, Is.False);
 
-            // settings still use default values -- not closed
-            Assert.AreEqual(Settings.Default.CommuniKatePagesetLocation, defaultCommuniKatePagesetLocation);
-            Assert.AreEqual(Settings.Default.MaryTTSLocation, defaultMaryTTSLocation);
+                // settings still use default values -- not closed
+                Assert.That(defaultCommuniKatePagesetLocation, Is.EqualTo(Settings.Default.CommuniKatePagesetLocation));
+                Assert.That(defaultMaryTTSLocation, Is.EqualTo(Settings.Default.MaryTTSLocation));
+            });            
         }
     }
 
@@ -79,11 +82,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         [Test]
         public void ThenWindowShouldBeClosedWithNoChanges()
         {
-            Assert.IsTrue(IsWindowClosed);
+            Assert.Multiple(() =>
+            {
+                Assert.That(IsWindowClosed, Is.True);
 
-            // settings still use default values -- no changes made
-            Assert.AreEqual(Settings.Default.CommuniKatePagesetLocation, defaultCommuniKatePagesetLocation);
-            Assert.AreEqual(Settings.Default.MaryTTSLocation, defaultMaryTTSLocation);
+                // settings still use default values -- no changes made
+                Assert.That(defaultCommuniKatePagesetLocation, Is.EqualTo(Settings.Default.CommuniKatePagesetLocation));
+                Assert.That(defaultMaryTTSLocation, Is.EqualTo(Settings.Default.MaryTTSLocation));
+            });            
         }
     }
 
@@ -103,11 +109,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         [Test]
         public void ThenWindowShouldBeClosedWithNoCoreChanges()
         {
-            Assert.IsTrue(IsWindowClosed);
+            Assert.Multiple(() =>
+            {
+                Assert.That(IsWindowClosed, Is.True);
 
-            // core settings not being changed updated -- still use default values
-            Assert.AreEqual(Settings.Default.CommuniKatePagesetLocation, defaultCommuniKatePagesetLocation);
-            Assert.AreEqual(Settings.Default.MaryTTSLocation, defaultMaryTTSLocation);
+                // core settings not being changed updated -- still use default values
+                Assert.That(defaultCommuniKatePagesetLocation, Is.EqualTo(Settings.Default.CommuniKatePagesetLocation));
+                Assert.That(defaultMaryTTSLocation, Is.EqualTo(Settings.Default.MaryTTSLocation));
+            });            
         }
     }
 
@@ -127,11 +136,14 @@ namespace JuliusSweetland.OptiKey.UnitTests.UI.ViewModels.ManagementViewModelSpe
         [Test]
         public void ThenWindowShouldRestartAndSaved()
         {
-            Assert.IsFalse(IsWindowClosed);
+            Assert.Multiple(() =>
+            {
+                Assert.That(IsWindowClosed, Is.False);
 
-            // settings being updated -- using new values
-            Assert.AreEqual(Settings.Default.CommuniKatePagesetLocation, "new location");
-            Assert.AreEqual(Settings.Default.MaryTTSLocation, "new location");
+                // settings being updated -- using new values
+                Assert.That("new location", Is.EqualTo(Settings.Default.CommuniKatePagesetLocation));
+                Assert.That("new location", Is.EqualTo(Settings.Default.MaryTTSLocation));
+            });            
         }
     }
 }


### PR DESCRIPTION
In NUnit 3.x, assertions are primarily written using constraint-based Assert model. (see https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html). There is no functional difference between the classic and constraint-based model. The new way improves readability of tests and makes it clear what is the actual value and what the expected value should be.

In addition, NUnit has the concept of multiple asserts. (see https://docs.nunit.org/articles/nunit/writing-tests/assertions/multiple-asserts.html). Usually when an assert fails, the test terminates. Most of the tests in this solution do not depend on the passing of the previous test(s). As a result, the Assert.Multiple allows us to execute all tests within the block and collect all failures within a method so they may all be fixed at once.