### PR TITLE
Fix LockonTime defaulting to zero

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Models/TimeSpanOverrides.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/TimeSpanOverrides.cs
@@ -6,7 +6,7 @@ namespace JuliusSweetland.OptiKey.Models
 {
     public class TimeSpanOverrides
     {
-        public TimeSpan LockOnTime { get; set; }
+        public TimeSpan? LockOnTime { get; set; }
         //This is a list of times required to trigger keystrokes
         //When used the time to trigger the first keystroke is overridden and the time to trigger repetitive keystrokes can be shortened
         public List<string> CompletionTimes { get; set; }

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -345,7 +345,11 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 
             if (overrideTimesByKey.TryGetValue(keyValue, out var timeSpanOverrides))
             {
-                return timeSpanOverrides.LockOnTime;
+                TimeSpan? lockonTime = timeSpanOverrides.LockOnTime;
+                if (lockonTime.HasValue)
+                {
+                    return lockonTime.Value;
+                }
             }
             
             return defaultLockOnTime;

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyboardKeyDownUpSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyboardKeyDownUpSource.cs
@@ -103,7 +103,11 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
                         .DistinctUntilChanged(signal => signal.Signal) //Combining latest will output a trigger signal for every change in BOTH sequences - only output when the trigger signal changes
                         .Where(_ => State == RunningStates.Running)
                         .Publish()
-                        .RefCount();
+                        .RefCount()
+                        .Finally(() => {                            
+                            sequence = null;
+                        });
+
                 }
 
                 return sequence;

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
@@ -935,7 +935,7 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
             if (xmlKeyValue != null && overrideTimesByKey != null)
             {
                 TimeSpanOverrides timeSpanOverrides;
-                if (xmlKey.LockOnTime > 0)
+                if (xmlKey.LockOnTime >= 0)
                 {
                     if (overrideTimesByKey.TryGetValue(xmlKeyValue, out timeSpanOverrides))
                     {
@@ -948,16 +948,16 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
                         overrideTimesByKey.Add(xmlKeyValue, timeSpanOverrides);
                     }
                 }
-                else if (keyGroupList != null && keyGroupList.Exists(x => x.LockOnTime > 0))
+                else if (keyGroupList != null && keyGroupList.Exists(x => x.LockOnTime >= 0))
                 {
                     if (overrideTimesByKey.TryGetValue(xmlKeyValue, out timeSpanOverrides))
                     {
-                        timeSpanOverrides.LockOnTime = TimeSpan.FromMilliseconds(Convert.ToDouble(keyGroupList.Find(x => x.LockOnTime > 0).LockOnTime));
+                        timeSpanOverrides.LockOnTime = TimeSpan.FromMilliseconds(Convert.ToDouble(keyGroupList.Find(x => x.LockOnTime >= 0).LockOnTime));
                         overrideTimesByKey[xmlKeyValue] = timeSpanOverrides;
                     }
                     else
                     {
-                        timeSpanOverrides = new TimeSpanOverrides() { LockOnTime = TimeSpan.FromMilliseconds(Convert.ToDouble(keyGroupList.Find(x => x.LockOnTime > 0).LockOnTime)) };
+                        timeSpanOverrides = new TimeSpanOverrides() { LockOnTime = TimeSpan.FromMilliseconds(Convert.ToDouble(keyGroupList.Find(x => x.LockOnTime >= 0).LockOnTime)) };
                         overrideTimesByKey.Add(xmlKeyValue, timeSpanOverrides);
                     }
                 }


### PR DESCRIPTION
When a CompletionTime was overridden with no accompanying LockonTime,
we were getting a LockonTime of zero rather than the default.