### PR TITLE
Fix LookToScroll for 2-monitor setups

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/Static/Graphics.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Static/Graphics.cs
@@ -41,18 +41,7 @@ namespace JuliusSweetland.OptiKey.Static
         public static double DipScalingFactorY
         {
             get { return (double)DpiY / (double)96; }
-        }
-
-
-        public static double VirtualScreenWidthInPixels
-        {
-            get { return SystemParameters.VirtualScreenWidth * DipScalingFactorX; }
-        }
-
-        public static double VirtualScreenHeightInPixels
-        {
-            get { return SystemParameters.VirtualScreenHeight * DipScalingFactorY; }
-        }
+        }        
 
         public static double PrimaryScreenWidthInPixels
         {

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.LookToScroll.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.LookToScroll.cs
@@ -824,17 +824,6 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             }
         }
 
-        private Rect GetVirtualScreenBoundsInPixels()
-        {
-            return new Rect
-            {
-                X = 0,
-                Y = 0,
-                Width = Graphics.VirtualScreenWidthInPixels,
-                Height = Graphics.VirtualScreenHeightInPixels,
-            };
-        }
-
         private Rect GetPrimaryScreenBoundsInPixels()
         {
             return new Rect

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.LookToScroll.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.LookToScroll.cs
@@ -551,7 +551,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 case LookToScrollBounds.ScreenCentred:
                     bounds = IsMainWindowDocked() 
                         ? FindLargestGapBetweenScreenAndMainWindow() 
-                        : GetVirtualScreenBoundsInPixels();
+                        : GetPrimaryScreenBoundsInPixels();
                     break;
 
                 case LookToScrollBounds.Window:
@@ -570,9 +570,11 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             return bounds;
         }
 
+        // Finds the largest rectangular region outside the main window
+        // Used to identify the main screen region remaining after docked app takes up space
         private Rect FindLargestGapBetweenScreenAndMainWindow()
         {
-            Rect screen = GetVirtualScreenBoundsInPixels();
+            Rect screen = GetPrimaryScreenBoundsInPixels();
             Rect window = GetMainWindowBoundsInPixels();
 
             var above = new Rect { X = screen.Left, Y = screen.Top, Width = screen.Width, Height = window.Top >= screen.Top ? window.Top - screen.Top : 0 };
@@ -832,6 +834,18 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 Height = Graphics.VirtualScreenHeightInPixels,
             };
         }
+
+        private Rect GetPrimaryScreenBoundsInPixels()
+        {
+            return new Rect
+            {
+                X = 0,
+                Y = 0,
+                Width = Graphics.PrimaryScreenWidthInPixels,
+                Height = Graphics.PrimaryScreenHeightInPixels,
+            };
+        }
+
 
         private Rect GetMainWindowBoundsInPixels()
         {

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -214,8 +214,8 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                             {
                                 var singlePoint = points[0]; 
                                 if (singlePoint.X < 0 || singlePoint.Y < 0 || 
-                                    singlePoint.X > Graphics.VirtualScreenWidthInPixels || 
-                                    singlePoint.Y > Graphics.VirtualScreenHeightInPixels)
+                                    singlePoint.X > Graphics.PrimaryScreenWidthInPixels || 
+                                    singlePoint.Y > Graphics.PrimaryScreenHeightInPixels)
                                 {
                                     preventRepeat = true;
                                 }


### PR DESCRIPTION
This resulted in #897, in which LTS wasn't considered valid with vertical docking of Optikey.