### PR TITLE
Support command line arguments for Optikey Pro

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Models/DynamicKeyboardFolder.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Models/DynamicKeyboardFolder.cs
@@ -37,11 +37,14 @@ namespace JuliusSweetland.OptiKey.Models
         #endregion
 
         public List<KeyboardInfo> keyboards;
-        
-        public DynamicKeyboardFolder()
+
+        public DynamicKeyboardFolder(String filePath)
         {
-            // Find all possible xml files
-            string filePath = Settings.Default.DynamicKeyboardsLocation;
+            if (String.IsNullOrEmpty(filePath))
+            {
+                filePath = Settings.Default.DynamicKeyboardsLocation;
+            }
+
             keyboards = new List<KeyboardInfo>();
 
             if (Directory.Exists(filePath))

--- a/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Controls/KeyboardHost.cs
@@ -658,7 +658,7 @@ namespace JuliusSweetland.OptiKey.UI.Controls
             else if (Keyboard is ViewModelKeyboards.DynamicKeyboardSelector)
             {
                 var kb = Keyboard as ViewModelKeyboards.DynamicKeyboardSelector;
-                newContent = new CommonViews.DynamicKeyboardSelector(kb.PageIndex) { DataContext = Keyboard };
+                newContent = new CommonViews.DynamicKeyboardSelector(kb.PageIndex, kb.Directory) { DataContext = Keyboard };
             }
             Content = newContent;
         }

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Keyboards/DynamicKeyboardSelector.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Keyboards/DynamicKeyboardSelector.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 using System;
+using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.UI.ViewModels.Keyboards.Base;
 
 namespace JuliusSweetland.OptiKey.UI.ViewModels.Keyboards
@@ -7,16 +8,30 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Keyboards
     public class DynamicKeyboardSelector : BackActionKeyboard
     {
         private int pageIndex;
+        private string directory;
 
-        public DynamicKeyboardSelector(Action backAction, int pageIndex)
+        public DynamicKeyboardSelector(Action backAction, int pageIndex, string directory = null)
             : base(backAction)
         {
             this.pageIndex = pageIndex;
+            if (String.IsNullOrEmpty(directory))
+            {
+                this.directory = Settings.Default.DynamicKeyboardsLocation;
+            }
+            else
+            {
+                this.directory = directory;
+            }
         }
 
         public int PageIndex
         {
             get { return pageIndex; }
+        }
+
+        public string Directory
+        {
+            get { return directory; }
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
@@ -330,8 +330,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 else if (File.Exists(keyboardOverride))
                 {
                     Log.Info($"Loading keyboard from requested file: {keyboardOverride}");
-                    Keyboard = new DynamicKeyboard(() => { }, keyStateService, keyboardOverride);
-                    //TODO: consider whether back action should take you to 'normal' keyboards?
+                    Keyboard = new DynamicKeyboard(() =>
+                    {
+                        mainWindowManipulationService.Restore();
+                        Keyboard = new Menu(() => Keyboard = new Alpha1());
+                    }, keyStateService, keyboardOverride);
                     return;
                 }
             }

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboardSelector.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboardSelector.xaml.cs
@@ -53,7 +53,7 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
                 MainGrid.ColumnDefinitions.Add(new ColumnDefinition());
             }
 
-            // Add back/quit key, bottom right
+            // Add back/menu key, bottom right
             if (keyboardsPath == Settings.Default.DynamicKeyboardsLocation)
             {
                 Key newKey = new Key();
@@ -67,11 +67,11 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
             {
                 Key newKey = new Key();
                 newKey.SharedSizeGroup = "SingleKey";
-                newKey.SymbolGeometry = (Geometry)this.Resources["QuitIcon"];
-                newKey.Text = JuliusSweetland.OptiKey.Properties.Resources.QUIT;
-                newKey.Value = KeyValues.QuitKey;
+                newKey.SymbolGeometry = (Geometry)this.Resources["MenuIcon"];
+                newKey.Text = JuliusSweetland.OptiKey.Properties.Resources.MENU;
+                newKey.Value = KeyValues.MenuKeyboardKey;
                 this.AddKey(newKey, this.mRows - 1, this.mCols - 1);
-            }
+            }            
 
             // Sleep key for bottom left
             {

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboardSelector.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboardSelector.xaml.cs
@@ -3,10 +3,12 @@ using JuliusSweetland.OptiKey.UI.Controls;
 using JuliusSweetland.OptiKey.Models;
 using System.Windows.Controls;
 using System;
+using System.IO;
 using System.Linq;
 using System.Windows.Media;
 using System.Reflection;
-
+using System.Windows;
+using JuliusSweetland.OptiKey.Enums;
 using log4net;
 using JuliusSweetland.OptiKey.Properties;
 
@@ -32,14 +34,14 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
 
         #endregion
 
-        public DynamicKeyboardSelector(int pageIndex)
+        public DynamicKeyboardSelector(int pageIndex, string keyboardsPath = null)
         {
             InitializeComponent();
             this.pageIndex = pageIndex;
 
             // Populate model
-            folder = new DynamicKeyboardFolder();
-            
+            folder = new DynamicKeyboardFolder(keyboardsPath);
+
             // Setup grid
             for (int i = 0; i < this.mRows; i++)
             {
@@ -51,13 +53,23 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
                 MainGrid.ColumnDefinitions.Add(new ColumnDefinition());
             }
 
-            // Add back key, bottom right
-            { 
+            // Add back/quit key, bottom right
+            if (keyboardsPath == Settings.Default.DynamicKeyboardsLocation)
+            {
                 Key newKey = new Key();
                 newKey.SharedSizeGroup = "SingleKey";
-                newKey.SymbolGeometry = (Geometry)this.Resources["MenuIcon"];
-                newKey.Text = JuliusSweetland.OptiKey.Properties.Resources.MENU;
-                newKey.Value = KeyValues.MenuKeyboardKey;
+                newKey.SymbolGeometry = (Geometry)this.Resources["BackIcon"];
+                newKey.Text = JuliusSweetland.OptiKey.Properties.Resources.BACK;
+                newKey.Value = KeyValues.BackFromKeyboardKey;
+                this.AddKey(newKey, this.mRows - 1, this.mCols - 1);
+            }
+            else
+            {
+                Key newKey = new Key();
+                newKey.SharedSizeGroup = "SingleKey";
+                newKey.SymbolGeometry = (Geometry)this.Resources["QuitIcon"];
+                newKey.Text = JuliusSweetland.OptiKey.Properties.Resources.QUIT;
+                newKey.Value = KeyValues.QuitKey;
                 this.AddKey(newKey, this.mRows - 1, this.mCols - 1);
             }
 

--- a/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
@@ -42,10 +42,11 @@ namespace JuliusSweetland.OptiKey.Pro
     public partial class App : OptiKeyApp
     {
         private static SplashScreen splashScreen;
+        private string startKeyboardOverride = null;
 
         #region Main
         [STAThread]
-        public static void Main()
+        public static void Main(string[] args)
         {
             // Setup derived settings class
             Settings.Initialise();
@@ -53,11 +54,10 @@ namespace JuliusSweetland.OptiKey.Pro
 
             Action runApp = () =>
             {
-
                 splashScreen = new SplashScreen("/Resources/Icons/OptikeyProSplash.png");
                 splashScreen.Show(false);
 
-                var application = new App();
+                var application = new App(args);
                 application.InitializeComponent();
                 application.Run();
             };
@@ -79,10 +79,24 @@ namespace JuliusSweetland.OptiKey.Pro
 
         #region Ctor
 
-        public App()
+        public App(string[] args)
         {
+            // Parse command-line args, 
+            
+            if (args.Length > 0)
+            {
+                // Allow entry straight into specified dynamic keyboard(s)
+                // keyboardArg may be:
+                // - single XML file to load
+                // - folder containing XML files                
+
+                startKeyboardOverride = args[0];
+            }
+
             // Core setup for all OptiKey apps
             Initialise();
+
+            // (Setup specific to this app happens in App_OnStartup)
         }
 
         #endregion
@@ -166,7 +180,7 @@ namespace JuliusSweetland.OptiKey.Pro
                     audioService, calibrationService, dictionaryService, keyStateService,
                     suggestionService, capturingStateManager, lastMouseActionStateManager,
                     inputService, keyboardOutputService, mouseOutputService, mainWindowManipulationService,
-                    errorNotifyingServices);
+                    errorNotifyingServices, startKeyboardOverride);
 
                 mainWindow.SetMainViewModel(mainViewModel);
 


### PR DESCRIPTION
See #782 as well as discussion in https://github.com/OptiKey/OptiKey/issues/761 

## New behaviour
(1) passing an XML file as an argument loads this file directly
(2) passing a folder as an argument loads the folder into the dynamic keyboard menu, with a Quit key available instead of the usual Back key

## Open questions
(a) How should "Back" work from either of these scenarios? Currently there is no back action available. This means you cannot access the rest of Optikey unless you've set up explicit links, and in the case of (1) you can't access Quit keys unless you've set them up yourself. In my own fork (OK Game On) I don't want to allow people default access to elsewhere since this kind of workflow (opening a single file) is a good way to lock an inexperienced user into a limited set of keyboards for the session. In Optikey Pro's case, dynamic keyboards are mainly for expert users managing their own files, so the arguments might be different

(b) How should it work if there is an existing Optikey instance open? Currently, if you allow multiple instances in your settings, it will launch a new instance, but if you don't, it will silently fail. One might consider pushing the keyboard to the existing instance, perhaps.

## Possible extensions
(c) Context menu items to right click on an XML file or a folder and "Open with Optikey"
(d) Support new file extension .ok that allows you to double click a file and launch it directly, without faffing with command line args in shortcuts

@JuliusSweetland this could be considered ready to merge but would like to discuss the above first. @AdamRoden @lsaranto for input also