### PR TITLE
Fix SkipWhile that missed first gamepad press

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/DirectInputButtonDownUpSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/DirectInputButtonDownUpSource.cs
@@ -90,7 +90,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 
                     sequence = keyDowns.Merge(keyUps)
                         .DistinctUntilChanged()
-                        .SkipWhile(b => b.eventType == EventType.DOWN) //Ensure the first value we hit is a true, i.e. a key down
+                        .SkipWhile(b => b.eventType == EventType.UP) //Ensure the first value we hit is a key down
                         .CombineLatest(pointSource.Sequence, (b, point) => new TriggerSignal(b.eventType == EventType.DOWN ? 1 : -1, null, point.Value))
                         .DistinctUntilChanged(signal => signal.Signal) //Combining latest will output a trigger signal for every change in BOTH sequences - only output when the trigger signal changes
                         .Where(_ => State == RunningStates.Running)

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/XInputButtonDownUpSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/XInputButtonDownUpSource.cs
@@ -98,7 +98,7 @@ namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 
                     sequence = keyDowns.Merge(keyUps)
                         .DistinctUntilChanged()
-                        .SkipWhile(b => b.eventType == EventType.DOWN) //Ensure the first value we hit is a true, i.e. a key down
+                        .SkipWhile(b => b.eventType == EventType.UP) //Ensure the first value we hit is a key down
                         .CombineLatest(pointSource.Sequence, (b, point) => new TriggerSignal(b.eventType == EventType.DOWN ? 1 : -1, null, point.Value))
                         .DistinctUntilChanged(signal => signal.Signal) //Combining latest will output a trigger signal for every change in BOTH sequences - only output when the trigger signal changes
                         .Where(_ => State == RunningStates.Running)


### PR DESCRIPTION
The first time you pressed a gamepad button as a trigger each time the input sequence was renewed, it didn't get detected until after an "up". This was just a silly logic bug.

Doesn't affect anything other than gamepad input