### PR TITLE
Add setting to limit "BackOne"

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
@@ -3125,7 +3125,18 @@ namespace JuliusSweetland.OptiKey.Properties {
                 return ResourceManager.GetString("LEFT_DOWN_UP_SPLIT_WITH_NEWLINE", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Limit "BackOne" deletion to a single character
+        /// </summary>
+        public static string LIMIT_BACKONE
+        {
+            get
+            {
+                return ResourceManager.GetString("LIMIT_BACKONE", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Load dictionary.
         /// </summary>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -2470,4 +2470,7 @@ Magyar
   <data name="POINT_SELECTION_GAMEPAD_CONTROLLER_LABEL" xml:space="preserve">
     <value>Point selection gamepad controller</value>
   </data>
+  <data name="LIMIT_BACKONE" xml:space="preserve">
+    <value>Limit "BackOne" deletion to a single character</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
@@ -196,6 +196,22 @@ namespace JuliusSweetland.OptiKey.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public bool LimitBackOne
+        {
+            get
+            {
+                return ((bool)(this["LimitBackOne"]));
+            }
+            set
+            {
+                this["LimitBackOne"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("00:00:00.0130000")]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public global::System.TimeSpan PointsMousePositionSampleInterval {

--- a/src/JuliusSweetland.OptiKey.Core/Services/KeyboardOutputService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/KeyboardOutputService.cs
@@ -147,7 +147,7 @@ namespace JuliusSweetland.OptiKey.Services
                         if (backOneCount == 1)
                         {
                             var inProgressWord = Text.InProgressWord(Text.Length);
-                            if (inProgressWord != null)
+                            if (inProgressWord != null && !Settings.Default.LimitBackOne)
                             {
                                 //Attempt to break-apart/decompose in-progress word using normalisation
                                 var decomposedInProgressWord = inProgressWord.Decompose();

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/WordsViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/WordsViewModel.cs
@@ -247,6 +247,13 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             set { SetProperty(ref autoCapitalise, value); }
         }
 
+        private bool limitBackOne;
+        public bool LimitBackOne
+        {
+            get { return limitBackOne; }
+            set { SetProperty(ref limitBackOne, value); }
+        }
+
         private bool suppressAutoCapitaliseIntelligently;
         public bool SuppressAutoCapitaliseIntelligently
         {
@@ -318,6 +325,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             SuggestWords = Settings.Default.SuggestWords;
             MultiKeySelectionEnabled = Settings.Default.MultiKeySelectionEnabled;
             MultiKeySelectionMaxDictionaryMatches = Settings.Default.MaxDictionaryMatchesOrSuggestions;
+            LimitBackOne = Settings.Default.LimitBackOne;
         }
 
         public void ApplyChanges()
@@ -345,6 +353,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
             Settings.Default.SuggestWords = SuggestWords;
             Settings.Default.MultiKeySelectionEnabled = MultiKeySelectionEnabled;
             Settings.Default.MaxDictionaryMatchesOrSuggestions = MultiKeySelectionMaxDictionaryMatches;
+            Settings.Default.LimitBackOne = LimitBackOne;
 
             if (reloadDictionary)
             {

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/WordsView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/WordsView.xaml
@@ -131,6 +131,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static resx:Resources.AUTO_SPACE_BETWEEN_WORDS_LABEL}"
@@ -173,21 +174,27 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                         </CheckBox.Style>
                     </CheckBox>
 
-                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static resx:Resources.SUGGEST_WORDS_LABEL}"
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="{x:Static resx:Resources.LIMIT_BACKONE}"
                                VerticalAlignment="Center" Margin="5" />
                     <CheckBox Grid.Row="3" Grid.Column="1"
                               VerticalAlignment="Center"
+                              IsChecked="{Binding LimitBackOne, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.SUGGEST_WORDS_LABEL}"
+                               VerticalAlignment="Center" Margin="5" />
+                    <CheckBox Grid.Row="4" Grid.Column="1"
+                              VerticalAlignment="Center"
                               IsChecked="{Binding SuggestWords, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="{x:Static resx:Resources.SUGGESTION_METHOD}"
+                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static resx:Resources.SUGGESTION_METHOD}"
                                VerticalAlignment="Center" Margin="5" />
-                    <ComboBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
+                    <ComboBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2"
                               ItemsSource="{Binding SuggestionMethods}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
                               SelectedValue="{Binding SuggestionMethod, Mode=TwoWay}" />
 
-                    <TextBlock Grid.Row="5" Grid.Column="0" Text="{x:Static resx:Resources.PRESAGE_DATABASE_LOCATION_LABEL}" 
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{x:Static resx:Resources.PRESAGE_DATABASE_LOCATION_LABEL}" 
                             VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -200,7 +207,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-                    <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Left">
+                    <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Left">
                         <Button Click="btnFindPresageDatabaseLocation_Click" MinWidth="100" Margin="0,5,5,5" VerticalAlignment="Center">
                             <x:Static Member="resx:Resources.MARYTTS_LOCATION_FIND_LABEL"/>
                         </Button>
@@ -215,7 +222,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                             </Style>
                         </StackPanel.Style>
                     </StackPanel>
-                    <TextBlock Grid.Row="5" Grid.Column="2" Name="txtPresageDatabaseLocation"
+                    <TextBlock Grid.Row="6" Grid.Column="2" Name="txtPresageDatabaseLocation"
                                 Text="{Binding PresageDatabaseLocation, Mode=TwoWay}" 
                                 VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
@@ -230,7 +237,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                         </TextBlock.Style>
                     </TextBlock>
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="{x:Static resx:Resources.PRESAGE_NUMBER_OF_SUGGESTIONS_LABEL}"
+                    <TextBlock Grid.Row="7" Grid.Column="0" Text="{x:Static resx:Resources.PRESAGE_NUMBER_OF_SUGGESTIONS_LABEL}"
                                VerticalAlignment="Center" Margin="5" >
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -243,7 +250,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-                    <controls:NumericUpDown Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
+                    <controls:NumericUpDown Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2" TextAlignment="Left"
                                             Minimum="1" Interval="1" Maximum="100"
                                             Value="{Binding PresageNumberOfSuggestions, Mode=TwoWay}" >
                         <controls:NumericUpDown.Style>


### PR DESCRIPTION
This prevents partial deletion of composed characters but
avoids unexpected behaviour where a word is re-inserted
elsewhere if the context has changed, for example by moving
the cursor to a different paragraph.

