### PR TITLE
Add log for command line args

### DIFF
--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
@@ -341,6 +341,10 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                     }, keyStateService, keyboardOverride);
                     return;
                 }
+                else
+                {
+                    Log.Error($"Can't find requested file or folder: {keyboardOverride}");                    
+                }
             }
 
             Action backaction = null;


### PR DESCRIPTION
Previously if you entered a command line arg (file or folder) incorrectly it silently failed, so just adding a log for this situation. 