### PR TITLE
Fixes to plugin engine

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
@@ -37,7 +37,13 @@ namespace JuliusSweetland.OptiKey.Services.PluginEngine
                 List<Plugin> plugins = ValidateAndCreatePlugins(file);
                 foreach (Plugin plugin in plugins)
                 {
-                    availablePlugins.Add(plugin.Id, plugin);
+                    if (availablePlugins.ContainsKey(plugin.Id))
+                    {
+                        Log.ErrorFormat("Cannot load plugin ID: '{0}' from {1} due to duplicate name.", plugin.Id, pathName);
+                    }
+                    else { 
+                        availablePlugins.Add(plugin.Id, plugin);
+                    }
                 }
             }
         }

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
@@ -80,6 +80,11 @@ namespace JuliusSweetland.OptiKey.Services.PluginEngine
             plugin.Type.InvokeMember(key.Method, BindingFlags.InvokeMethod, null, plugin.Instance, methodArgs?.ToArray());
         }
 
+        public static bool IsPluginAvailable(string key)
+        {
+            return availablePlugins.ContainsKey(key);
+        }
+
         public static void RunDynamicPlugin(Dictionary<string, string> context, KeyCommand key)
         {
             Plugin plugin = availablePlugins[key.Value];

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
@@ -161,7 +161,7 @@ namespace JuliusSweetland.OptiKey.Services.PluginEngine
 
         private static bool FindMetadataResource(string resource)
         {
-            return resource.StartsWith("JuliusSweetland.OptiKey.") && resource.EndsWith("metadata.xml");
+            return resource.ToLower().StartsWith("juliussweetland.optikey.") && resource.EndsWith("metadata.xml");
         }
 
         private static string GetArgumentValue(Dictionary<String, String> context, string value)

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginEngine.cs
@@ -149,6 +149,10 @@ namespace JuliusSweetland.OptiKey.Services.PluginEngine
                         }
                     }
                 }
+                else
+                {
+                    Log.ErrorFormat("Error handling library: [{0}]. No manifest found.", file);                    
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
I wrote some plugins today, and in the process discovered that the standard plugins weren't loading because the `PluginEngine` was looking for the hardcoded namespace `JuliusSweetland.OptiKey.` but the plugin namespace had been renamed `JuliusSweetland.Optikey`. I've fixed this by making the check case-insensitive, and also added some more user-friendly error messages for common errors such as
- plugins are disabled but you are trying to run one
- a plugin's manifest file hasn't been found
- there is a naming collision between plugins
- the plugin method you are calling doesn't exist