### PR TITLE
Fix incorrect autogen filename

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
+++ b/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
@@ -1463,7 +1463,7 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <SubType>Designer</SubType>
       <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources1.Designer.cs</LastGenOutput>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <Content Include="Dictionaries\EnglishUS.dic">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
This has been causing build errors for a while, as you'd end up with both Resources.Designer.cs and Resources1.Designer.cs defining the same thing. 