### PR TITLE
Add DLL support

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,1 @@
+<TargetPlatform>x64</TargetPlatform>

--- a/OptiKey.sln
+++ b/OptiKey.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 15.0.28307.1259
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JuliusSweetland.OptiKey.Core", "src\JuliusSweetland.OptiKey.Core\JuliusSweetland.OptiKey.Core.csproj", "{6865C5AF-C6F0-4BDA-BA1C-7AE8BC225234}"
 	ProjectSection(ProjectDependencies) = postProject
+		{77C8F650-7992-4FF6-B434-1C15B72672E6} = {77C8F650-7992-4FF6-B434-1C15B72672E6}
 		{0C8F0372-2D55-41BC-9730-4ACE3ED67452} = {0C8F0372-2D55-41BC-9730-4ACE3ED67452}
 	EndProjectSection
 EndProject
@@ -57,6 +58,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleInstance.Wpf", "src\SingleInstance.Wpf\SingleInstance.Wpf.csproj", "{2A8B4AE0-48BE-4A49-9C9C-654C195C8AB2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestConnectedControllers", "src\TestControllers\TestConnectedControllers.csproj", "{C19F5A3D-271A-44B4-9F98-628F4534F959}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JuliusSweetland.OptiKey.Contracts", "src\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj", "{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JuliusSweetland.OptiKey.PointSourceUtils", "src\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj", "{77C8F650-7992-4FF6-B434-1C15B72672E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -154,6 +159,22 @@ Global
 		{C19F5A3D-271A-44B4-9F98-628F4534F959}.DefaultBuild|x64.Build.0 = Debug|x64
 		{C19F5A3D-271A-44B4-9F98-628F4534F959}.Release|x64.ActiveCfg = Release|x64
 		{C19F5A3D-271A-44B4-9F98-628F4534F959}.Release|x64.Build.0 = Release|x64
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.All|x64.ActiveCfg = Release|Any CPU
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.All|x64.Build.0 = Release|Any CPU
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.Debug|x64.ActiveCfg = Debug|x64
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.Debug|x64.Build.0 = Debug|x64
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.DefaultBuild|x64.ActiveCfg = Debug|Any CPU
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.DefaultBuild|x64.Build.0 = Debug|Any CPU
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.Release|x64.ActiveCfg = Release|x64
+		{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}.Release|x64.Build.0 = Release|x64
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.All|x64.ActiveCfg = Release|Any CPU
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.All|x64.Build.0 = Release|Any CPU
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.Debug|x64.ActiveCfg = Debug|x64
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.Debug|x64.Build.0 = Debug|x64
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.DefaultBuild|x64.ActiveCfg = Debug|Any CPU
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.DefaultBuild|x64.Build.0 = Debug|Any CPU
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.Release|x64.ActiveCfg = Release|x64
+		{77C8F650-7992-4FF6-B434-1C15B72672E6}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/JuliusSweetland.OptiKey.Chat/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Chat/App.xaml.cs
@@ -18,6 +18,7 @@ using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
 using JuliusSweetland.OptiKey.Observables.TriggerSources;
 using JuliusSweetland.OptiKey.Chat.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.Services.PluginEngine;
 using JuliusSweetland.OptiKey.Static;
@@ -116,7 +117,7 @@ namespace JuliusSweetland.OptiKey.Chat
                 ValidatePluginsLocation();
                 if (Settings.Default.EnablePlugins)
                 {
-                    PluginEngine.LoadAvailablePlugins();
+                    OptikeyPluginEngine.LoadAvailablePlugins();
                 }
 
                 var presageInstallationProblem = PresageInstallationProblemsDetected();
@@ -133,7 +134,7 @@ namespace JuliusSweetland.OptiKey.Chat
                 ILastMouseActionStateManager lastMouseActionStateManager = new LastMouseActionStateManager();
                 IKeyStateService keyStateService = new KeyStateService(suggestionService, capturingStateManager, lastMouseActionStateManager, calibrationService, fireKeySelectionEvent);
                 IInputService inputService = CreateInputService(keyStateService, dictionaryService, audioService,
-                    calibrationService, capturingStateManager, errorNotifyingServices);
+                    calibrationService, capturingStateManager, errorNotifyingServices, out string inputServiceErrorMessage);
                 IKeyboardOutputService keyboardOutputService = new KeyboardOutputService(keyStateService, suggestionService, publishService, dictionaryService, fireKeySelectionEvent);
                 IMouseOutputService mouseOutputService = new MouseOutputService(publishService);
                 errorNotifyingServices.Add(audioService);
@@ -187,10 +188,13 @@ namespace JuliusSweetland.OptiKey.Chat
                     await mainViewModel.RaiseAnyPendingErrorToastNotifications();
                     await AttemptToStartMaryTTSService(inputService, audioService, mainViewModel);
                     await AlertIfPresageBitnessOrBootstrapOrVersionFailure(presageInstallationProblem, inputService, audioService, mainViewModel);
+                    await AlertIfInputServiceError(inputService, audioService, mainViewModel, inputServiceErrorMessage);
                     await AlertIfEyeTrackerDeprecated(inputService, audioService, mainViewModel);
 
                     inputService.RequestResume(); //Start the input service
 
+                    // Github queries happen in the background
+                    await StartCheckForEyeTrackerPluginsOnline();
                     await CheckForUpdates(inputService, audioService, mainViewModel);
                 };
 

--- a/src/JuliusSweetland.OptiKey.Chat/JuliusSweetland.OptiKey.Chat.csproj
+++ b/src/JuliusSweetland.OptiKey.Chat/JuliusSweetland.OptiKey.Chat.csproj
@@ -70,7 +70,7 @@
     </Reference>
     <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
@@ -199,7 +199,7 @@
     </Reference>
     <Reference Include="TETCSharpClient">
       <HintPath>..\..\ext\TheEyeTribe\TETCSharpClient.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -1010,6 +1010,14 @@
     <ProjectReference Include="..\JuliusSweetland.OptiKey.Core\JuliusSweetland.OptiKey.Core.csproj">
       <Project>{6865c5af-c6f0-4bda-ba1c-7ae8bc225234}</Project>
       <Name>JuliusSweetland.OptiKey.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj">
+      <Project>{77c8f650-7992-4ff6-b434-1c15b72672e6}</Project>
+      <Name>JuliusSweetland.OptiKey.PointSourceUtils</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj">
+      <Project>{6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719}</Project>
+      <Name>JuliusSweetland.OptiKey.Contracts</Name>
     </ProjectReference>
     <ProjectReference Include="..\JuliusSweetland.OptiKey.StandardPlugins\JuliusSweetland.OptiKey.StandardPlugins.csproj">
       <Project>{0c8f0372-2d55-41bc-9730-4ace3ed67452}</Project>

--- a/src/JuliusSweetland.OptiKey.Contracts/INotifyErrors.cs
+++ b/src/JuliusSweetland.OptiKey.Contracts/INotifyErrors.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 using System;
 
-namespace JuliusSweetland.OptiKey.Services
+namespace JuliusSweetland.OptiKey.Contracts
 {
     public interface INotifyErrors
     {

--- a/src/JuliusSweetland.OptiKey.Contracts/IPointService.cs
+++ b/src/JuliusSweetland.OptiKey.Contracts/IPointService.cs
@@ -3,11 +3,12 @@ using System;
 using System.Reactive;
 using System.Windows;
 
-namespace JuliusSweetland.OptiKey.Services
+namespace JuliusSweetland.OptiKey.Contracts
 {
     public interface IPointService : INotifyErrors
     {
         bool KalmanFilterSupported { get; }
         event EventHandler<Timestamped<Point>> Point;
+        //void CleanupOnAppShutdown(); // can't we just ensure eye tracker APIs are Disposed on app exit??
     }
 }

--- a/src/JuliusSweetland.OptiKey.Contracts/JuliusSweetland.OptiKey.Contracts.csproj
+++ b/src/JuliusSweetland.OptiKey.Contracts/JuliusSweetland.OptiKey.Contracts.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6B7FD101-F21C-4EEA-A2E0-4B5CBFBFE719}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>JuliusSweetland.OptiKey.Contracts</RootNamespace>
+    <AssemblyName>JuliusSweetland.OptiKey.Contracts</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="INotifyErrors.cs" />
+    <Compile Include="IPointService.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/JuliusSweetland.OptiKey.Contracts/Properties/AssemblyInfo.cs
+++ b/src/JuliusSweetland.OptiKey.Contracts/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("JuliusSweetland.OptiKey.PointSourceContract")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("JuliusSweetland.OptiKey.PointSourceContract")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/JuliusSweetland.OptiKey.Contracts/packages.config
+++ b/src/JuliusSweetland.OptiKey.Contracts/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+</packages>

--- a/src/JuliusSweetland.OptiKey.Core/Enums/PointsSources.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Enums/PointsSources.cs
@@ -7,9 +7,12 @@ namespace JuliusSweetland.OptiKey.Enums
         [System.Obsolete("Not supported in v4+", true)]
         Alienware17,
 
+        DllIntegration,
+
         GazeTracker,
         IrisbondDuo,
         IrisbondHiru,
+        
         MousePosition,
 
         [System.Obsolete("Not supported in v4+", true)]
@@ -54,6 +57,7 @@ namespace JuliusSweetland.OptiKey.Enums
                 case PointsSources.TobiiPcEyeMini: return Resources.TOBII_PCEYE_MINI;
                 case PointsSources.TobiiX2_30: return Resources.TOBII_X2_30;
                 case PointsSources.TobiiX2_60: return Resources.TOBII_X2_60;
+                case PointsSources.DllIntegration: return Resources.EXTERNAL_EYETRACKER_DLL;
             }
 
             return pointSource.ToString();
@@ -74,6 +78,7 @@ namespace JuliusSweetland.OptiKey.Enums
                 case PointsSources.TobiiPcEyeMini: return Resources.TOBII_ASSISTIVE_INFO;
                 case PointsSources.TobiiX2_30: return Resources.TOBII_ASSISTIVE_INFO;
                 case PointsSources.TobiiX2_60: return Resources.TOBII_ASSISTIVE_INFO;
+                case PointsSources.DllIntegration: return "";
             }
 
             return pointSource.ToString();

--- a/src/JuliusSweetland.OptiKey.Core/Extensions/FileInfoExtensions.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Extensions/FileInfoExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2024 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+using System;
+using System.IO;
+
+namespace JuliusSweetland.OptiKey.Extensions
+{
+    public static class FileInfoExtensions
+    {
+
+        public static string GetRelativePath(this FileInfo f, string basePath)
+        {
+            string fullPath = Path.GetDirectoryName(f.FullName) + Path.DirectorySeparatorChar;
+
+            Uri baseUri = new Uri(basePath + Path.DirectorySeparatorChar);
+            Uri fullUri = new Uri(fullPath);
+            string relativePath = Uri.UnescapeDataString(baseUri.MakeRelativeUri(fullUri).ToString());
+
+            // Represent the current directory if empty
+            if (string.IsNullOrEmpty(relativePath) ||
+                relativePath == Path.DirectorySeparatorChar.ToString())
+                relativePath = "." + Path.DirectorySeparatorChar;
+
+            // Uris use "/" in all cases. Replace with DirectorySeparatorChar
+            relativePath = relativePath.Replace('/', Path.DirectorySeparatorChar);
+
+            return relativePath;
+        }
+
+
+        public static bool IsLocked(this FileInfo f)
+        {
+            FileStream fs = null;
+            try
+            {
+                fs = File.Open(f.FullName, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                return false;
+            }
+            catch (IOException)
+            {
+                return true;
+            }
+            finally
+            {
+                fs?.Close(); 
+            }
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/Extensions/ZipArchiveExtensions.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Extensions/ZipArchiveExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JuliusSweetland.OptiKey.Extensions
+{
+    public static class ZipArchiveExtensions    
+    {
+
+        public static void ExtractToDirectory(this ZipArchive archive, string extractPath, bool overwrite)
+        {
+            if (!overwrite)
+            {
+                // standard implementation that doesn't allow overwriting
+                archive.ExtractToDirectory(extractPath); 
+            }
+            else
+            {
+                foreach (ZipArchiveEntry file in archive.Entries)
+                {
+                    string completeFileName = Path.Combine(extractPath, file.FullName);
+                    string directory = Path.GetDirectoryName(completeFileName);
+
+                    // Don't allow extraction outside the destination dir
+                    if (!completeFileName.StartsWith(extractPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new IOException("Trying to extract file outside of destination directory. See this link for more info: https://snyk.io/research/zip-slip-vulnerability");
+                    }
+
+                    if (!Directory.Exists(directory))
+                        Directory.CreateDirectory(directory);
+
+                    if (file.Name != "")
+                        file.ExtractToFile(completeFileName, true);
+                }
+            }
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
+++ b/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
@@ -218,7 +218,7 @@
     </Reference>
     <Reference Include="TETCSharpClient">
       <HintPath>..\..\ext\TheEyeTribe\TETCSharpClient.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -228,6 +228,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Enums\TriggerTypes.cs" />
+    <Compile Include="Extensions\FileInfoExtensions.cs" />
+    <Compile Include="Extensions\ZipArchiveExtensions.cs" />
     <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="Models\Gamepads\GamepadButtonEvents.cs" />
     <Compile Include="Models\Gamepads\DirectInputControllerState.cs" />
@@ -383,17 +385,21 @@
     <Compile Include="Services\Audio\SoundPlayerEx.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Services\PluginEngine\DllLoader.cs" />
+    <Compile Include="Services\PluginEngine\EyeTrackerPluginEngine.cs" />
+    <Compile Include="Services\PluginEngine\GithubPluginsSearch.cs" />
+    <Compile Include="Services\PluginEngine\GithubRepoModel.cs" />
+    <Compile Include="Services\PluginEngine\InstalledPluginsSearch.cs" />
+    <Compile Include="Services\PluginEngine\PluginUtils.cs" />
     <Compile Include="Services\PointSources\IrisbondHiruCalibrationService.cs" />
     <Compile Include="Services\PointSources\IrisbondHiruPointService.cs" />
-    <Compile Include="Services\PluginEngine\PluginEngine.cs" />
+    <Compile Include="Services\PluginEngine\OptikeyPluginEngine.cs" />
     <Compile Include="Services\Suggestions\IManagedSuggestions.cs" />
     <Compile Include="Services\Suggestions\BasicAutoComplete.cs" />
     <Compile Include="Services\Suggestions\ISuggestions.cs" />
     <Compile Include="Services\Suggestions\NGramAutoComplete.cs" />
     <Compile Include="Services\ICalibrationService.cs" />
     <Compile Include="Services\IMouseOutputService.cs" />
-    <Compile Include="Services\INotifyErrors.cs" />
-    <Compile Include="Services\IPointService.cs" />
     <Compile Include="Services\IWindowManipulationService.cs" />
     <Compile Include="Services\KeyStateService.cs" />
     <Compile Include="Services\IKeyStateService.cs" />
@@ -461,10 +467,16 @@
       <DependentUpon>CK20Page.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\Controls\KeyboardView.cs" />
+    <Compile Include="UI\ValueConverters\FileNameConverter .cs" />
     <Compile Include="UI\ValueConverters\CompletionTimesValidation.cs" />
+    <Compile Include="UI\ValueConverters\DateTimeToDateStringConverter.cs" />
     <Compile Include="UI\ValueConverters\HlsColor.cs" />
     <Compile Include="UI\ValueConverters\InvertedBoolToVisibilityConverter.cs" />
     <Compile Include="UI\ValueConverters\MultiBoolToVisibilityConverter.cs" />
+    <Compile Include="UI\ValueConverters\ProgressUnderwayEnabledConverter.cs" />
+    <Compile Include="UI\ValueConverters\ProgressUnderwayVisibilityConverter.cs" />
+    <Compile Include="UI\ValueConverters\StringNullOrEmptyToVisibilityConverter.cs" />
+    <Compile Include="UI\ValueConverters\WidthWithoutScrollbarConverter.cs" />
     <Compile Include="UI\ViewModels\Keyboards\Alpha3.cs" />
     <Compile Include="UI\ViewModels\Keyboards\ConversationAlpha3.cs" />
     <Compile Include="UI\ViewModels\Keyboards\DynamicKeyboard.cs" />
@@ -917,6 +929,9 @@
     </Compile>
     <Compile Include="UI\Controls\GestureEditor.xaml.cs">
       <DependentUpon>GestureEditor.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UI\Views\Management\EyeTrackerPluginsWindow.xaml.cs">
+      <DependentUpon>EyeTrackerPluginsWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\Views\Management\GesturesView.xaml.cs">
       <DependentUpon>GesturesView.xaml</DependentUpon>
@@ -1510,6 +1525,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Resources\Themes\EyeTrackerPluginsTheme.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="UI\Controls\CK20Page.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -2047,6 +2066,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="UI\Views\Management\EyeTrackerPluginsWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="UI\Views\Management\GesturesView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -2140,6 +2163,14 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj">
+      <Project>{6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719}</Project>
+      <Name>JuliusSweetland.OptiKey.Contracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj">
+      <Project>{77c8f650-7992-4ff6-b434-1c15b72672e6}</Project>
+      <Name>JuliusSweetland.OptiKey.PointSourceUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SingleInstance.Wpf\SingleInstance.Wpf.csproj">
       <Project>{2a8b4ae0-48be-4a49-9c9c-654c195c8ab2}</Project>
       <Name>SingleInstance.Wpf</Name>

--- a/src/JuliusSweetland.OptiKey.Core/Observables/PointSources/MousePositionSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/PointSources/MousePositionSource.cs
@@ -9,6 +9,7 @@ using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Observables.PointSources
 {

--- a/src/JuliusSweetland.OptiKey.Core/Observables/PointSources/PointServiceSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/PointSources/PointServiceSource.cs
@@ -10,6 +10,7 @@ using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.DataFilters;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Observables.PointSources
 {

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/EyeGestureSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/EyeGestureSource.cs
@@ -10,6 +10,7 @@ using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
 using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Static;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 {

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/KeyFixationSource.cs
@@ -9,6 +9,7 @@ using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 {

--- a/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/PointFixationSource.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Observables/TriggerSources/PointFixationSource.cs
@@ -8,6 +8,7 @@ using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Observables.TriggerSources
 {

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.Designer.cs
@@ -260,6 +260,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to remove all versions in:.
+        /// </summary>
+        public static string ASK_CONFIRM_UNINSTALL {
+            get {
+                return ResourceManager.GetString("ASK_CONFIRM_UNINSTALL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ATTENTION.
         /// </summary>
         public static string ATTENTION {
@@ -310,6 +319,24 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string AUTO_SPACE_BETWEEN_WORDS_LABEL {
             get {
                 return ResourceManager.GetString("AUTO_SPACE_BETWEEN_WORDS_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available eyetracker plugins.
+        /// </summary>
+        public static string AVAILABLE_EYETRACKER_PLUGINS {
+            get {
+                return ResourceManager.GetString("AVAILABLE_EYETRACKER_PLUGINS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available from GitHub.
+        /// </summary>
+        public static string AVAILABLE_FROM_GITHUB {
+            get {
+                return ResourceManager.GetString("AVAILABLE_FROM_GITHUB", resourceCulture);
             }
         }
         
@@ -576,6 +603,24 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change points source?.
+        /// </summary>
+        public static string CHANGE_EYETRACKER_CAPTION {
+            get {
+                return ResourceManager.GetString("CHANGE_EYETRACKER_CAPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do you want to use the newly installed plugin ({0}) as your points source?.
+        /// </summary>
+        public static string CHANGE_EYETRACKER_DETAILS {
+            get {
+                return ResourceManager.GetString("CHANGE_EYETRACKER_DETAILS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CHANGE KEYBOARD KEYS:.
         /// </summary>
         public static string CHANGE_KEYBOARD_KEY_GROUP {
@@ -785,11 +830,21 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter multiple values separated by commas to speed up/slow down subsequent selections, for example: 1250,750,450,250.
+        ///   Looks up a localized string similar to Enter multiple values separated by commas to speed up/slow down subsequent selections.
+        ///For example: 1250,750,450,250.
         /// </summary>
         public static string COMPLETION_TIMES_HINT {
             get {
                 return ResourceManager.GetString("COMPLETION_TIMES_HINT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm Uninstall.
+        /// </summary>
+        public static string CONFIRM_UNINSTALL {
+            get {
+                return ResourceManager.GetString("CONFIRM_UNINSTALL", resourceCulture);
             }
         }
         
@@ -1625,6 +1680,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to load input service.
+        /// </summary>
+        public static string ERROR_LOADING_INPUT_SERVICE {
+            get {
+                return ResourceManager.GetString("ERROR_LOADING_INPUT_SERVICE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error has occurred during the magnification process. Please disable magnification and contact Optikey for further support..
         /// </summary>
         public static string ERROR_MAGNIFYING {
@@ -1648,6 +1712,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string ERROR_TITLE {
             get {
                 return ResourceManager.GetString("ERROR_TITLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error uninstalling plugin.
+        /// </summary>
+        public static string ERROR_UNINSTALLING_PLUGIN {
+            get {
+                return ResourceManager.GetString("ERROR_UNINSTALLING_PLUGIN", resourceCulture);
             }
         }
         
@@ -1845,6 +1918,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to External eye tracker via DLL plugin.
+        /// </summary>
+        public static string EXTERNAL_EYETRACKER_DLL {
+            get {
+                return ResourceManager.GetString("EXTERNAL_EYETRACKER_DLL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extra keys.
         /// </summary>
         public static string EXTRA_KEYS {
@@ -1872,6 +1954,42 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string EYETRACKER_DEPRECATED_DETAILS {
             get {
                 return ResourceManager.GetString("EYETRACKER_DEPRECATED_DETAILS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plugin has been installed, but Optikey was unable to start it. Check the log for details. .
+        /// </summary>
+        public static string EYETRACKER_DLL_INSTALLED_BUT_NOT_INSTANTIATED {
+            get {
+                return ResourceManager.GetString("EYETRACKER_DLL_INSTALLED_BUT_NOT_INSTANTIATED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DLL file for eye tracker plugin.
+        /// </summary>
+        public static string EYETRACKER_DLL_LOCATION_LABEL {
+            get {
+                return ResourceManager.GetString("EYETRACKER_DLL_LOCATION_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Eyetracker DLL file was not found.
+        /// </summary>
+        public static string EYETRACKER_DLL_NOT_FOUND {
+            get {
+                return ResourceManager.GetString("EYETRACKER_DLL_NOT_FOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Eyetracker DLL file is not valid.
+        /// </summary>
+        public static string EYETRACKER_DLL_NOT_VALID {
+            get {
+                return ResourceManager.GetString("EYETRACKER_DLL_NOT_VALID", resourceCulture);
             }
         }
         
@@ -2083,6 +2201,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Files locked.
+        /// </summary>
+        public static string FILES_LOCKED {
+            get {
+                return ResourceManager.GetString("FILES_LOCKED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fill Pie.
         /// </summary>
         public static string FILL_PIE {
@@ -2198,6 +2325,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to found in.
+        /// </summary>
+        public static string FOUND_IN {
+            get {
+                return ResourceManager.GetString("FOUND_IN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to French (Canada) / Française (Canada).
         /// </summary>
         public static string FRENCH_CANADA {
@@ -2236,6 +2372,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string FRENCH_FRANCE_SPLIT_WITH_NEWLINE {
             get {
                 return ResourceManager.GetString("FRENCH_FRANCE_SPLIT_WITH_NEWLINE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From GitHub:.
+        /// </summary>
+        public static string FROM_GITHUB_COLON {
+            get {
+                return ResourceManager.GetString("FROM_GITHUB_COLON", resourceCulture);
             }
         }
         
@@ -2543,6 +2688,24 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string INS {
             get {
                 return ResourceManager.GetString("INS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install.
+        /// </summary>
+        public static string INSTALL {
+            get {
+                return ResourceManager.GetString("INSTALL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installed plugins.
+        /// </summary>
+        public static string INSTALLED_PLUGINS {
+            get {
+                return ResourceManager.GetString("INSTALLED_PLUGINS", resourceCulture);
             }
         }
         
@@ -3082,6 +3245,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Latest release available.
+        /// </summary>
+        public static string LATEST_RELEASE_AVAILABLE {
+            get {
+                return ResourceManager.GetString("LATEST_RELEASE_AVAILABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Left.
         /// </summary>
         public static string LEFT {
@@ -3426,6 +3598,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string MAGNIFY_SUPPRESSED_FOR_SCROLLING_ACTIONS_LABEL {
             get {
                 return ResourceManager.GetString("MAGNIFY_SUPPRESSED_FOR_SCROLLING_ACTIONS_LABEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage eye tracker plugins.
+        /// </summary>
+        public static string MANAGE_ET_PLUGINS {
+            get {
+                return ResourceManager.GetString("MANAGE_ET_PLUGINS", resourceCulture);
             }
         }
         
@@ -4349,6 +4530,16 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No eye tracker plugins found.
+        ///Check your internet connection and wait a few minutes to rescan..
+        /// </summary>
+        public static string NO_EYETRACKER_PLUGINS {
+            get {
+                return ResourceManager.GetString("NO_EYETRACKER_PLUGINS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No keyboards found.
         /// </summary>
         public static string NO_KEYBOARDS_FOUND {
@@ -4372,6 +4563,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string NO_SOUND {
             get {
                 return ResourceManager.GetString("NO_SOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find valid eyetracker plugin (DLL) file.
+        /// </summary>
+        public static string NO_VALID_DLL_FOUND {
+            get {
+                return ResourceManager.GetString("NO_VALID_DLL_FOUND", resourceCulture);
             }
         }
         
@@ -4514,6 +4714,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open Containing Folder.
+        /// </summary>
+        public static string OPEN_CONTAINING_FOLDER {
+            get {
+                return ResourceManager.GetString("OPEN_CONTAINING_FOLDER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Optikey Chat : Easy Communication.
         /// </summary>
         public static string OPTIKEY_CHAT_DESCRIPTION {
@@ -4566,6 +4775,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string OTHER_TRACKER {
             get {
                 return ResourceManager.GetString("OTHER_TRACKER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Others:.
+        /// </summary>
+        public static string OTHERS_COLON {
+            get {
+                return ResourceManager.GetString("OTHERS_COLON", resourceCulture);
             }
         }
         
@@ -4689,6 +4907,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string PLAY_SOUND {
             get {
                 return ResourceManager.GetString("PLAY_SOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plugin search wizard.
+        /// </summary>
+        public static string PLUGIN_SEARCH_WIZARD {
+            get {
+                return ResourceManager.GetString("PLUGIN_SEARCH_WIZARD", resourceCulture);
             }
         }
         
@@ -5834,6 +6061,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to stars.
+        /// </summary>
+        public static string STARS {
+            get {
+                return ResourceManager.GetString("STARS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uh-oh! We&apos;ve encountered the following errors during startup:.
         /// </summary>
         public static string STARTUP_CRASH_TITLE {
@@ -6443,6 +6679,24 @@ namespace JuliusSweetland.OptiKey.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to uninstall currently. Please restart Optikey and try again..
+        /// </summary>
+        public static string UNABLE_UNINSTALL {
+            get {
+                return ResourceManager.GetString("UNABLE_UNINSTALL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall.
+        /// </summary>
+        public static string UNINSTALL {
+            get {
+                return ResourceManager.GetString("UNINSTALL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Something went wrong, but I don&apos;t know what - please check the logs.
         /// </summary>
         public static string UNKNOWN_CALIBRATION_ERROR {
@@ -6485,6 +6739,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string UPDATE_AVAILABLE {
             get {
                 return ResourceManager.GetString("UPDATE_AVAILABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upgrade.
+        /// </summary>
+        public static string UPGRADE {
+            get {
+                return ResourceManager.GetString("UPGRADE", resourceCulture);
             }
         }
         
@@ -6611,6 +6874,15 @@ namespace JuliusSweetland.OptiKey.Properties {
         public static string VERSION_DESCRIPTION {
             get {
                 return ResourceManager.GetString("VERSION_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version installed.
+        /// </summary>
+        public static string VERSION_INSTALLED {
+            get {
+                return ResourceManager.GetString("VERSION_INSTALLED", resourceCulture);
             }
         }
         

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -535,7 +535,8 @@ UP</value>
     <value>Key text transformation:</value>
   </data>
   <data name="COMPLETION_TIMES_HINT" xml:space="preserve">
-    <value>Enter multiple values separated by commas to speed up/slow down subsequent selections, for example: 1250,750,450,250</value>
+    <value>Enter multiple values separated by commas to speed up/slow down subsequent selections.
+For example: 1250,750,450,250</value>
   </data>
   <data name="KEY_FIXATION_TIME_TO_COMPLETE_LABEL" xml:space="preserve">
     <value>Time to complete and repeat a key (ms):</value>
@@ -2502,5 +2503,96 @@ www.optikey.org/supported-eyetrackers</value>
   </data>
   <data name="REPEAT_SOUND_LABEL" xml:space="preserve">
     <value>Repeat last key:</value>
+  </data>
+  <data name="EYETRACKER_DLL_LOCATION_LABEL" xml:space="preserve">
+    <value>DLL file for eye tracker plugin</value>
+  </data>
+  <data name="EXTERNAL_EYETRACKER_DLL" xml:space="preserve">
+    <value>External eye tracker via DLL plugin</value>
+  </data>
+  <data name="EYETRACKER_DLL_NOT_FOUND" xml:space="preserve">
+    <value>Eyetracker DLL file was not found</value>
+  </data>
+  <data name="EYETRACKER_DLL_NOT_VALID" xml:space="preserve">
+    <value>Eyetracker DLL file is not valid</value>
+  </data>
+  <data name="ERROR_LOADING_INPUT_SERVICE" xml:space="preserve">
+    <value>Failed to load input service</value>
+  </data>
+  <data name="EYETRACKER_DLL_INSTALLED_BUT_NOT_INSTANTIATED" xml:space="preserve">
+    <value>Plugin has been installed, but Optikey was unable to start it. Check the log for details. </value>
+  </data>
+  <data name="MANAGE_ET_PLUGINS" xml:space="preserve">
+    <value>Manage eye tracker plugins</value>
+  </data>
+  <data name="AVAILABLE_EYETRACKER_PLUGINS" xml:space="preserve">
+    <value>Available eyetracker plugins</value>
+  </data>
+  <data name="INSTALLED_PLUGINS" xml:space="preserve">
+    <value>Installed plugins</value>
+  </data>
+  <data name="FROM_GITHUB_COLON" xml:space="preserve">
+    <value>From GitHub:</value>
+  </data>
+  <data name="OTHERS_COLON" xml:space="preserve">
+    <value>Others:</value>
+  </data>
+  <data name="AVAILABLE_FROM_GITHUB" xml:space="preserve">
+    <value>Available from GitHub</value>
+  </data>
+  <data name="PLUGIN_SEARCH_WIZARD" xml:space="preserve">
+    <value>Plugin search wizard</value>
+  </data>
+  <data name="OPEN_CONTAINING_FOLDER" xml:space="preserve">
+    <value>Open Containing Folder</value>
+  </data>
+  <data name="INSTALL" xml:space="preserve">
+    <value>Install</value>
+  </data>
+  <data name="UPGRADE" xml:space="preserve">
+    <value>Upgrade</value>
+  </data>
+  <data name="UNINSTALL" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="STARS" xml:space="preserve">
+    <value>stars</value>
+  </data>
+  <data name="LATEST_RELEASE_AVAILABLE" xml:space="preserve">
+    <value>Latest release available</value>
+  </data>
+  <data name="VERSION_INSTALLED" xml:space="preserve">
+    <value>Version installed</value>
+  </data>
+  <data name="FOUND_IN" xml:space="preserve">
+    <value>found in</value>
+  </data>
+  <data name="ERROR_UNINSTALLING_PLUGIN" xml:space="preserve">
+    <value>Error uninstalling plugin</value>
+  </data>
+  <data name="NO_VALID_DLL_FOUND" xml:space="preserve">
+    <value>Could not find valid eyetracker plugin (DLL) file</value>
+  </data>
+  <data name="CONFIRM_UNINSTALL" xml:space="preserve">
+    <value>Confirm Uninstall</value>
+  </data>
+  <data name="ASK_CONFIRM_UNINSTALL" xml:space="preserve">
+    <value>Are you sure you want to remove all versions in:</value>
+  </data>
+  <data name="UNABLE_UNINSTALL" xml:space="preserve">
+    <value>Unable to uninstall currently. Please restart Optikey and try again.</value>
+  </data>
+  <data name="FILES_LOCKED" xml:space="preserve">
+    <value>Files locked</value>
+  </data>
+  <data name="CHANGE_EYETRACKER_CAPTION" xml:space="preserve">
+    <value>Change points source?</value>
+  </data>
+  <data name="CHANGE_EYETRACKER_DETAILS" xml:space="preserve">
+    <value>Do you want to use the newly installed plugin ({0}) as your points source?</value>
+  </data>
+  <data name="NO_EYETRACKER_PLUGINS" xml:space="preserve">
+    <value>No eye tracker plugins found.
+Check your internet connection and wait a few minutes to rescan.</value>
   </data>
 </root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Settings.cs
@@ -238,6 +238,22 @@ namespace JuliusSweetland.OptiKey.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
+        public string EyeTrackerDllFilePath
+        {
+            get
+            {
+                return ((string)(this["EyeTrackerDllFilePath"]));
+            }
+            set
+            {
+                this["EyeTrackerDllFilePath"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("MousePosition")]
         [global::System.Configuration.SettingsManageabilityAttribute(global::System.Configuration.SettingsManageability.Roaming)]
         public global::JuliusSweetland.OptiKey.Enums.PointsSources PointsSource {

--- a/src/JuliusSweetland.OptiKey.Core/Resources/Themes/EyeTrackerPluginsTheme.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/Resources/Themes/EyeTrackerPluginsTheme.xaml
@@ -1,0 +1,33 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:JuliusSweetland.OptiKey.Resources.Themes">
+    <!-- this template is required to ensure scrolling is captured by outer scrollviewer, not individual listboxes -->
+    <Style TargetType="ListBox">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ItemsControl">
+                    <Border>
+                        <ItemsPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!-- this is the style for all list boxes -->
+    <Style x:Key="ListBoxStyle" TargetType="ListBoxItem">
+        <Setter Property="Margin" Value="10,0,10,10" />
+        <Style.Triggers>
+            <Trigger Property="ItemsControl.AlternationIndex" Value="0">
+                <Setter Property="Background" Value="#FFF6F6F6" />
+            </Trigger>
+            <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                <Setter Property="Background" Value="#FFFFFFFF" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <!-- this is the style for all buttons -->
+    <Style x:Key="ButtonStyle" TargetType="Button">
+        <Setter Property="Margin" Value="0,3,0,3"/>
+        <Setter Property="Padding" Value="3"/>
+    </Style>
+</ResourceDictionary>

--- a/src/JuliusSweetland.OptiKey.Core/Services/IAudioService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IAudioService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 using System;
 using System.Collections.Generic;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Services
 {

--- a/src/JuliusSweetland.OptiKey.Core/Services/IDictionaryService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IDictionaryService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Contracts;
 using System;
 using System.Collections.Generic;
 using System.Reactive;

--- a/src/JuliusSweetland.OptiKey.Core/Services/IInputService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IInputService.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Services
 {

--- a/src/JuliusSweetland.OptiKey.Core/Services/IPublishService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IPublishService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 using System.Windows;
 using WindowsInput.Native;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Services
 {

--- a/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/IWindowManipulationService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Windows;
 using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Services
 {

--- a/src/JuliusSweetland.OptiKey.Core/Services/InputService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/InputService.cs
@@ -8,6 +8,7 @@ using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
 using JuliusSweetland.OptiKey.Observables.TriggerSources;
+using JuliusSweetland.OptiKey.Contracts;
 using log4net;
 using Prism.Mvvm;
 

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/DllLoader.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/DllLoader.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using log4net;
+using System.Reflection;
+using System.IO;
+using JuliusSweetland.OptiKey.Contracts;
+
+namespace JuliusSweetland.OptiKey.Services.PluginEngine
+{
+    // These methods run in non-standard AppDomains
+    // MarshalByRefObject allows this to be used across AppDomains 
+    public class AssemblyLoader : MarshalByRefObject
+    {
+        private Type TypeToLoad = typeof(IPointService);
+
+        public Type LoadAssemblyAndFindType(string dllFilePath)
+        {
+            try
+            {
+                Assembly assembly = Assembly.LoadFrom(dllFilePath);
+                var types = assembly.GetTypes();
+                foreach (var t in types)
+                {
+                    var i = t.GetInterfaces();
+                }
+                return types.FirstOrDefault(t => t.GetInterfaces().Contains(TypeToLoad));
+            }
+            catch (Exception e)
+            {
+                // ?? can't log this
+                int a = 1;
+                return null;
+            }
+        }
+
+        public bool LoadAssemblyAndConfirmType(string assemblyPath)
+        {
+            return LoadAssemblyAndFindType(assemblyPath) != null;
+        }
+    }
+
+    /** This class handles 
+     *  - testing DLL files in a separate AppDomain 
+     *  - finding type info 
+     *  - instantiating plugin classes
+     */
+    static class DllLoader
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        #region Handling temporary domain 
+
+        // AppDomain is reused, but can be reset when we need to release the lock on DLL files that
+        // have been tested
+        private static string DOMAIN_NAME = "EyeTrackerPluginsDomain";
+        private static AppDomain temporaryDomain = null;
+
+        public static void ResetTempDomain()
+        {
+            if (temporaryDomain != null)
+            {
+                AppDomain.Unload(temporaryDomain);
+                temporaryDomain = null;
+            }
+        }
+
+        
+
+        private static AppDomain GetTempDomain()
+        {
+            DllLoader.ResetTempDomain();
+
+            if (temporaryDomain == null)
+            {
+                var domainSetup = new AppDomainSetup { ApplicationBase = AppDomain.CurrentDomain.BaseDirectory };
+                temporaryDomain = AppDomain.CreateDomain(DOMAIN_NAME, null, domainSetup);
+                temporaryDomain.UnhandledException += (sender, args) =>
+                    {
+                        Log.Error("An UnhandledException has been encountered...", args.ExceptionObject as Exception);
+                    };
+            }
+            return temporaryDomain;
+        }
+
+        #endregion
+
+        #region Utility methods for loading files
+
+        public static List<string> FindValidDlls(string basePath)
+        {
+            if (!Directory.Exists(basePath))
+            {
+                return new List<string>();
+            }
+
+            var dllFiles = Directory.GetFiles(basePath, "*.dll", SearchOption.AllDirectories);
+            var validFiles = dllFiles.Where(file => DllLoader.IsValidPlugin(file)).ToList();
+
+            // Reset lock on files
+            DllLoader.ResetTempDomain();
+
+            return validFiles;
+        }
+
+        public static bool IsValidPlugin(string dllFilePath)
+        {
+            Log.Debug($"Testing DLL file: { dllFilePath }");
+
+            try
+            {
+                // Create the loader (a proxy) in the new AppDomain
+                var assemblyLoader = (AssemblyLoader)DllLoader.GetTempDomain().CreateInstanceAndUnwrap(
+                    typeof(AssemblyLoader).Assembly.FullName,
+                    typeof(AssemblyLoader).FullName);
+
+                bool available = assemblyLoader.LoadAssemblyAndConfirmType(dllFilePath);
+                DllLoader.ResetTempDomain();
+                return available;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug($"Error trying to load {dllFilePath}: {ex}");
+                return false;
+            }
+        }
+
+        // Return PointService if available + error string if not
+        public static Tuple<IPointService, string> TryInstantiatePointSource(string dllFilePath)
+        {
+            string baseFileName = Path.GetFileName(dllFilePath);
+
+            string errorString = null;
+            Type typeToLoad = null;
+            IPointService dllService = null;
+
+            // Try to identify the available implementation
+            try
+            {
+                Assembly assembly = Assembly.LoadFrom(dllFilePath);
+                typeToLoad = assembly.GetTypes().FirstOrDefault(t => t.GetInterfaces().Contains(typeof(IPointService)));
+                if (typeToLoad == null)
+                {
+                    Log.Error($"No IPointService implementation found in {baseFileName}");
+                }
+            }
+            catch (Exception e) {
+                errorString = OptiKey.Properties.Resources.EYETRACKER_DLL_NOT_VALID;
+
+                Log.Error($"Exception trying to load {baseFileName}");
+                Log.Error(e);
+            }
+
+            // Instantiate it 
+            if (typeToLoad != null)
+            {
+                try
+                {
+                    dllService = (IPointService)Activator.CreateInstance(typeToLoad);
+                }
+                catch (Exception e) {
+                    errorString = OptiKey.Properties.Resources.EYETRACKER_DLL_INSTALLED_BUT_NOT_INSTANTIATED;
+
+                    Log.Error($"Exception trying to instantiate { typeToLoad } from {baseFileName}");
+                    Log.Error(e);
+                }
+            }
+            return new Tuple<IPointService, string>(dllService, errorString);
+        }
+
+        #endregion
+
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/EyeTrackerPluginEngine.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/EyeTrackerPluginEngine.cs
@@ -1,0 +1,515 @@
+﻿using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+using System.IO;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Net;
+using Prism.Commands;
+using System.Windows;
+using JuliusSweetland.OptiKey.Extensions;
+using System.IO.Compression;
+using Prism.Mvvm;
+using JuliusSweetland.OptiKey.Properties;
+
+namespace JuliusSweetland.OptiKey.Services.PluginEngine
+{
+    // This class is a ViewModel that contains the logic for presenting available
+    // eye tracker plugins to the user. 
+    public partial class EyeTrackerPluginEngine : BindableBase
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private string _topic;
+        private InstalledPluginsSearch installedPlugins;
+        private GithubPluginsSearch githubPlugins = GithubPluginsSearch.Instance;
+
+        public DelegateCommand<GithubRepoModel> InstallCommand { get; private set; }
+        public DelegateCommand<GithubRepoModel> UninstallCommand { get; private set; }
+        public DelegateCommand<LocalPluginModel> OpenDirectoryCommand { get; private set; }
+
+        //fixme: add IsSearching (or Loading?) property hooked up to GH plugins search
+
+        #region Constructor
+
+        public EyeTrackerPluginEngine()
+        {
+            // Delegates for button handling            
+            InstallCommand = new DelegateCommand<GithubRepoModel>(Install);
+            UninstallCommand = new DelegateCommand<GithubRepoModel>(Uninstall);
+            OpenDirectoryCommand = new DelegateCommand<LocalPluginModel>(OpenDirectory);
+
+            // Initialise lists and listeners
+            locallyInstalledPlugins = new ObservableCollection<LocalPluginModel>();
+            githubPluginsInstalled = new ObservableCollection<GithubRepoModel>();
+            githubPluginsAvailable = new ObservableCollection<GithubRepoModel>();
+
+            if (!githubPlugins.IsLoaded)
+            {
+                githubPlugins.Loaded += (s, e) => 
+                {
+                    Refresh();
+                    RaisePropertyChanged("IsSearching");
+                };
+            }
+            
+            Refresh();
+        }
+
+        private void GithubPlugins_Loaded(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region Public properties
+
+        public bool IsSearching {
+            get { return !githubPlugins.IsLoaded; }
+        }
+
+        public GithubRepoModel MostRecentlyInstalledDll
+        {
+            get; set;
+        }
+
+        public List<KeyValuePair<string, string>> AllSourcesAvailable
+        {
+            get
+            {
+                var allRepos = new List<KeyValuePair<string, string>>();
+
+                // Add entries from Repositories
+                foreach (var repo in Repositories.Values)
+                {
+                    if (repo.InstallStatus != PluginInstallStatus.NotInstalled)
+                    {
+                        var repoKey = PluginUtils.GetRepoKey(repo);
+                        allRepos.Add(new KeyValuePair<string, string>(repoKey, repo.InstalledDllPath));
+                    }
+                }
+
+                // Add entries from LocalPlugins
+                foreach (var plugin in LocallyInstalledPlugins)
+                {
+                    var fileName = Path.GetFileNameWithoutExtension(plugin.FilePathDLL);
+                    allRepos.Add(new KeyValuePair<string, string>(plugin.UserFacingName, plugin.FilePathDLL));
+                }
+
+                return allRepos;
+            }
+        }
+
+        public Dictionary<string, GithubRepoModel> Repositories
+        {
+            get { return githubPlugins.Repositories; }
+        }
+
+        public ObservableCollection<LocalPluginModel> LocalPlugins
+        {
+            get { return installedPlugins.Repositories; }
+        }
+
+        public bool HasLocalPlugins
+        {
+            get { return locallyInstalledPlugins.Count > 0; }
+        }
+
+        public bool HasGithubPluginsInstalled
+        {
+            get { return githubPluginsInstalled.Count > 0; }
+        }
+
+        public bool HasGithubPluginsAvailable
+        {
+            get { return githubPluginsAvailable.Count > 0; }
+        }
+
+        ObservableCollection<LocalPluginModel> locallyInstalledPlugins;
+        public ObservableCollection<LocalPluginModel> LocallyInstalledPlugins
+        {
+            get { return locallyInstalledPlugins; }
+            set { SetProperty(ref locallyInstalledPlugins, value); }
+        }
+
+        ObservableCollection<GithubRepoModel> githubPluginsInstalled;
+        public ObservableCollection<GithubRepoModel> GithubPluginsInstalled
+        {
+            get { return githubPluginsInstalled; }
+            set { SetProperty(ref githubPluginsInstalled, value); }
+        }
+
+        ObservableCollection<GithubRepoModel> githubPluginsAvailable;
+        public ObservableCollection<GithubRepoModel> GithubPluginsAvailable
+        {
+            get { return githubPluginsAvailable; }
+            set { SetProperty(ref githubPluginsAvailable, value); }
+        }
+
+        #endregion
+
+        public static string GetTopLevelPluginDirectory()
+        {
+            string ApplicationDataSubPath = @"OptiKey\OptiKey";
+
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                                ApplicationDataSubPath,
+                                "EyeTrackerPlugins");
+        }
+
+        /* Go through the list of available plugins on GitHub, and the DLLs that have been
+         * found on the file system, and pair them up to consolidate list of "installed" and "available"
+         * plugins
+         */
+        public void Refresh()
+        {
+            // Find locally available ones            
+            installedPlugins = new InstalledPluginsSearch();
+
+            // Clear previous cache
+            locallyInstalledPlugins.Clear();
+            githubPluginsInstalled.Clear();
+            githubPluginsAvailable.Clear();
+
+            // Reset the install state of github plugins
+            foreach (GithubRepoModel githubRepo in githubPlugins.Repositories.Values)
+            {
+                githubRepo.InstallStatus = PluginInstallStatus.NotInstalled;
+            }
+
+            // Figure out which of the files found locally correspond to github repos       
+            foreach (LocalPluginModel localRepo in installedPlugins.Repositories)
+            {
+                //var parts = 
+                string[] pathParts = localRepo.FolderName.Split(Path.DirectorySeparatorChar);
+                bool foundRepo = false;
+                if (pathParts.Length >= 2)
+                {
+                    string key = PluginUtils.GetRepoKey(pathParts[0], pathParts[1]);
+                    if (githubPlugins.Repositories.ContainsKey(key))
+                    {
+                        var githubRepo = githubPlugins.Repositories[key];
+                        githubRepo.InstalledDllPath = Path.Combine(GetTopLevelPluginDirectory(),
+                                                                   localRepo.FolderName,
+                                                                   localRepo.FilePathDLL);
+
+                        // We may get here multiple times, for multiple version subfolders.
+                        // So we need to update our belief of installed status as we go along
+                        if (githubRepo.InstallStatus != PluginInstallStatus.UpToDate)
+                        {
+                            // Is it the latest?
+                            if (pathParts.Length >= 3 && pathParts[2] == githubRepo.LatestRelease.TagName)
+                            {
+                                githubRepo.InstallStatus = PluginInstallStatus.UpToDate;
+                                githubRepo.InstalledReleaseName = githubRepo.LatestRelease.TagName;
+                            }
+                            else if (githubRepo.InstallStatus != PluginInstallStatus.UpToDate &&
+                                pathParts.Length >= 3)
+                            {
+                                githubRepo.InstallStatus = PluginInstallStatus.UpgradeAvailable;
+
+                                // see if this is a more up to date version that whatever we've already found
+                                var tag = pathParts[2];
+                                int indexThisTag = githubRepo.AllReleases.FindIndex(release => release.TagName == tag);
+                                int indexExistingTag = githubRepo.AllReleases.FindIndex(release => release.TagName == githubRepo.InstalledReleaseName);
+
+                                if (indexExistingTag == -1 ||
+                                    (indexThisTag != -1 && indexThisTag < indexExistingTag))
+                                {
+                                    githubRepo.InstalledReleaseName = tag;
+                                }
+                            }
+                            else
+                            {
+                                githubRepo.InstalledReleaseName = "unknown";
+                            }
+                        }
+
+                        foundRepo = true;
+                    }
+                }
+                if (!foundRepo)
+                {
+                    locallyInstalledPlugins.Add(localRepo);
+                }
+            }
+
+            // Create list of unique local plugins (having consolidated multiple versions of same github rep[)
+
+            // Figure out which of the github repos are installed or not
+            foreach (GithubRepoModel githubRepo in githubPlugins.Repositories.Values)
+            {
+                switch (githubRepo.InstallStatus)
+                {
+                    case PluginInstallStatus.UpToDate:
+                    case PluginInstallStatus.UpgradeAvailable:
+                        githubPluginsInstalled.Add(githubRepo);
+                        break;
+                    case PluginInstallStatus.NotInstalled:
+                        githubPluginsAvailable.Add(githubRepo);
+                        break;
+                }
+            }
+
+            RaisePropertyChanged("HasGithubPluginsAvailable");
+            RaisePropertyChanged("HasGithubPluginsInstalled");
+            RaisePropertyChanged("HasLocalPlugins");
+
+            // Release any file locks
+            DllLoader.ResetTempDomain();
+        }
+
+        #region UI-driven commands and associated utils
+
+        private void OpenDirectory(LocalPluginModel plugin)
+        {
+            //var folderName = plugin.FolderName.Replace('/', Path.DirectorySeparatorChar); //fixme: can we do away with this? choose key better
+            var path = Path.Combine(GetTopLevelPluginDirectory(), plugin.FolderName);
+
+            Process.Start(new ProcessStartInfo()
+            {
+                FileName = "explorer.exe",
+                Arguments = path,
+                UseShellExecute = true
+            });
+        }
+
+        private string GetInstallFolderName(GithubRepoModel repo, bool includeVersionTag = true)
+        {
+            List<string> paths = new List<string>
+            {
+                GetTopLevelPluginDirectory(),
+                repo.Owner,
+                repo.Name
+            };
+
+            if (includeVersionTag)
+                paths.Add(repo.LatestRelease.TagName);
+
+            return Path.Combine(paths.ToArray());
+        }
+
+        private void EnsureExists(string folderName)
+        {
+            if (!Directory.Exists(folderName))
+            {
+                Directory.CreateDirectory(folderName);
+            }
+        }
+
+        private static void ShowMessage(string errorMessage)
+        {
+            MessageBox.Show(errorMessage,
+                "Error downloading plugin",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Asterisk);
+        }
+
+        private void Uninstall(GithubRepoModel repo)
+        {
+            // We will uninstall all versions
+            var folderName = GetInstallFolderName(repo, false);
+
+            if (Directory.Exists(folderName))
+            {
+                // Check if deleteable (it might not be, if loaded by current AppDomain)
+                if (new FileInfo(repo.InstalledDllPath).IsLocked())
+                {
+                    MessageBox.Show(Resources.UNABLE_UNINSTALL,
+                    Resources.FILES_LOCKED,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                }
+                else
+                {
+                    // Confirm the uninstallation                
+                    var result = MessageBox.Show($"{Resources.ASK_CONFIRM_UNINSTALL}\n\n{folderName}",
+                        Resources.CONFIRM_UNINSTALL,
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Warning);
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        // Release the AppDomain that has been used for loading DLL files, otherwise we find
+                        // files are locked
+                        DllLoader.ResetTempDomain();
+
+                        // Recursively delete all files and subdirectories
+                        DeleteDirectory(folderName);
+
+                        // Make sure not in "most recently installed"
+                        if (MostRecentlyInstalledDll != null &&
+                            MostRecentlyInstalledDll.InstalledDllPath == repo.InstalledDllPath)
+                            MostRecentlyInstalledDll = null;
+
+                        // Remove parent directory if it was left empty
+                        var parentDirectory = System.IO.Directory.GetParent(folderName).FullName;
+                        if (!Directory.EnumerateFileSystemEntries(parentDirectory).Any())
+                        {
+                            DeleteDirectory(parentDirectory);
+                        }
+
+                        Refresh();
+                    }
+                }
+            }
+        }
+
+        private static void DeleteDirectory(string targetDir)
+        {
+            try
+            {
+                Directory.Delete(targetDir, true);
+            }
+            catch (Exception e)
+            {
+                ShowMessage($"{Resources.ERROR_UNINSTALLING_PLUGIN}\n{e}");
+
+                Log.Error($"Error deleting directory: {targetDir}");
+                Log.Error(e);
+            }
+        }        
+
+        private void Install(GithubRepoModel repo)
+        {
+            var folderName = GetInstallFolderName(repo);
+
+            EnsureExists(folderName);
+
+            // The payload is a ZIP file
+            // so we'll download to TMP and then extract into APPDATA
+
+            var uri = new Uri(repo.LatestRelease.AssetsUrl);
+            string sourceFilePath = System.IO.Path.GetFileName(uri.LocalPath);
+            string tempFilePath = Path.Combine(System.IO.Path.GetTempPath(), sourceFilePath);
+            string destFilePath = Path.GetFileNameWithoutExtension(Path.Combine(folderName, sourceFilePath));
+
+            // We'll download the content asynchronously with a progress bar
+            WebClient client = new WebClient();
+            client.DownloadProgressChanged += (s, ev) =>
+            {
+                repo.DownloadProgress = Math.Max(ev.ProgressPercentage, 90); // save some 'progress' for unzipping etc
+            };
+
+            client.DownloadFileCompleted += (s, ev) =>
+            {
+                repo.DownloadProgress = 95;
+
+                // Extract the ZIP file
+                try
+                {
+                    if (ev.Error == null && !ev.Cancelled)
+                    {
+                        using (ZipArchive archive = ZipFile.Open(tempFilePath, ZipArchiveMode.Read, Encoding.UTF8))
+                        {
+                            archive.ExtractToDirectory(folderName, true);
+                            Log.Debug($"Downloaded plugin and extracted to {folderName}");
+                            var result = TestNewInstall(folderName, repo);
+                            var success = result.Item1;
+                            var filename = result.Item2;
+
+                            // If fully successfully, we can coerce this choice later
+                            if (success)
+                            {
+                                repo.InstalledDllPath = filename;
+                                MostRecentlyInstalledDll = repo;
+                            }
+                            else
+                            {
+                                MostRecentlyInstalledDll = null;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        ShowMessage(ev.Error.Message);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ShowMessage(ex.Message);
+                }
+                finally
+                {
+                    try
+                    {
+                        File.Delete(tempFilePath);
+                    }
+                    catch
+                    {
+                        Log.Error($"Unable to delete temporary file {tempFilePath}");
+                    }
+                    repo.DownloadProgress = 100;
+                    Refresh();
+                }
+            };
+
+            try
+            {
+                client.DownloadFileAsync(uri, tempFilePath);
+            }
+            catch (Exception ex)
+            {
+                ShowMessage(ex.Message);
+            }
+            finally
+            {
+                Refresh();
+            }
+        }
+        
+        private Tuple<bool, string> TestNewInstall(string folderName, GithubRepoModel repo)
+        {
+            bool success = false;
+            string dllFilename = null;
+
+            // Is there an appropriate DLL available?
+            List<string> dlls = DllLoader.FindValidDlls(folderName);            
+            if (dlls.Count > 0)
+            {
+                dllFilename = dlls[0];
+            }
+            else
+            {
+                Log.Info($"No valid DLL file was found in {folderName}");
+                ShowMessage(Resources.NO_VALID_DLL_FOUND);
+                return new Tuple<bool, string>(false, null);
+            }
+
+            // Can we instantiate it okay?            
+            DllLoader.ResetTempDomain(); // release lock so we can load same file in main appdomain
+
+            var dllServiceAndErrorString = DllLoader.TryInstantiatePointSource(dlls[0]);
+            var dllService = dllServiceAndErrorString.Item1;
+            var errorMsg = dllServiceAndErrorString.Item2;
+            
+            //fixme: if we could instantiate in temp domain, would be better, otherwise it stays locked
+            // but when we actually use it, it will be in main AppDomain, so might not be appropriate test
+
+            if (dllService == null) {
+                Log.Info($"Couldn't instantiate pointsource from {dlls[0]}");
+                ShowMessage(errorMsg);
+                success = false;
+            }
+            else
+            {
+                // Dispose it properly - we are not using it now
+                if (dllService is IDisposable)
+                {
+                    var disposable = (IDisposable)dllService;
+                    disposable.Dispose();
+                }
+                success = true;
+            }
+            return new Tuple<bool, string>(success, dllFilename);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/GithubPluginsSearch.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/GithubPluginsSearch.cs
@@ -1,0 +1,249 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Prism.Mvvm;
+using System.Net.Http;
+using log4net;
+using System.Reflection;
+
+namespace JuliusSweetland.OptiKey.Services.PluginEngine
+{
+    // This class queries github to find any repos advertising support for Optikey
+    // (tag = "optikey-plugins")
+    // Due to a small public rate limit on the github API, the results are cached in
+    // a file between instantiations, and on construction we attempt to refresh but
+    // fall back to the previous results if we hit a limit.
+    public class GithubPluginsSearch : BindableBase
+    {
+        // static instance means we can trigger the class to be instantiated and loaded at startup, but 
+        // don't need to pass around the object.
+        private static readonly Lazy<GithubPluginsSearch> instance =
+            new Lazy<GithubPluginsSearch>(() => new GithubPluginsSearch());
+        public static GithubPluginsSearch Instance { get { return instance.Value; } }
+
+        #region Private members
+
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private readonly GitHubClient _github;
+        private const string topic = "optikey-plugin";
+        private Dictionary<string, GithubRepoModel> _cachedRepositories;
+
+        #endregion
+
+        #region Public properties
+
+        private Dictionary<string, GithubRepoModel> _availableRepositories;
+        public Dictionary<string, GithubRepoModel> Repositories
+        {
+            get { return _availableRepositories; }
+            set { SetProperty(ref _availableRepositories, value); }
+        }
+
+        private bool _isLoaded = false;
+        public bool IsLoaded
+        {
+            get { return _isLoaded; }
+            set
+            {
+                _isLoaded = true;
+                if (_isLoaded)
+                {
+                    Loaded?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        public event EventHandler Loaded;
+
+        #endregion
+
+        public GithubPluginsSearch()
+        {
+            string token = null; 
+            if (!String.IsNullOrEmpty(token))
+            {
+                _github = new GitHubClient(new ProductHeaderValue("OptiKey"))
+                {
+                    Credentials = new Credentials(token)
+                };
+            }
+            else
+            {
+                _github = new GitHubClient(new ProductHeaderValue("OptiKey"));
+            }        
+
+            _cachedRepositories = DeserializeRepositoriesFromFile() ?? new Dictionary<string, GithubRepoModel>();
+            _availableRepositories = new Dictionary<string, GithubRepoModel>();
+        }
+
+        public async Task TryLoad(int attempts, int delaySeconds)
+        {
+            for (int i =0; i < attempts; i++)
+            {
+                try {
+                    await this.Load();
+                    break;
+                }
+                catch (HttpRequestException)
+                {
+                    // We get this if no network connection
+                    Log.Error("Unable to connect to GitHub API to search for eye tracker plugins");
+                }
+                catch (Exception otherException)
+                {
+                    Log.Error("Exception trying to query github API for eyetracker plugins");
+                    Log.Error($"{otherException.GetType()}: {otherException}");                    
+                }
+
+                // Wait and try again later
+                await Task.Delay(1000 * delaySeconds);
+            }
+        }
+
+        public async Task Load()
+        {           
+            // Initially load up the repos from previous cache - we'll update any if we find new info
+            foreach (var item in _cachedRepositories)
+            {
+                var repo = item.Value;
+                if (repo.AllReleases.Count > 0)
+                {
+                    Repositories[item.Key] = repo;
+                }
+            }
+
+            var searchRequest = new SearchRepositoriesRequest($"topic:{topic}")
+            {
+                Page = 1,
+                PerPage = 100
+            };
+            
+            var result = await _github.Search.SearchRepo(searchRequest);
+
+            // First query any new repos, then 
+            // existing repos - most stale first.
+            foreach (var item in result.Items.OrderBy(item =>
+                _availableRepositories.ContainsKey(PluginUtils.GetRepoKey(item.Owner.Login, item.Name)) ?
+                _availableRepositories[PluginUtils.GetRepoKey(item.Owner.Login, item.Name)].QueriedAt :
+                DateTime.MinValue))
+            {
+                string key = PluginUtils.GetRepoKey(item.Owner.Login, item.Name);
+                try
+                {
+                    var releases = await _github.Repository.Release.GetAll(item.Owner.Login, item.Name);
+
+                    // Filter for prereleases and order them by creation date                   
+                    var orderedPreReleases = releases.Where(r => !r.Prerelease)
+                                                     .OrderBy(r => r.CreatedAt)
+                                                     .ToList();
+
+                    // Find any ZIP assets - these are the only releases we care about
+                    List<ReleaseInfo> allReleases = new List<ReleaseInfo>();
+                    foreach (var release in orderedPreReleases)
+                    {
+                        ReleaseInfo info = ReleaseInfoFromGH(release);
+                        if (info != null)
+                            allReleases.Add(info);
+                    }
+
+
+                    ReleaseInfo latestRelease = null;
+                    if (allReleases.Count > 0)
+                    {
+                        // Separately query the "Latest" release - this has particular semantic meaning outside of datetimes
+                        var latest = await _github.Repository.Release.GetLatest(item.Owner.Login, item.Name);
+                        latestRelease = ReleaseInfoFromGH(latest);
+                    }
+
+                    // Make a repo data structure
+                    var repository = new GithubRepoModel
+                    {
+                        Name = item.Name,
+                        Description = item.Description,
+                        HtmlUrl = item.HtmlUrl,
+                        Owner = item.Owner.Login,
+                        Stars = item.StargazersCount,
+                        AllReleases = allReleases,
+                        LatestRelease = latestRelease,
+                        QueriedAt = DateTime.Now
+                    };
+
+                    // Only include in our user-facing list if there's a release to download
+                    if (repository.AllReleases.Count > 0)
+                    {
+                        _availableRepositories[key] = repository;
+                    }
+
+                    // Include in our cache regardless.
+                    // This means that in the event there are lots of repos with the right tag
+                    // but without releases/ZIPs then we don't waste API quota on re-querying 
+                    // them until after we've looked for new ones. 
+                    _cachedRepositories[key] = repository;
+
+                }
+                catch (RateLimitExceededException)
+                {
+                    Log.Info("Rate limit exceeded while querying github for plugins");
+                }
+            }
+
+            SerializeRepositoriesToFile();
+
+            IsLoaded = true;
+        }        
+
+        #region Private methods
+
+        private ReleaseInfo ReleaseInfoFromGH(Release release)
+        {
+            ReleaseInfo info = null;
+
+            var zipAsset = release.Assets.Where(asset => asset.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            if (zipAsset != null)
+            {
+                info = new ReleaseInfo
+                {
+                    TagName = release.TagName,
+                    CreatedAt = zipAsset.CreatedAt.DateTime,
+                    AssetsUrl = zipAsset.BrowserDownloadUrl
+                };
+            }
+
+            return info;
+        }
+
+        private void SerializeRepositoriesToFile()
+        {
+            var jsonString = JsonConvert.SerializeObject(_cachedRepositories, Formatting.Indented);
+            File.WriteAllText(GetRepositoryInfoFileName(), jsonString);
+        }
+
+        private Dictionary<string, GithubRepoModel> DeserializeRepositoriesFromFile()
+        {
+            string filePath = GetRepositoryInfoFileName();
+            if (File.Exists(filePath))
+            {
+                var jsonString = File.ReadAllText(filePath);
+                return JsonConvert.DeserializeObject<Dictionary<string, GithubRepoModel>>(jsonString);
+            }
+            else
+            {
+                return new Dictionary<string, GithubRepoModel>();
+            }
+        }
+
+        private string GetRepositoryInfoFileName()
+        {
+            string ApplicationDataSubPath = @"OptiKey\OptiKey";
+            var appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ApplicationDataSubPath);
+            return Path.Combine(appDataPath, "repositories.json");
+        }
+
+        #endregion
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/GithubRepoModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/GithubRepoModel.cs
@@ -1,0 +1,50 @@
+﻿using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JuliusSweetland.OptiKey.Services.PluginEngine
+{
+    public enum PluginInstallStatus
+    {
+        NotInstalled = 0,
+        UpgradeAvailable,
+        UpToDate
+    }
+
+    public class ReleaseInfo
+    {
+        public string TagName { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string AssetsUrl { get; set; }
+    }
+
+    public class GithubRepoModel : BindableBase
+    {
+        // make these non mutable? would need a constructor since we can't use `init`
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string HtmlUrl { get; set; }
+        public string Owner { get; set; }
+        public int Stars { get; set; } // stars
+        public DateTime? QueriedAt { get; set; }
+        public ReleaseInfo LatestRelease { get; set; }
+        public List<ReleaseInfo> AllReleases { get; set; }
+
+        // Mutable state
+        public PluginInstallStatus InstallStatus { get; set; }
+        public string InstalledReleaseName { get; set; }
+        public string InstalledDllPath { get; set; }
+
+        // Changeable property
+        private int _downloadProgress = 0;
+        public int DownloadProgress
+        {
+            get { return _downloadProgress; }
+            set { SetProperty(ref _downloadProgress, value); }
+        }
+
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/InstalledPluginsSearch.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/InstalledPluginsSearch.cs
@@ -1,0 +1,65 @@
+﻿using log4net;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using JuliusSweetland.OptiKey.Extensions;
+
+namespace JuliusSweetland.OptiKey.Services.PluginEngine
+{
+    public class LocalPluginModel
+    {
+        public string FolderName { get; set; }
+        public string FilePathDLL { get; set; }
+        public string UserFacingName
+        {
+            get
+            {
+                return FolderName + Path.GetFileName(FilePathDLL);
+            }
+        }
+    }
+
+    public class InstalledPluginsSearch
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private ObservableCollection<LocalPluginModel> _repositories = new ObservableCollection<LocalPluginModel>();
+        public ObservableCollection<LocalPluginModel> Repositories
+        {
+            get { return _repositories; }
+        }
+
+        public InstalledPluginsSearch()
+        {
+            string folderName = EyeTrackerPluginEngine.GetTopLevelPluginDirectory();
+
+            // Find all installed plugins
+            List<string> dlls = DllLoader.FindValidDlls(folderName);
+            foreach (string dll in dlls)
+            {
+                FileInfo file = new FileInfo(dll);                
+                string relativePath = file.GetRelativePath(EyeTrackerPluginEngine.GetTopLevelPluginDirectory());
+                
+                Log.Debug($"{file.Name} from { relativePath }");
+
+                _repositories.Add(new LocalPluginModel
+                {
+                    FolderName = relativePath,
+                    FilePathDLL = file.FullName,
+                });
+                var f = Directory.GetDirectoryRoot(relativePath);
+                var a = 1;
+            }
+
+            // Release any file locks
+            DllLoader.ResetTempDomain();
+        }
+
+    }
+}
+

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/OptikeyPluginEngine.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/OptikeyPluginEngine.cs
@@ -13,7 +13,7 @@ using log4net;
 
 namespace JuliusSweetland.OptiKey.Services.PluginEngine
 {
-    public class PluginEngine
+    public class OptikeyPluginEngine
     {
 
         #region Private Member Vars

--- a/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginUtils.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PluginEngine/PluginUtils.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JuliusSweetland.OptiKey.Services.PluginEngine
+{
+    static class PluginUtils
+    {
+        // Get single unique string that combines owner and repo
+        // We'll use this as a key in dictionaries        
+        public static string GetRepoKey(string owner, string repoName)
+        {
+            return $"{owner}{Path.DirectorySeparatorChar}{repoName}";
+        }
+
+        public static string GetRepoKey(GithubRepoModel repo)
+        {
+            return GetRepoKey(repo.Owner, repo.Name);
+        }        
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/Services/PointSources/IrisBondDuoPointService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PointSources/IrisBondDuoPointService.cs
@@ -8,6 +8,7 @@ using JuliusSweetland.OptiKey.Native.Irisbond;
 using JuliusSweetland.OptiKey.Native.Irisbond.Duo;
 using JuliusSweetland.OptiKey.Native.Irisbond.Duo.Enums;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Services
 {

--- a/src/JuliusSweetland.OptiKey.Core/Services/PointSources/IrisbondHiruPointService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PointSources/IrisbondHiruPointService.cs
@@ -7,6 +7,7 @@ using log4net;
 using JuliusSweetland.OptiKey.Native.Irisbond.Hiru;
 using JuliusSweetland.OptiKey.Native.Irisbond.Hiru.Enums;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 
 namespace JuliusSweetland.OptiKey.Services
 {

--- a/src/JuliusSweetland.OptiKey.Core/Services/PointSources/TheEyeTribePointService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PointSources/TheEyeTribePointService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Reactive;
 using System.Windows;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 using log4net;
 using TETCSharpClient;
 using TETCSharpClient.Data;

--- a/src/JuliusSweetland.OptiKey.Core/Services/PointSources/TobiiPointService.cs
+++ b/src/JuliusSweetland.OptiKey.Core/Services/PointSources/TobiiPointService.cs
@@ -10,6 +10,7 @@ using System.Threading;
 
 using JuliusSweetland.OptiKey.Static;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 
 using log4net;
 using System.IO;

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/DateTimeToDateStringConverter.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/DateTimeToDateStringConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    public class DateTimeToDateStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is DateTime dateTime)
+            {
+                // Use the current culture rather than the WPF culture (which defaults to en-US and doesn't respect locale)
+                return dateTime.ToString("d", CultureInfo.CurrentCulture);
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/FileNameConverter .cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/FileNameConverter .cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    public class FileNameConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return string.Empty;
+            // Convert the full path to just the file name.
+            return Path.GetFileName(value.ToString());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/ProgressUnderwayEnabledConverter.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/ProgressUnderwayEnabledConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    // Set IsEnabled to this
+    // To disable a control when progress > 0 and < 100, i.e. underway
+    public class ProgressUnderwayDisabledConverter : System.Windows.Markup.MarkupExtension, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            int progress = 0;
+            if (value != null)
+            {
+                progress = (int)value;
+            }
+
+            if (progress > 0 && progress < 100)
+                return false;
+            else
+                return true;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/ProgressUnderwayVisibilityConverter.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/ProgressUnderwayVisibilityConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    // Set Visibility to this
+    // To make a control visible only when progress > 0 and < 100, i.e. underway
+    public class ProgressUnderwayVisibilityConverter : System.Windows.Markup.MarkupExtension, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            int progress = 0;
+            if (value != null)
+            {
+                progress = (int)value;
+            }
+
+            if (progress > 0 && progress < 100)
+                return Visibility.Visible;
+            else
+                return Visibility.Hidden;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/StringNullOrEmptyToVisibilityConverter.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/StringNullOrEmptyToVisibilityConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    public class StringNullOrEmptyToVisibilityConverter : System.Windows.Markup.MarkupExtension, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return string.IsNullOrEmpty(value as string)
+                ? Visibility.Collapsed : Visibility.Visible;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/WidthWithoutScrollbarConverter.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ValueConverters/WidthWithoutScrollbarConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace JuliusSweetland.OptiKey.UI.ValueConverters
+{
+    class WidthWithoutScrollbarConverter : IValueConverter
+    {
+        // Subtract the VerticalScrollBarWidth as well as optional extra padding as input parameter
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            double width = (double)value;
+            
+            int extraSpaceRequested = 0;
+            if (parameter != null) 
+                extraSpaceRequested = int.Parse((string)parameter);
+
+            return width - SystemParameters.VerticalScrollBarWidth - extraSpaceRequested;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.ServiceEventHandlers.cs
@@ -2840,7 +2840,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
                 DisplayPluginError("Plugins are currently disabled");
                 return;
             }
-            if (!PluginEngine.IsPluginAvailable(keyCommand.Value))
+            if (!OptikeyPluginEngine.IsPluginAvailable(keyCommand.Value))
             {
                 DisplayPluginError($"Could not find plugin {keyCommand.Value}");
                 return;
@@ -2850,7 +2850,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             Dictionary<string, string> context = BuildPluginContext();
             try
             {
-                PluginEngine.RunDynamicPlugin(context, keyCommand);
+                OptikeyPluginEngine.RunDynamicPlugin(context, keyCommand);
             }
             catch (Exception exception)
             {
@@ -2882,7 +2882,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
             {
                 XmlSerializer serializer = new XmlSerializer(typeof(XmlPluginKey));
                 StringReader rdr = new StringReader(command);
-                PluginEngine.RunPlugin_Legacy(context, (XmlPluginKey)serializer.Deserialize(rdr));
+                OptikeyPluginEngine.RunPlugin_Legacy(context, (XmlPluginKey)serializer.Deserialize(rdr));
             }
             catch (Exception exception)
             {

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/MainViewModel.cs
@@ -8,6 +8,7 @@ using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.Services.Translation;
 using JuliusSweetland.OptiKey.Static;
@@ -49,17 +50,20 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels
         private EventHandler<Tuple<TriggerTypes, PointAndKeyValue, double>> inputServiceSelectionProgressHandler;
         private EventHandler<Tuple<TriggerTypes, PointAndKeyValue>> inputServiceSelectionHandler;
         private EventHandler<Tuple<TriggerTypes, List<Point>, KeyValue, List<string>>> inputServiceSelectionResultHandler;
+
         private SelectionModes selectionMode;
         private Point currentPositionPoint;
         private KeyValue currentPositionKey;
         private Tuple<Point, double> pointSelectionProgress;
         private Dictionary<Rect, KeyValue> pointToKeyValueMap;
+
         private bool showCursor;
         private bool showCrosshair;
         private bool showMonical;
         private bool showSuggestions;
         private bool suspendCommands;
         private bool manualModeEnabled;
+
         private Action<Point> nextPointSelectionAction;
         private Point? magnifyAtPoint;
         private Action<Point?> magnifiedPointSelectionAction;

--- a/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/FeaturesViewModel.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/ViewModels/Management/FeaturesViewModel.cs
@@ -376,7 +376,7 @@ namespace JuliusSweetland.OptiKey.UI.ViewModels.Management
         {
             get
             {
-                return PluginEngine.GetAllAvailablePlugins();
+                return OptikeyPluginEngine.GetAllAvailablePlugins();
             }
         }
 

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/EyeTrackerPluginsWindow.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/EyeTrackerPluginsWindow.xaml
@@ -1,0 +1,197 @@
+﻿<mah:MetroWindow
+        x:Class="JuliusSweetland.OptiKey.UI.Views.Management.EyeTrackerPluginsWindow"
+        xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:resx="clr-namespace:JuliusSweetland.OptiKey.Properties"
+        xmlns:local="clr-namespace:JuliusSweetland.OptiKey.UI.Views.Management"
+        xmlns:valueConverters="clr-namespace:JuliusSweetland.OptiKey.UI.ValueConverters"
+        mc:Ignorable="d"            
+        Title="{x:Static resx:Resources.PLUGIN_SEARCH_WIZARD}" Height="450" Width="800">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/OptiKey;component/Resources/Themes/EyeTrackerPluginsTheme.xaml" />
+                <ResourceDictionary>
+                    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+                    <valueConverters:WidthWithoutScrollbarConverter x:Key="WidthWithoutScrollbar" />
+                    <valueConverters:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+                    <valueConverters:ProgressUnderwayVisibilityConverter x:Key="ProgressUnderwayVisibilityConverter" />
+                    <valueConverters:ProgressUnderwayDisabledConverter x:Key="ProgressUnderwayDisabledConverter" />
+                    <valueConverters:DateTimeToDateStringConverter x:Key="DateTimeToDateStringConverter"/>
+                    <valueConverters:FileNameConverter x:Key="FileNameConverter"/>
+                    <valueConverters:InvertedBoolToVisibilityConverter x:Key="InvertedBoolToVisibilityConverter" />
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+            <DataTemplate x:Key="LocalRepositoryTemplate">
+                <DockPanel Width="{Binding ActualWidth,  ElementName=scrollViewer, Converter={StaticResource WidthWithoutScrollbar}, ConverterParameter=80}">
+                    <StackPanel Orientation="Vertical" DockPanel.Dock="Right" VerticalAlignment="Center">
+                        <Button Style="{StaticResource ButtonStyle}" Content="{x:Static resx:Resources.OPEN_CONTAINING_FOLDER}" Command="{Binding DataContext.OpenDirectoryCommand, RelativeSource={RelativeSource AncestorType=ListBox}}" CommandParameter="{Binding}"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock FontSize="16" FontWeight="Bold">
+                            <Run Text="{Binding FilePathDLL, Converter={StaticResource FileNameConverter}}"/>
+                        </TextBlock>
+                        <TextBlock >
+                             <Run Text="{x:Static resx:Resources.FOUND_IN}"/>
+                             <Run Text="{Binding FolderName}"/>
+                        </TextBlock>
+                    </StackPanel>
+                </DockPanel>
+            </DataTemplate>
+            <!-- this is the template for listing github repos -->
+            <DataTemplate x:Key="GithubRepositoryTemplate">
+                <DockPanel Width="{Binding ActualWidth,  ElementName=scrollViewer, Converter={StaticResource WidthWithoutScrollbar}, ConverterParameter=80}">
+                    <StackPanel Orientation="Vertical" DockPanel.Dock="Right"  VerticalAlignment="Center">
+                        <Button                             
+                            Command="{Binding DataContext.InstallCommand, RelativeSource={RelativeSource AncestorType=ListBox}}" CommandParameter="{Binding}"
+                            IsEnabled="{Binding DownloadProgress, Converter={StaticResource ProgressUnderwayDisabledConverter}}" >
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource ButtonStyle}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Setter Property="Content" Value="{x:Static resx:Resources.INSTALL}"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding InstallStatus}" Value="UpToDate">
+                                            <Setter Property="Visibility" Value="Hidden"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding InstallStatus}" Value="UpToDate">
+                                            <Setter Property="Content" Value="{x:Static resx:Resources.INSTALL}"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding InstallStatus}" Value="UpgradeAvailable">
+                                            <Setter Property="Content" Value="{x:Static resx:Resources.UPGRADE}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+
+                        <ProgressBar Height="10" Visibility="{Binding DownloadProgress, Converter={StaticResource ProgressUnderwayVisibilityConverter}}"
+                                         Value="{Binding DownloadProgress}"/>
+
+                        <Button Content="{x:Static resx:Resources.UNINSTALL}" Padding="3" Command="{Binding DataContext.UninstallCommand, RelativeSource={RelativeSource AncestorType=ListBox}}" CommandParameter="{Binding}">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource ButtonStyle}">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding InstallStatus}" Value="NotInstalled">
+                                            <Setter Property="Visibility" Value="Hidden"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+                    </StackPanel>
+                    <StackPanel Orientation="Vertical">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.Resources>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Margin" Value="0,0,5,0"/>
+                                    <Setter Property="VerticalAlignment" Value="Center"/>
+                                </Style>
+                            </Grid.Resources>
+                            <TextBlock Grid.Column="0" FontSize="18" FontWeight="Bold">
+                                <Run Text="{Binding Name}"/>
+                            </TextBlock>
+                            <TextBlock Grid.Column="2">
+                                <Run Text="{Binding Stars}" BaselineAlignment="Center"/>
+                                <Run Text="{x:Static resx:Resources.STARS}" BaselineAlignment="Center"/>
+                            </TextBlock>
+                        </Grid>
+                        <TextBlock Text="{Binding Description}" FontSize="14" Foreground="Gray" TextWrapping="Wrap" />
+                        <TextBlock Margin="0,0,0,10">
+                            <Hyperlink NavigateUri="{Binding HtmlUrl}" RequestNavigate="Hyperlink_RequestNavigate">
+                                <Run Text="{Binding HtmlUrl}"/>
+                            </Hyperlink>
+                        </TextBlock>
+
+                        <TextBlock>
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="{}{0}: {1} ({2})">
+                                    <Binding Source="{x:Static resx:Resources.LATEST_RELEASE_AVAILABLE}"/>
+                                    <Binding Path="LatestRelease.TagName" />
+                                    <Binding Path="LatestRelease.CreatedAt" Converter="{StaticResource DateTimeToDateStringConverter}" />
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+
+                        <TextBlock>
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="{}{0}: {1}">
+                                    <Binding Source="{x:Static resx:Resources.VERSION_INSTALLED}"/>
+                                    <Binding Path="InstalledReleaseName" />
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+                    </StackPanel>
+                </DockPanel>
+            </DataTemplate>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        
+        <ProgressBar Grid.Row="0" Height="20" IsIndeterminate="{Binding IsSearching}" 
+                     Visibility="{Binding IsSearching, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+        <TextBox Text="{x:Static resx:Resources.AVAILABLE_EYETRACKER_PLUGINS}" Grid.Row="1" FontSize="24"/>
+        <ScrollViewer Grid.Row="2" Name="scrollViewer">
+            <StackPanel Name="stackPanel">
+
+                <Border Name="borderLocalPlugins" BorderBrush="Black" BorderThickness="1" CornerRadius="10" Padding="5" Margin="10" >
+                    <Border.Style>
+                        <Style TargetType="{x:Type Border}">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasGithubPluginsInstalled}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding HasLocalPlugins}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                    <StackPanel>
+                        <TextBlock Text="{x:Static resx:Resources.INSTALLED_PLUGINS}" FontSize="18" FontWeight="Bold" Padding="5,0,0,15"/>
+                        <TextBlock Text="{x:Static resx:Resources.FROM_GITHUB_COLON}" FontSize="14" Padding="10,0,0,15"/>
+                        <ListBox ItemsSource="{Binding GithubPluginsInstalled}" ItemTemplate="{StaticResource GithubRepositoryTemplate}" 
+                                 AlternationCount="2" ItemContainerStyle="{StaticResource ListBoxStyle}"/>
+                        <!-- spacer between two lists makes up for potential alternation mismatch-->
+                        <Rectangle Height="10"/>
+                        <Line Stroke="Gray" StrokeThickness="2" Opacity="0.3" X2="10000" Margin="5"/>
+                        <TextBlock Text="{x:Static resx:Resources.OTHERS_COLON}" FontSize="14" Padding="10,0,0,15"
+                            Visibility="{Binding HasLocalPlugins, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                        <ListBox ItemsSource="{Binding LocallyInstalledPlugins}" ItemTemplate="{StaticResource LocalRepositoryTemplate}" 
+            AlternationCount="2" ItemContainerStyle="{StaticResource ListBoxStyle}"/>
+                    </StackPanel>
+                </Border>
+
+                <Border Name="borderGithubAvailable" BorderBrush="Black" BorderThickness="1" CornerRadius="10" Padding="5" Margin="10">
+                    <StackPanel>
+                        <TextBlock Text="{x:Static resx:Resources.AVAILABLE_FROM_GITHUB}" FontSize="18" FontWeight="Bold" Padding="5,0,0,15"/>
+                        <ListBox Visibility="{Binding HasGithubPluginsAvailable, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                 ItemsSource="{Binding GithubPluginsAvailable}" ItemTemplate="{StaticResource GithubRepositoryTemplate}" 
+                                 AlternationCount="2" ItemContainerStyle="{StaticResource ListBoxStyle}"/>
+                        <TextBox Visibility="{Binding HasGithubPluginsAvailable, Converter={StaticResource InvertedBoolToVisibilityConverter}}"
+                                Grid.Row="1" FontSize="18" TextWrapping="Wrap" Foreground="DarkGray" 
+                                Text="{x:Static resx:Resources.NO_EYETRACKER_PLUGINS}" Panel.ZIndex="100" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        </TextBox>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</mah:MetroWindow>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/EyeTrackerPluginsWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/EyeTrackerPluginsWindow.xaml.cs
@@ -1,0 +1,36 @@
+﻿using MahApps.Metro.Controls;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace JuliusSweetland.OptiKey.UI.Views.Management
+{
+    /// <summary>
+    /// Interaction logic for EyeTrackerPluginsWindow.xaml
+    /// </summary>
+    public partial class EyeTrackerPluginsWindow : MetroWindow
+    {
+        public EyeTrackerPluginsWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            System.Diagnostics.Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
+            e.Handled = true;
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/FeaturesView.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/FeaturesView.xaml.cs
@@ -70,11 +70,11 @@ namespace JuliusSweetland.OptiKey.UI.Views.Management
 
         private void RefreshAvailablePlugins(object sender, System.Windows.RoutedEventArgs e)
         {            
-            PluginEngine.RefreshAvailablePlugins(txtPluginsLocation.Text);
+            OptikeyPluginEngine.RefreshAvailablePlugins(txtPluginsLocation.Text);
 
             // Force refresh by re-binding the CollectionView source
             // TODO: how should this be done with MVVM properly? we don't have property change notifications for the read-only list of plugins...
-            ((CollectionViewSource)this.Resources["AvailablePluginsCollectionViewSource"]).Source = PluginEngine.GetAllAvailablePlugins(); 
+            ((CollectionViewSource)this.Resources["AvailablePluginsCollectionViewSource"]).Source = OptikeyPluginEngine.GetAllAvailablePlugins(); 
         }
     }
 }

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/PointingAndSelectingView.xaml
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/PointingAndSelectingView.xaml
@@ -49,8 +49,15 @@ Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserve
                               ItemsSource="{Binding PointsSources}"
                               DisplayMemberPath="Key"
                               SelectedValuePath="Value"
-                              SelectedValue="{Binding PointsSource, Mode=TwoWay}" />
-                    
+                              SelectedValue="{Binding PointsSourceString, Mode=TwoWay}" />
+
+                    <Button Grid.Row="1" Grid.Column="1" MinWidth="100" Margin="5,5,5,5" 
+                                VerticalAlignment="Center"  
+                                HorizontalAlignment="Left"
+                                Click="OpenPluginsWindow">
+                        <x:Static Member="resx:Resources.MANAGE_ET_PLUGINS"/>
+                    </Button>
+
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static resx:Resources.IRISBOND_DATA_STREAM_PROCESSING_LEVEL}" 
                                VerticalAlignment="Center" Margin="5">
                         <TextBlock.Style>

--- a/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/PointingAndSelectingView.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Views/Management/PointingAndSelectingView.xaml.cs
@@ -1,16 +1,43 @@
 // Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+using JuliusSweetland.OptiKey.Services.PluginEngine;
+using JuliusSweetland.OptiKey.UI.ViewModels.Management;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 
 namespace JuliusSweetland.OptiKey.UI.Views.Management
 {
     /// <summary>
     /// Interaction logic for PointingAndSelectingView.xaml
     /// </summary>
-    public partial class PointingAndSelectingView : UserControl
+    public partial class PointingAndSelectingView : System.Windows.Controls.UserControl
     {
         public PointingAndSelectingView()
         {
-            InitializeComponent();
+            InitializeComponent();            
         }
+
+        void OpenPluginsWindow(object sender, RoutedEventArgs e)
+        {
+            var viewModel = this.DataContext as PointingAndSelectingViewModel;
+            if (viewModel != null)
+            {       
+                // Reset plugin engine
+                viewModel.eyeTrackerPluginEngine.MostRecentlyInstalledDll = null; // reset this state before re-use
+                viewModel.eyeTrackerPluginEngine.Refresh();
+
+                var eyeTrackerPluginsWindow = new EyeTrackerPluginsWindow();
+                eyeTrackerPluginsWindow.DataContext = viewModel.eyeTrackerPluginEngine;
+                eyeTrackerPluginsWindow.Owner = Window.GetWindow(this);
+                eyeTrackerPluginsWindow.Closing += (_, __) =>
+                {
+                    DllLoader.ResetTempDomain(); // release any locks on files
+                    viewModel.UpdatePlugins();
+                };
+                eyeTrackerPluginsWindow.ShowDialog();
+
+            }
+        }
+
     }
 }

--- a/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Core/UI/Windows/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ using JuliusSweetland.OptiKey.Properties;
 using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.Static;
 using JuliusSweetland.OptiKey.UI.ViewModels;
+using JuliusSweetland.OptiKey.Contracts;
 using log4net;
 using Prism.Commands;
 using Prism.Interactivity.InteractionRequest;

--- a/src/JuliusSweetland.OptiKey.Mouse/JuliusSweetland.OptiKey.Mouse.csproj
+++ b/src/JuliusSweetland.OptiKey.Mouse/JuliusSweetland.OptiKey.Mouse.csproj
@@ -71,7 +71,7 @@
     </Reference>
     <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
@@ -200,7 +200,7 @@
     </Reference>
     <Reference Include="TETCSharpClient">
       <HintPath>..\..\ext\TheEyeTribe\TETCSharpClient.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -1011,6 +1011,14 @@
     <ProjectReference Include="..\JuliusSweetland.OptiKey.Core\JuliusSweetland.OptiKey.Core.csproj">
       <Project>{6865c5af-c6f0-4bda-ba1c-7ae8bc225234}</Project>
       <Name>JuliusSweetland.OptiKey.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj">
+      <Project>{77c8f650-7992-4ff6-b434-1c15b72672e6}</Project>
+      <Name>JuliusSweetland.OptiKey.PointSourceUtils</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj">
+      <Project>{6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719}</Project>
+      <Name>JuliusSweetland.OptiKey.Contracts</Name>
     </ProjectReference>
     <ProjectReference Include="..\JuliusSweetland.OptiKey.StandardPlugins\JuliusSweetland.OptiKey.StandardPlugins.csproj">
       <Project>{0c8f0372-2d55-41bc-9730-4ace3ed67452}</Project>

--- a/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/Graphics.cs
+++ b/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/Graphics.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using Microsoft.Win32;
+
+namespace JuliusSweetland.OptiKey.Static
+{
+    public static class Graphics
+    {
+        static Graphics()
+        {
+            DisplaySettingsChanged(); // Set initial values
+            SystemEvents.DisplaySettingsChanged += new EventHandler((s,e) => { DisplaySettingsChanged(); });
+        }
+
+        [DllImport("gdi32.dll")]
+        public static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+        private static void DisplaySettingsChanged()
+        {
+            ComputeDpiXandY();
+        }
+
+        // These are cached values, updated when display settings change
+        // To refresh, you may manually call ComputeDpiXandY
+        public static int DpiX { get; private set; }
+        public static int DpiY { get; private set; }
+
+        // Calling this method takes some time, so by default it gets cached on changes only
+        // If you want to 
+        public static void ComputeDpiXandY() { 
+            using (var g = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+            {
+                var desktop = g.GetHdc();
+                DpiX = GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSX);
+                DpiY = GetDeviceCaps(desktop, (int)DeviceCap.LOGPIXELSY);
+            }
+        }
+
+        public static double DipScalingFactorX //need
+        {
+            get { return (double)DpiX / (double)96; }
+        }
+        
+        public static double DipScalingFactorY //need
+        {
+            get { return (double)DpiY / (double)96; }
+        }        
+
+        public static double PrimaryScreenWidthInPixels //need
+        {
+            get { return SystemParameters.PrimaryScreenWidth * DipScalingFactorX; }
+        }
+
+        public static double PrimaryScreenHeightInPixels
+        {
+            get { return SystemParameters.PrimaryScreenHeight * DipScalingFactorY; }
+        }
+
+
+        public enum DeviceCap
+        {
+            /// <summary>
+            /// Device driver version
+            /// </summary>
+            DRIVERVERSION = 0,
+            /// <summary>
+            /// Device classification
+            /// </summary>
+            TECHNOLOGY = 2,
+            /// <summary>
+            /// Horizontal size in millimeters
+            /// </summary>
+            HORZSIZE = 4,
+            /// <summary>
+            /// Vertical size in millimeters
+            /// </summary>
+            VERTSIZE = 6,
+            /// <summary>
+            /// Horizontal width in pixels
+            /// </summary>
+            HORZRES = 8,
+            /// <summary>
+            /// Vertical height in pixels
+            /// </summary>
+            VERTRES = 10,
+            /// <summary>
+            /// Number of bits per pixel
+            /// </summary>
+            BITSPIXEL = 12,
+            /// <summary>
+            /// Number of planes
+            /// </summary>
+            PLANES = 14,
+            /// <summary>
+            /// Number of brushes the device has
+            /// </summary>
+            NUMBRUSHES = 16,
+            /// <summary>
+            /// Number of pens the device has
+            /// </summary>
+            NUMPENS = 18,
+            /// <summary>
+            /// Number of markers the device has
+            /// </summary>
+            NUMMARKERS = 20,
+            /// <summary>
+            /// Number of fonts the device has
+            /// </summary>
+            NUMFONTS = 22,
+            /// <summary>
+            /// Number of colors the device supports
+            /// </summary>
+            NUMCOLORS = 24,
+            /// <summary>
+            /// Size required for device descriptor
+            /// </summary>
+            PDEVICESIZE = 26,
+            /// <summary>
+            /// Curve capabilities
+            /// </summary>
+            CURVECAPS = 28,
+            /// <summary>
+            /// Line capabilities
+            /// </summary>
+            LINECAPS = 30,
+            /// <summary>
+            /// Polygonal capabilities
+            /// </summary>
+            POLYGONALCAPS = 32,
+            /// <summary>
+            /// Text capabilities
+            /// </summary>
+            TEXTCAPS = 34,
+            /// <summary>
+            /// Clipping capabilities
+            /// </summary>
+            CLIPCAPS = 36,
+            /// <summary>
+            /// Bitblt capabilities
+            /// </summary>
+            RASTERCAPS = 38,
+            /// <summary>
+            /// Length of the X leg
+            /// </summary>
+            ASPECTX = 40,
+            /// <summary>
+            /// Length of the Y leg
+            /// </summary>
+            ASPECTY = 42,
+            /// <summary>
+            /// Length of the hypotenuse
+            /// </summary>
+            ASPECTXY = 44,
+            /// <summary>
+            /// Shading and Blending caps
+            /// </summary>
+            SHADEBLENDCAPS = 45,
+
+            /// <summary>
+            /// Logical pixels inch in X
+            /// </summary>
+            LOGPIXELSX = 88,
+            /// <summary>
+            /// Logical pixels inch in Y
+            /// </summary>
+            LOGPIXELSY = 90,
+
+            /// <summary>
+            /// Number of entries in physical palette
+            /// </summary>
+            SIZEPALETTE = 104,
+            /// <summary>
+            /// Number of reserved entries in palette
+            /// </summary>
+            NUMRESERVED = 106,
+            /// <summary>
+            /// Actual color resolution
+            /// </summary>
+            COLORRES = 108,
+
+            // Printing related DeviceCaps. These replace the appropriate Escapes
+            /// <summary>
+            /// Physical Width in device units
+            /// </summary>
+            PHYSICALWIDTH = 110,
+            /// <summary>
+            /// Physical Height in device units
+            /// </summary>
+            PHYSICALHEIGHT = 111,
+            /// <summary>
+            /// Physical Printable Area x margin
+            /// </summary>
+            PHYSICALOFFSETX = 112,
+            /// <summary>
+            /// Physical Printable Area y margin
+            /// </summary>
+            PHYSICALOFFSETY = 113,
+            /// <summary>
+            /// Scaling factor x
+            /// </summary>
+            SCALINGFACTORX = 114,
+            /// <summary>
+            /// Scaling factor y
+            /// </summary>
+            SCALINGFACTORY = 115,
+
+            /// <summary>
+            /// Current vertical refresh rate of the display device (for displays only) in Hz
+            /// </summary>
+            VREFRESH = 116,
+            /// <summary>
+            /// Vertical height of entire desktop in pixels
+            /// </summary>
+            DESKTOPVERTRES = 117,
+            /// <summary>
+            /// Horizontal width of entire desktop in pixels
+            /// </summary>
+            DESKTOPHORZRES = 118,
+            /// <summary>
+            /// Preferred blt alignment
+            /// </summary>
+            BLTALIGNMENT = 119
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/JuliusSweetland.OptiKey.PointSourceUtils.csproj
+++ b/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/JuliusSweetland.OptiKey.PointSourceUtils.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{77C8F650-7992-4FF6-B434-1C15B72672E6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PointSourceUtils</RootNamespace>
+    <AssemblyName>PointSourceUtils</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="JuliusSweetland.OptiKey.Contracts">
+      <HintPath>..\..\JuliusSweetland.OptiKey.Contracts\bin\x64\Release\JuliusSweetland.OptiKey.Contracts.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\..\JuliusSweetland.OptiKey.Contracts\bin\x64\Release\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq">
+      <HintPath>..\..\JuliusSweetland.OptiKey.Contracts\bin\x64\Release\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Graphics.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Time.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/Properties/AssemblyInfo.cs
+++ b/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PointSourceUtils")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PointSourceUtils")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("77c8f650-7992-4ff6-b434-1c15b72672e6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/Time.cs
+++ b/src/JuliusSweetland.OptiKey.PointSourceUtils/PointSourceUtils/Time.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2023 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace JuliusSweetland.OptiKey.Static
+{
+    public static class Time
+    {
+        [DllImport("Kernel32.dll", CallingConvention = CallingConvention.Winapi)]
+        private static extern void GetSystemTimePreciseAsFileTime(out long filetime);
+
+        public static DateTime HighResolutionUtcNow
+        {
+            get
+            {
+                try
+                {
+                    long filetime;
+                    GetSystemTimePreciseAsFileTime(out filetime);
+                    return DateTime.FromFileTimeUtc(filetime);
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    // GetSystemTimePreciseAsFileTime is available from Windows 8+
+                    // Fall back to lower resolution alternative
+                    return DateTime.UtcNow;
+                }
+            }
+        }
+    }
+}

--- a/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Pro/App.xaml.cs
@@ -18,6 +18,7 @@ using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Observables.PointSources;
 using JuliusSweetland.OptiKey.Observables.TriggerSources;
 using JuliusSweetland.OptiKey.Pro.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.Services.PluginEngine;
 using JuliusSweetland.OptiKey.Static;
@@ -139,7 +140,7 @@ namespace JuliusSweetland.OptiKey.Pro
                 ValidatePluginsLocation();
                 if (Settings.Default.EnablePlugins)
                 {
-                    PluginEngine.LoadAvailablePlugins();
+                    OptikeyPluginEngine.LoadAvailablePlugins();
                 }
 
                 var presageInstallationProblem = PresageInstallationProblemsDetected();
@@ -157,7 +158,7 @@ namespace JuliusSweetland.OptiKey.Pro
                 IKeyStateService keyStateService = new KeyStateService(suggestionService, capturingStateManager,
                     lastMouseActionStateManager, calibrationService, fireKeySelectionEvent);
                 IInputService inputService = CreateInputService(keyStateService, dictionaryService, audioService,
-                    calibrationService, capturingStateManager, errorNotifyingServices);
+                    calibrationService, capturingStateManager, errorNotifyingServices, out string inputServiceErrorMessage);
                 IKeyboardOutputService keyboardOutputService = new KeyboardOutputService(keyStateService,
                     suggestionService, publishService, dictionaryService, fireKeySelectionEvent);
                 IMouseOutputService mouseOutputService = new MouseOutputService(publishService);
@@ -217,12 +218,15 @@ namespace JuliusSweetland.OptiKey.Pro
                     await ShowSplashScreen(inputService, audioService, mainViewModel, OptiKey.Properties.Resources.OPTIKEY_PRO_DESCRIPTION);
                     await mainViewModel.RaiseAnyPendingErrorToastNotifications();
                     await AttemptToStartMaryTTSService(inputService, audioService, mainViewModel);
+                    await AlertIfInputServiceError(inputService, audioService, mainViewModel, inputServiceErrorMessage);
                     await AlertIfEyeTrackerDeprecated(inputService, audioService, mainViewModel);
                     await AlertIfPresageBitnessOrBootstrapOrVersionFailure(presageInstallationProblem, inputService,
                         audioService, mainViewModel);
 
                     inputService.RequestResume(); //Start the input service
 
+                    // Github queries happen in the background
+                    await StartCheckForEyeTrackerPluginsOnline(); 
                     await CheckForUpdates(inputService, audioService, mainViewModel);
                 };
 

--- a/src/JuliusSweetland.OptiKey.Pro/JuliusSweetland.OptiKey.Pro.csproj
+++ b/src/JuliusSweetland.OptiKey.Pro/JuliusSweetland.OptiKey.Pro.csproj
@@ -1002,6 +1002,14 @@
       <Project>{6865c5af-c6f0-4bda-ba1c-7ae8bc225234}</Project>
       <Name>JuliusSweetland.OptiKey.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj">
+      <Project>{77c8f650-7992-4ff6-b434-1c15b72672e6}</Project>
+      <Name>JuliusSweetland.OptiKey.PointSourceUtils</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj">
+      <Project>{6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719}</Project>
+      <Name>JuliusSweetland.OptiKey.Contracts</Name>
+    </ProjectReference>
     <ProjectReference Include="..\JuliusSweetland.OptiKey.StandardPlugins\JuliusSweetland.OptiKey.StandardPlugins.csproj">
       <Project>{0c8f0372-2d55-41bc-9730-4ace3ed67452}</Project>
       <Name>JuliusSweetland.OptiKey.StandardPlugins</Name>

--- a/src/JuliusSweetland.OptiKey.Symbol/App.xaml.cs
+++ b/src/JuliusSweetland.OptiKey.Symbol/App.xaml.cs
@@ -15,6 +15,7 @@ using System.Windows;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Contracts;
 using JuliusSweetland.OptiKey.Observables.PointSources;
 using JuliusSweetland.OptiKey.Observables.TriggerSources;
 using JuliusSweetland.OptiKey.Symbol.Properties;
@@ -116,7 +117,7 @@ namespace JuliusSweetland.OptiKey.Symbol
                 ValidatePluginsLocation();
                 if (Settings.Default.EnablePlugins)
                 {
-                    PluginEngine.LoadAvailablePlugins();
+                    OptikeyPluginEngine.LoadAvailablePlugins();
                 }
 
                 var presageInstallationProblem = PresageInstallationProblemsDetected();
@@ -133,7 +134,7 @@ namespace JuliusSweetland.OptiKey.Symbol
                 ILastMouseActionStateManager lastMouseActionStateManager = new LastMouseActionStateManager();
                 IKeyStateService keyStateService = new KeyStateService(suggestionService, capturingStateManager, lastMouseActionStateManager, calibrationService, fireKeySelectionEvent);
                 IInputService inputService = CreateInputService(keyStateService, dictionaryService, audioService,
-                    calibrationService, capturingStateManager, errorNotifyingServices);
+                    calibrationService, capturingStateManager, errorNotifyingServices, out string inputServiceErrorMessage);
                 IKeyboardOutputService keyboardOutputService = new KeyboardOutputService(keyStateService, suggestionService, publishService, dictionaryService, fireKeySelectionEvent);
                 IMouseOutputService mouseOutputService = new MouseOutputService(publishService);
                 errorNotifyingServices.Add(audioService);
@@ -186,11 +187,14 @@ namespace JuliusSweetland.OptiKey.Symbol
                     await ShowSplashScreen(inputService, audioService, mainViewModel, OptiKey.Properties.Resources.OPTIKEY_SYMBOL_DESCRIPTION);
                     await mainViewModel.RaiseAnyPendingErrorToastNotifications();
                     await AttemptToStartMaryTTSService(inputService, audioService, mainViewModel);
+                    await AlertIfInputServiceError(inputService, audioService, mainViewModel, inputServiceErrorMessage);
                     await AlertIfEyeTrackerDeprecated(inputService, audioService, mainViewModel);
                     await AlertIfPresageBitnessOrBootstrapOrVersionFailure(presageInstallationProblem, inputService, audioService, mainViewModel);
 
                     inputService.RequestResume(); //Start the input service
 
+                    // Github queries happen in the background
+                    await StartCheckForEyeTrackerPluginsOnline();
                     await CheckForUpdates(inputService, audioService, mainViewModel);
                 };
 

--- a/src/JuliusSweetland.OptiKey.Symbol/JuliusSweetland.OptiKey.Symbol.csproj
+++ b/src/JuliusSweetland.OptiKey.Symbol/JuliusSweetland.OptiKey.Symbol.csproj
@@ -199,7 +199,7 @@
     </Reference>
     <Reference Include="TETCSharpClient">
       <HintPath>..\..\ext\TheEyeTribe\TETCSharpClient.dll</HintPath>
-    </Reference>    
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -1010,6 +1010,14 @@
     <ProjectReference Include="..\JuliusSweetland.OptiKey.Core\JuliusSweetland.OptiKey.Core.csproj">
       <Project>{6865c5af-c6f0-4bda-ba1c-7ae8bc225234}</Project>
       <Name>JuliusSweetland.OptiKey.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj">
+      <Project>{77c8f650-7992-4ff6-b434-1c15b72672e6}</Project>
+      <Name>JuliusSweetland.OptiKey.PointSourceUtils</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj">
+      <Project>{6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719}</Project>
+      <Name>JuliusSweetland.OptiKey.Contracts</Name>
     </ProjectReference>
     <ProjectReference Include="..\JuliusSweetland.OptiKey.StandardPlugins\JuliusSweetland.OptiKey.StandardPlugins.csproj">
       <Project>{0c8f0372-2d55-41bc-9730-4ace3ed67452}</Project>

--- a/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
+++ b/src/JuliusSweetland.OptiKey.UnitTests/JuliusSweetland.OptiKey.UnitTests.csproj
@@ -142,9 +142,17 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.Contracts\JuliusSweetland.OptiKey.Contracts.csproj">
+      <Project>{6b7fd101-f21c-4eea-a2e0-4b5cbfbfe719}</Project>
+      <Name>JuliusSweetland.OptiKey.Contracts</Name>
+    </ProjectReference>
     <ProjectReference Include="..\JuliusSweetland.OptiKey.Core\JuliusSweetland.OptiKey.Core.csproj">
       <Project>{6865c5af-c6f0-4bda-ba1c-7ae8bc225234}</Project>
       <Name>JuliusSweetland.OptiKey.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JuliusSweetland.OptiKey.PointSourceUtils\PointSourceUtils\JuliusSweetland.OptiKey.PointSourceUtils.csproj">
+      <Project>{77c8f650-7992-4ff6-b434-1c15b72672e6}</Project>
+      <Name>JuliusSweetland.OptiKey.PointSourceUtils</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/MainViewModelTestBase.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/MainViewModelTestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2022 OPTIKEY LTD (UK company number 11854839) - All Rights Reserved
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Models;
+using JuliusSweetland.OptiKey.Contracts;
 using JuliusSweetland.OptiKey.Services;
 using JuliusSweetland.OptiKey.UI.ViewModels;
 using Moq;

--- a/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
+++ b/src/JuliusSweetland.OptiKey.UnitTests/UI/ViewModels/MainViewModelSpecifications/WhenAttachServiceEventHandlers.cs
@@ -2,6 +2,7 @@
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.Models;
 using JuliusSweetland.OptiKey.Properties;
+using JuliusSweetland.OptiKey.Contracts;
 using JuliusSweetland.OptiKey.Services;
 using Moq;
 using NUnit.Framework;


### PR DESCRIPTION
## What is included in this PR:
- Split out some core functionality to define public interfaces for DLLs
- Add support for external DLLs to be used as PointsSource
- Add management console UI to allow installing & management of DLLs

In the constructor of `GithubPluginsSearch` you can set a github API token, for high-volume testing. I can send you one. 

## Some outstanding discussion points:

### github errors
On startup, we asynchronously call out to github to update our list of available repos. If this fails for any reason, we log but do not toast the user. I think this is okay, but it does mean we could miss some unpredicted unrecoverable error that we might want to be aware of...? 

FWIW if the issue was a network connection, we try 3 times before giving up (to allow for users who have Optikey start automatically on startup when the network connection may not be ready)

### Coercion of application smoothing level 

Currently, if you install a new plugin, and then close the plugins window, it asks if you want to select your newly--installed plugin as the points source. If you say yes, it changes the point source and defaults the smoothing level back to zero. You can then change it to something else if you like. 
It does *not* prompt you or coerce anything if you choose a plugin in the dropdown manually. 
Is the current behaviour what we want?

Given that we are instantiating the points source at install, we could add to our interface a notion of “recommended smoothing level” that defaults to zero. I ruled this out previously as I wasn’t sure how to expose this without instantiating the class. The downside is that it locks us in a bit to the ‘meaning’ of our application smoothing levels. The upside is people who want the built in smoothing can have it, and others can implement their own and expect ours not to interfere (i.e. only if a user turns it on again)

### Test architecture
I had to set processor architecture for tests to get them to work with the 64 bit build - we may need to do this in CI ? You can also use the .runsettings file I added, but this also needs hooking up in VS/CI. 

### Failing test 
In `ThenSelectionProgressShouldBeProcessed`, the `AudioService` assertion is failing. I suspect this was broken back when we switched to 64 bit and I didn't realise tests weren't running. I'll try to track it down

