### PR TITLE
Feature/try get

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -245,9 +245,11 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
                                             {
                                                 t.Dispose();
                                             }
-                                                keystroke = (fixationCentrePointAndKeyValue.KeyValue.Equals(lastKeyValue)) ? keystroke + 1 : 1;
-                                                lastKeyValue = fixationCentrePointAndKeyValue.KeyValue;
-                                                fixationStart = latestPointAndKeyValue.Timestamp;
+
+                                            keystroke = (fixationCentrePointAndKeyValue.KeyValue.Equals(lastKeyValue)) ? keystroke + 1 : 1;
+                                            lastKeyValue = fixationCentrePointAndKeyValue.KeyValue;
+                                            fixationStart = latestPointAndKeyValue.Timestamp;
+
                                             //Temporary logic: if override times exist then we can presume that a dynamic keyboard with overrides is being user
                                             //The logic here would be to NOT require lock on again, hence why fixationCentrePointAndKeyValue is not cleared out.
                                             if (overrideTimesByKey != null && overrideTimesByKey.ContainsKey(lastKeyValue))

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -252,10 +252,10 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 
                                             //Temporary logic: if override times exist then we can presume that a dynamic keyboard with overrides is being user
                                             //The logic here would be to NOT require lock on again, hence why fixationCentrePointAndKeyValue is not cleared out.
-                                            if (overrideTimesByKey != null && overrideTimesByKey.ContainsKey(lastKeyValue))
+                                            if (overrideTimesByKey != null &&
+                                                overrideTimesByKey.TryGetValue(fixationCentrePointAndKeyValue.KeyValue, out TimeSpanOverrides tmpOverride))
                                             {
-                                                overrideTimesByKey[lastKeyValue].LockDownCancelTime = DateTimeOffset.Now 
-                                                    + overrideTimesByKey[lastKeyValue].TimeRequiredToLockDown;
+                                                tmpOverride.LockDownCancelTime = DateTimeOffset.Now + tmpOverride.TimeRequiredToLockDown; 
                                             }
                                             incompleteFixationProgress.Clear();
                                             incompleteFixationTimeouts.Clear();

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -32,7 +32,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
         private readonly bool resumeRequiresLockOn;
         private readonly string defaultTimeToCompleteTrigger;
         private readonly IDictionary<KeyValue, string> timeToCompleteTriggerByKey;
-        private readonly IDictionary<KeyValue, TimeSpanOverrides> overrideTimesByKey;
+        private readonly ConcurrentDictionary<KeyValue, TimeSpanOverrides> overrideTimesByKey;
         private readonly TimeSpan incompleteFixationTtl;
         private readonly ConcurrentDictionary<KeyValue, long> incompleteFixationProgress;
         private readonly ConcurrentDictionary<KeyValue, IDisposable> incompleteFixationTimeouts;
@@ -57,7 +57,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
             this.defaultTimeToCompleteTrigger = defaultTimeToCompleteTrigger;
             this.timeToCompleteTriggerByKey = timeToCompleteTriggerByKey ?? new Dictionary<KeyValue, string>();
             this.incompleteFixationTtl = incompleteFixationTtl;
-            this.overrideTimesByKey = new Dictionary<KeyValue, TimeSpanOverrides>();
+            this.overrideTimesByKey = new ConcurrentDictionary<KeyValue, TimeSpanOverrides>();
             this.pointSource = pointSource;
 
             incompleteFixationProgress = new ConcurrentDictionary<KeyValue, long>();

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -250,7 +250,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
                                                 fixationStart = latestPointAndKeyValue.Timestamp;
                                             //Temporary logic: if override times exist then we can presume that a dynamic keyboard with overrides is being user
                                             //The logic here would be to NOT require lock on again, hence why fixationCentrePointAndKeyValue is not cleared out.
-                                            if (overrideTimesByKey != null && overrideTimesByKey.ContainsKey(fixationCentrePointAndKeyValue.KeyValue))
+                                            if (overrideTimesByKey != null && overrideTimesByKey.ContainsKey(lastKeyValue))
                                             {
                                                 overrideTimesByKey[lastKeyValue].LockDownCancelTime = DateTimeOffset.Now 
                                                     + overrideTimesByKey[lastKeyValue].TimeRequiredToLockDown;

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -201,8 +201,11 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
                                             incompleteFixationTimeouts[fixationCentrePointAndKeyValue.KeyValue] =
                                                 Observable.Timer(fixationTimeout).Subscribe(_ =>
                                                 {
-                                                    if (fixationTimeout != incompleteFixationTtl)
-                                                        overrideTimesByKey[fixationCentrePointAndKeyValueCopy.KeyValue].LockDownCancelTime = DateTimeOffset.MinValue;
+                                                    if (fixationTimeout != incompleteFixationTtl &&
+                                                        overrideTimesByKey.TryGetValue(fixationCentrePointAndKeyValueCopy.KeyValue, out TimeSpanOverrides tmpOverride))
+                                                    {
+                                                        tmpOverride.LockDownCancelTime = DateTimeOffset.MinValue;
+                                                    }
                                                     incompleteFixationProgress.TryRemove(fixationCentrePointAndKeyValueCopy.KeyValue, out var _);
                                                     incompleteFixationTimeouts.TryRemove(fixationCentrePointAndKeyValueCopy.KeyValue, out var _);
                                                     observer.OnNext(new TriggerSignal(null, 0, fixationCentrePointAndKeyValueCopy));


### PR DESCRIPTION
I've kept commits separate to show clearly what's changed, I will squash them when approved.

Two mitigations:
- Makes overrides dictionary concurrent
- Uses TryGet pattern to avoid race conditions

I've confirmed the behaviour is the same as before my changes (except hopefully without the sporadic crashes🙂)

Re: the concurrent dictionary, I'm not sure this is necessary so I'm happy to drop that change if you prefer. 

I hooked up a property changed handler (in testing) to `overrideTimesByKey`. As far as I can tell, it is only ever changed via `KeyboardHost:GenerateContent` which clears the dictionaries and then re-populates with any overrides from the dynamic keyboard XML. This is always on the same thread.

However, the `overrideTimesByKey` dictionary is exposed via the `IFixationTriggerSource` interface and widely accessible - `KeyboardHost`'s dictionary points to `mainWindow`'s dictionary which points to `inputService`'s dictionary which points to `fixationTrigger`'s dictionary which is the one I'm touching. So it's available pretty much globally and it might be reasonable to protect it against future changes by making it concurrency-safe. What do you think? Happy either way - I'll just drop the commit when I squash everything if you want to keep it as-is.

 