### PR TITLE
Fix selection mode after scrolling/dragging

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -1486,6 +1486,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                                         }
 
                                         ResetAndCleanupAfterMouseAction();
+                                        SelectionMode = SelectionModes.Keys;
                                         resumeLookToScroll();
                                     };
 
@@ -1823,6 +1824,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     };
                     performScroll(currentPoint);
                     ResetAndCleanupAfterMouseAction();
+                    SelectionMode = SelectionModes.Keys;
 
                     break;
 
@@ -1846,6 +1848,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     };
                     performScrollDown(currentPointScroll);
                     ResetAndCleanupAfterMouseAction();
+                    SelectionMode = SelectionModes.Keys;
 
                     break;
 


### PR DESCRIPTION
The SelectionMode was not correctly reset after a drag operation or a "move and scroll" operation. This led to some funny state sometimes. It is now fixed.