### PR TITLE
Fix logging on restart

### DIFF
--- a/src/JuliusSweetland.OptiKey.Chat/log4net.config
+++ b/src/JuliusSweetland.OptiKey.Chat/log4net.config
@@ -14,6 +14,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
       <staticLogFileName value="true" />
       <rollingStyle value="Once" />
       <maxSizeRollBackups value="10" />
+      <param name="OnStartupTriggeringPolicy" value="true" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%date [%2thread] %-5level %logger: %message%newline" />
       </layout>

--- a/src/JuliusSweetland.OptiKey.Core/OptiKeyApp.cs
+++ b/src/JuliusSweetland.OptiKey.Core/OptiKeyApp.cs
@@ -75,6 +75,10 @@ namespace JuliusSweetland.OptiKey
 
         public static void RestartApp()
         {
+            // Shut down logging so that new app instance can roll over log files okay
+            LogManager.Flush(1000);
+            LogManager.Shutdown();
+
             // Release single-instance mutex if we've got one
             if (_manager != null)
             {

--- a/src/JuliusSweetland.OptiKey.Mouse/log4net.config
+++ b/src/JuliusSweetland.OptiKey.Mouse/log4net.config
@@ -14,6 +14,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
       <staticLogFileName value="true" />
       <rollingStyle value="Once" />
       <maxSizeRollBackups value="10" />
+      <param name="OnStartupTriggeringPolicy" value="true" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%date [%2thread] %-5level %logger: %message%newline" />
       </layout>

--- a/src/JuliusSweetland.OptiKey.Pro/log4net.config
+++ b/src/JuliusSweetland.OptiKey.Pro/log4net.config
@@ -14,6 +14,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
       <staticLogFileName value="true" />
       <rollingStyle value="Once" />
       <maxSizeRollBackups value="10" />
+      <param name="OnStartupTriggeringPolicy" value="true" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%date [%2thread] %-5level %logger: %message%newline" />
       </layout>

--- a/src/JuliusSweetland.OptiKey.Symbol/log4net.config
+++ b/src/JuliusSweetland.OptiKey.Symbol/log4net.config
@@ -14,6 +14,7 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
       <staticLogFileName value="true" />
       <rollingStyle value="Once" />
       <maxSizeRollBackups value="10" />
+      <param name="OnStartupTriggeringPolicy" value="true" />
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%date [%2thread] %-5level %logger: %message%newline" />
       </layout>


### PR DESCRIPTION
When an Optikey app was restarted (e.g. via Management Console, context menu, or crash handling) the old log file was still open for writing when the new log file was established and the rollover carried out.

The result was that the old log file (from the instance requesting the restart) was lost completely, and there was a gap in the list of rolled-over log files, e.g.
```
EyeMine.log
EyeMine.log.2
EyeMine.log.4
```

This change ensures that a new process starts a new log file, after the old process explicitly closes down the old log file.