### PR TITLE
Modify window style and behavior of overlays

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Native/Common/Enums/ExtendedWindowStyles.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Native/Common/Enums/ExtendedWindowStyles.cs
@@ -8,6 +8,7 @@ namespace JuliusSweetland.OptiKey.Native.Common.Enums
     {
         WS_EX_NOACTIVATE          = 0x08000000,
         WS_EX_TRANSPARENT         = 0x00000020,
+        WS_EX_TOOLWINDOW          = 0x00000080,
 
         // Other members omitted for brevity. The complete list can be found at:
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ff700543(v=vs.85).aspx

--- a/src/JuliusSweetland.OptiKey.Core/Static/Windows.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Static/Windows.cs
@@ -32,12 +32,6 @@ namespace JuliusSweetland.OptiKey.Static
             PInvoke.SetWindowLong(hWnd, (int)GWL.GWL_EXSTYLE, (int)exStyle);
         }
 
-        // Based on: https://stackoverflow.com/a/3367137/9091159
-        public static void SetWindowExTransparent(IntPtr hWnd)
-        {
-            SetExtendedWindowStyle(hWnd, GetExtendedWindowStyle(hWnd) | ExtendedWindowStyles.WS_EX_TRANSPARENT);
-        }
-
         public static List<IntPtr> GetHandlesOfTopLevelWindows()
         {
             var hWnds = new List<IntPtr>();

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/FeaturesViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/FeaturesViewModel.cs
@@ -379,7 +379,10 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             {
 
                 return (Settings.Default.Debug != Debug)
-                    || Settings.Default.CommuniKatePagesetLocation != CommuniKatePagesetLocation;
+                    || Settings.Default.CommuniKatePagesetLocation != CommuniKatePagesetLocation
+                    || (Settings.Default.LookToScrollOverlayBoundsThickness
+                        + Settings.Default.LookToScrollOverlayDeadzoneThickness == 0
+                        && LookToScrollOverlayBoundsThickness + LookToScrollOverlayDeadzoneThickness > 0);
             }
         }
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/VisualsViewModel.cs
@@ -587,7 +587,9 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
                 return Settings.Default.ConversationOnlyMode != ConversationOnlyMode
                     || Settings.Default.ConversationConfirmEnable != ConversationConfirmEnable
                     || Settings.Default.ConversationConfirmOnlyMode != ConversationConfirmOnlyMode
-                    || Settings.Default.EnableResizeWithMouse != EnableResizeWithMouse;
+                    || Settings.Default.EnableResizeWithMouse != EnableResizeWithMouse
+                    || (Settings.Default.GazeIndicatorStyle == GazeIndicatorStyles.None
+                        && (GazeIndicatorStyles)Enum.Parse(typeof(GazeIndicatorStyles), GazeIndicatorStyle) != GazeIndicatorStyles.None);
             }
         }
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/LookToScrollOverlayWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/LookToScrollOverlayWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Interop;
+using JuliusSweetland.OptiKey.Native.Common.Enums;
 using JuliusSweetland.OptiKey.UI.ViewModels;
 
 namespace JuliusSweetland.OptiKey.UI.Windows
@@ -23,15 +24,13 @@ namespace JuliusSweetland.OptiKey.UI.Windows
             DataContext = viewModel;
         }
 
-        // Based on: https://stackoverflow.com/a/3367137/9091159
         protected override void OnSourceInitialized(EventArgs e)
         {
             base.OnSourceInitialized(e);
 
-            // Apply the WS_EX_TRANSPARENT flag to the overlay window so that mouse events will
-            // pass through to any window underneath.
-            var hWnd = new WindowInteropHelper(this).Handle;
-            Static.Windows.SetWindowExTransparent(hWnd);
+            var windowHandle = new WindowInteropHelper(this).Handle;
+            Static.Windows.SetExtendedWindowStyle(windowHandle,
+                Static.Windows.GetExtendedWindowStyle(windowHandle) | ExtendedWindowStyles.WS_EX_TRANSPARENT | ExtendedWindowStyles.WS_EX_TOOLWINDOW);
         }
 
         private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/OverlayWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/OverlayWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace JuliusSweetland.OptiKey.UI.Windows
 
             var windowHandle = new WindowInteropHelper(this).Handle;
             Static.Windows.SetExtendedWindowStyle(windowHandle, 
-                Static.Windows.GetExtendedWindowStyle(windowHandle) | ExtendedWindowStyles.WS_EX_TRANSPARENT);
+                Static.Windows.GetExtendedWindowStyle(windowHandle) | ExtendedWindowStyles.WS_EX_TRANSPARENT | ExtendedWindowStyles.WS_EX_TOOLWINDOW);
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
@@ -191,7 +191,8 @@ namespace JuliusSweetland.OptiKey.Pro
                     new LookToScrollOverlayWindow(mainViewModel);
                 }
 
-                new OverlayWindow(mainViewModel);
+                if (Settings.Default.GazeIndicatorStyle != GazeIndicatorStyles.None)
+                    new OverlayWindow(mainViewModel);
 
                 //Display splash screen and check for updates (and display message) after the window has been sized and positioned for the 1st time
                 EventHandler sizeAndPositionInitialised = null;


### PR DESCRIPTION
@JuliusSweetland 
With these changes the overlays windows only load at application launch if enabled in setting, so if they are initially disabled they consume no resources, but in order to enable them (from MC) it will prompt you to restart the application. 

I also changed the extended window style to avoid them spawning in the alt-tab menu.

I'm running very smoothly now, even with them enabled. 