### PR TITLE
Add setting to ignore warning

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
@@ -7073,6 +7073,17 @@ namespace JuliusSweetland.OptiKey.Properties
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Suppress warning...
+        /// </summary>
+        public static string SUPPRESS_TRIGGER_WARNING
+        {
+            get
+            {
+                return ResourceManager.GetString("SUPPRESS_TRIGGER_WARNING", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to TAB.
         /// </summary>
         public static string TAB

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -2433,5 +2433,8 @@ Magyar
   </data>
   <data name="GAZE_INDICATOR_STYLE" xml:space="preserve">
     <value>Gaze Indicator Style</value>
+  </data>  
+  <data name="SUPPRESS_TRIGGER_WARNING" xml:space="preserve">
+    <value>Suppress warning when gaze is missing during trigger event</value>
   </data>
 </root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
@@ -2621,6 +2621,22 @@ namespace JuliusSweetland.OptiKey.Properties {
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool SuppressTriggerWithoutPositionError
+        {
+            get
+            {
+                return ((bool)(this["SuppressTriggerWithoutPositionError"]));
+            }
+            set
+            {
+                this["SuppressTriggerWithoutPositionError"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public virtual bool AllowMultipleInstances
         {
             get

--- a/src/JuliusSweetland.OptiKey.Core/Services/InputService.subscriptions.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/InputService.subscriptions.cs
@@ -226,7 +226,10 @@ namespace JuliusSweetland.OptiKey.Services
                             + "Discarding trigger as point source is down, or producing stale points. "
                             + "Publishing error instead.");
 
-                    PublishError(this, new ApplicationException(Resources.TRIGGER_WITHOUT_POSITION_ERROR));
+                    if (!Settings.Default.SuppressTriggerWithoutPositionError)
+                    {
+                        PublishError(this, new ApplicationException(Resources.TRIGGER_WITHOUT_POSITION_ERROR));
+                    }
                 }
             }
             else if (CapturingMultiKeySelection)

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/FeaturesViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/FeaturesViewModel.cs
@@ -190,6 +190,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref publishVirtualKeyCodesForCharacters, value); }
         }
 
+        private bool suppressTriggerWarning;
+        public bool SuppressTriggerWarning
+        {
+            get { return suppressTriggerWarning; }
+            set { SetProperty(ref suppressTriggerWarning, value); }
+        }
+
         private bool suppressModifierKeysForAllMouseActions;
         public bool SuppressModifierKeysForAllMouseActions
         {
@@ -448,6 +455,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             PublishVirtualKeyCodesForCharacters = Settings.Default.PublishVirtualKeyCodesForCharacters;
             SuppressModifierKeysForAllMouseActions = Settings.Default.SuppressModifierKeysForAllMouseActions;
             SuppressModifierKeysWhenInMouseKeyboard = Settings.Default.SuppressModifierKeysWhenInMouseKeyboard;
+            SuppressTriggerWarning = Settings.Default.SuppressTriggerWithoutPositionError;
             MagnifySuppressedForScrollingActions = Settings.Default.MagnifySuppressedForScrollingActions;
             Debug = Settings.Default.Debug;
             LookToScrollBounds = Settings.Default.LookToScrollBounds;
@@ -495,6 +503,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.PublishVirtualKeyCodesForCharacters = PublishVirtualKeyCodesForCharacters;
             Settings.Default.SuppressModifierKeysForAllMouseActions = SuppressModifierKeysForAllMouseActions;
             Settings.Default.SuppressModifierKeysWhenInMouseKeyboard = SuppressModifierKeysWhenInMouseKeyboard;
+            Settings.Default.SuppressTriggerWithoutPositionError = SuppressTriggerWarning;
             Settings.Default.MagnifySuppressedForScrollingActions = MagnifySuppressedForScrollingActions;
             Settings.Default.Debug = Debug;
             Settings.Default.LookToScrollBounds = LookToScrollBounds;

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/FeaturesView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/FeaturesView.xaml
@@ -191,9 +191,14 @@ Copyright (c) 2020 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                               VerticalAlignment="Center"
                               IsEnabled="{Binding Source='MagnifySuppressedForScrollingActions', Converter={StaticResource EnabledIfNotOverridden}}"
                               IsChecked="{Binding MagnifySuppressedForScrollingActions, Mode=TwoWay}" />
-          <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.DEBUGGING_MODE_LABEL}" 
-                               VerticalAlignment="Center" Margin="5" />
+          <TextBlock Grid.Row="16" Grid.Column="0" Text="{x:Static resx:Resources.SUPPRESS_TRIGGER_WARNING}" 
+                              VerticalAlignment="Center" Margin="5" />
           <CheckBox Grid.Row="16" Grid.Column="1" 
+                              VerticalAlignment="Center"
+                              IsChecked="{Binding SuppressTriggerWarning, Mode=TwoWay}" />
+          <TextBlock Grid.Row="17" Grid.Column="0" Text="{x:Static resx:Resources.DEBUGGING_MODE_LABEL}" 
+                               VerticalAlignment="Center" Margin="5" />
+          <CheckBox Grid.Row="17" Grid.Column="1" 
                               VerticalAlignment="Center"
                               IsChecked="{Binding Debug, Mode=TwoWay}" />
         </Grid>


### PR DESCRIPTION
Resolves #780 

This warning was triggered any time there was
instantaneously no gaze point when a trigger was
pressed, which happens fairly often, but the
warning is a significant imposition on user
workflows.