### PR TITLE
Fix bug in toast handing

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/ToastNotificationPopup.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/ToastNotificationPopup.cs
@@ -75,19 +75,19 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
             Action closePopup = () =>
             {
-                    args.Callback?.Invoke();
-                    messageQueue.Dequeue();    // message is done, remove from the queue
+                args.Callback?.Invoke();
+                messageQueue.Dequeue();    // message is done, remove from the queue
 
-                    if (messageQueue.Count > 0)
-                    {
-                        // raise next message
-                        RaiseNotificationChain();
-                    }
-                    else
-                    {
-                        // all messages are displayed, we're done and lower the popup
-                        this.IsOpen = false;
-                    }
+                if (messageQueue.Count > 0)
+                {
+                    // raise next message
+                    RaiseNotificationChain();
+                }
+                else
+                {
+                    // all messages are displayed, we're done and lower the popup
+                    this.IsOpen = false;
+                }
             };
 
             AnimateTarget(args.Content, toastNotification, closePopup);

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/ToastNotificationPopup.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/ToastNotificationPopup.cs
@@ -75,8 +75,6 @@ namespace JuliusSweetland.OptiKey.UI.Controls
 
             Action closePopup = () =>
             {
-                if (this.IsOpen)
-                {
                     args.Callback?.Invoke();
                     messageQueue.Dequeue();    // message is done, remove from the queue
 
@@ -90,7 +88,6 @@ namespace JuliusSweetland.OptiKey.UI.Controls
                         // all messages are displayed, we're done and lower the popup
                         this.IsOpen = false;
                     }
-                }
             };
 
             AnimateTarget(args.Content, toastNotification, closePopup);

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
@@ -653,11 +653,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         public bool RaiseToastNotification(string title, string content, NotificationTypes notificationType, Action callback)
         {
             bool notificationRaised = false;
-
-            // Disabling resize handles temporarily prevents mouse capture by the non-client area around the main keyboard
-            this.mainWindowManipulationService.DisableResize();
-            callback += () => this.mainWindowManipulationService.SetResizeState();
-
+            
             if (ToastNotification != null)
             {
                 ToastNotification(this, new NotificationEventArgs(title, content, notificationType, callback));


### PR DESCRIPTION
The original manifestation of this bug was as follows:

**TL;DR:** If a toast is requested at the same time as loading dynamic keyboard, the toast isn't visible and the input source stops working

**Steps to reproduce:**
- Load dynamic keyboard with `AddToDictionary` function key
- Use `AddToDictionary` key to add a new word to the dictionary
- You are presented with a confirmation YesNo keyboard
- Select Yes

**Expected behaviour:**
- A toast _should_ appear saying you've successfully added the word

**Actual behaviour:** 
- No toast appears, but the eye tracker (or other input source) stops working
- No more toasts appear 

**Explanation + history of fix:**
- When I added mouse resize/reposition functionality, this added a non-client area around the app which is grabbable
- When a toast was up and you clicked this non-client area (basically, the border of the keyboard) the toast was automatically dismissed (presumably due to some low-level default Toast behaviour)
- When the toast was dismissed, it left the input source paused since it wasn't calling the toast's callback for cleanup
- I didn't fully understand the bug so worked around it by not allowing resizing while a toast was visible. This "solved" the issue in all the situations I could find
- HOWEVER when loading a dynamic keyboard the resizeability is set again, and for some reason the act of setting it at this precise moment dismisses the toast, leading to the original problem. 
- The real original issue is that if a toast is dismissed before its natural end time, for any reason, the cleanup callback was not being called and the queue of toast notifications was left backing up

This PR undoes my band-aid fix and fixes the real problem
