### PR TITLE
Fix styling of keyboard error screen

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Keyboards/Common/DynamicKeyboard.xaml.cs
@@ -318,13 +318,15 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
             AddRowsToGrid(4);
             AddColsToGrid(4);
 
-             // Top middle two cells are main error message
+            // We hardcode black-on-white text for full visibility
+
+            // Top middle two cells are main error message
             {
                 var newKey = new Key {
                     Text = heading,
+                    DisabledForegroundColourOverride = Brushes.Black,
+                    DisabledBackgroundColourOverride = Brushes.White
                 };
-                // Swap for default "not disabled" foreground colour for better visibility
-                newKey.DisabledForegroundColourOverride = newKey.Foreground;
 
                 PlaceKeyInPosition(newKey, 0, 1, 1, 2);                
             }
@@ -332,9 +334,9 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
             {
                 var newKey = new Key {
                     Text = content,
+                    DisabledForegroundColourOverride = Brushes.Black,
+                    DisabledBackgroundColourOverride = Brushes.White
                 };
-                // Swap for default "not disabled" foreground colour for better visibility
-                newKey.DisabledForegroundColourOverride = newKey.Foreground;
 
                 PlaceKeyInPosition(newKey, 1, 0, 2, 4);
             }
@@ -345,26 +347,40 @@ namespace JuliusSweetland.OptiKey.UI.Views.Keyboards.Common
                 {
                     SymbolGeometry = (Geometry)Application.Current.Resources["BackIcon"],
                     Text = Properties.Resources.BACK,
-                    Value = KeyValues.BackFromKeyboardKey
+                    Value = KeyValues.BackFromKeyboardKey,
+                    ForegroundColourOverride = Brushes.Black,
+                    BackgroundColourOverride = Brushes.White
                 };
                 PlaceKeyInPosition(newKey, 3, 3);
             }
 
             // Fill in empty keys
             {
-                var newKey = new Key();
+                var newKey = new Key {
+                    DisabledForegroundColourOverride = Brushes.Black,
+                    DisabledBackgroundColourOverride = Brushes.White
+                };
                 PlaceKeyInPosition(newKey, 0, 0, 1, 1);
             }
             {
-                var newKey = new Key();
+                var newKey = new Key { 
+                    DisabledForegroundColourOverride = Brushes.Black,
+                    DisabledBackgroundColourOverride = Brushes.White
+                };
                 PlaceKeyInPosition(newKey, 0, 3, 1, 1);
             }
             {
-                var newKey = new Key();
+                var newKey = new Key {
+                    DisabledForegroundColourOverride = Brushes.Black,
+                    DisabledBackgroundColourOverride = Brushes.White
+                };
                 PlaceKeyInPosition(newKey, 3, 0, 1, 1);
             }
             {
-                var newKey = new Key();
+                var newKey = new Key {
+                    DisabledForegroundColourOverride = Brushes.Black,
+                    DisabledBackgroundColourOverride = Brushes.White
+                };
                 PlaceKeyInPosition(newKey, 3, 1, 1, 2);
             }
 


### PR DESCRIPTION
Sometimes the styles were not active at the right time for us to swap the enabled/disabled colours. Instead we choose "black on white" for all keyboard error screens, regardless of theme.