### PR TITLE
Fix install translations

### DIFF
--- a/installer/OptiKeyPro.aip
+++ b/installer/OptiKeyPro.aip
@@ -78,6 +78,7 @@
     <ROW Directory="trTR_Dir" Directory_Parent="Release_Dir" DefaultDir="tr-TR"/>
     <ROW Directory="ukUA_Dir" Directory_Parent="Release_Dir" DefaultDir="uk-UA"/>
     <ROW Directory="urPK_Dir" Directory_Parent="Release_Dir" DefaultDir="ur-PK"/>
+    <ROW Directory="zhCN_Dir" Directory_Parent="Release_Dir" DefaultDir="zh-CN"/>
     <ROW Directory="zhTW_Dir" Directory_Parent="Release_Dir" DefaultDir="zh-TW"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCompsComponent">
@@ -126,6 +127,7 @@
     <ROW Component="OptiKey.resources.dll_26" ComponentId="{447E3633-F334-4C6F-A79A-267F55E6B229}" Directory_="ukUA_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_26"/>
     <ROW Component="OptiKey.resources.dll_27" ComponentId="{D09C6938-B952-4609-82AE-A5C6631BC62D}" Directory_="urPK_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_27"/>
     <ROW Component="OptiKey.resources.dll_28" ComponentId="{5E3D9C6F-8E25-4D07-AD98-9DBE67DD106E}" Directory_="zhTW_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_28"/>
+    <ROW Component="OptiKey.resources.dll_29" ComponentId="{91AF7C9E-E8C6-4CB9-8A97-9CE5502D3C92}" Directory_="zhCN_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_29"/>
     <ROW Component="OptiKey.resources.dll_3" ComponentId="{CA0B63F0-1712-4865-BE64-C7F5FD466DC2}" Directory_="deDE_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_3"/>
     <ROW Component="OptiKey.resources.dll_4" ComponentId="{B8F63A3C-68A8-4935-9F55-2DFFE8B000FF}" Directory_="elGR_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_4"/>
     <ROW Component="OptiKey.resources.dll_5" ComponentId="{7A61EB35-0E34-44CE-A2BD-35EF0CF65287}" Directory_="enUS_Dir" Attributes="256" KeyPath="OptiKey.resources.dll_5"/>
@@ -449,6 +451,7 @@
     <ROW File="terra_pinyin.schema.yaml" Component_="bopomofo.schema.yaml" FileName="TERRA_~2.YAM|terra_pinyin.schema.yaml" Attributes="0" SourcePath="..\src\JuliusSweetland.OptiKey.Pro\bin\x64\Release\Resources\Rime\terra_pinyin.schema.yaml" SelfReg="false"/>
     <ROW File="zhuyin.yaml" Component_="bopomofo.schema.yaml" FileName="ZHUYIN~1.YAM|zhuyin.yaml" Attributes="0" SourcePath="..\src\JuliusSweetland.OptiKey.Pro\bin\x64\Release\Resources\Rime\zhuyin.yaml" SelfReg="false"/>
     <ROW File="OptiKey.resources.dll_28" Component_="OptiKey.resources.dll_28" FileName="OPTIKE~1.DLL|OptiKey.resources.dll" Attributes="0" SourcePath="..\src\JuliusSweetland.OptiKey.Pro\bin\x64\Release\zh-TW\OptiKey.resources.dll" SelfReg="false"/>
+    <ROW File="OptiKey.resources.dll_29" Component_="OptiKey.resources.dll_29" FileName="OPTIKE~1.DLL|OptiKey.resources.dll" Attributes="0" SourcePath="..\src\JuliusSweetland.OptiKey.Pro\bin\x64\Release\zh-CN\OptiKey.resources.dll" SelfReg="false"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites" Options="2"/>
@@ -896,6 +899,7 @@
     <ROW Feature_="MainFeature" Component_="hk2s.json"/>
     <ROW Feature_="MainFeature" Component_="rime.dll"/>
     <ROW Feature_="MainFeature" Component_="OptiKey.resources.dll_28"/>
+    <ROW Feature_="MainFeature" Component_="OptiKey.resources.dll_29"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiIconsComponent">
     <ROW Name="Pro.exe" SourcePath="..\src\JuliusSweetland.OptiKey.Pro\Pro.ico" Index="0"/>

--- a/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
+++ b/src/JuliusSweetland.OptiKey.Core/JuliusSweetland.OptiKey.Core.csproj
@@ -382,6 +382,11 @@
     <Compile Include="Observables\TriggerSources\TouchTriggerSource.cs" />
     <Compile Include="Observables\TriggerSources\XInputButtonDownUpSource.cs" />
     <Compile Include="OptiKeyApp.cs" />
+    <Compile Include="Properties\Resources.zh-CN.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.zh-CN.resx</DependentUpon>
+    </Compile>
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -1067,6 +1072,11 @@
     <Content Include="Resources\EyeTrackerSupport\tobii-trackers.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Properties\Resources.zh-CN.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.zh-CN.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.ca-ES.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.resx
@@ -2363,8 +2363,7 @@ Magyar
   <data name="IRISBOND_DUO_INFO" xml:space="preserve">
     <value>If you plan to use Optikey with the Irisbond Duo eye tracker then please make sure you have the Irisbond Duo drivers installed. These can be downloaded from https://www.irisbond.com/en/producto/irisbond-duo-2.</value>
   </data>
-  <data name="IRISBOND_HIRU_INFO" xml:space="preserve">
-    <value />
+  <data name="IRISBOND_HIRU_INFO" xml:space="preserve"><value />
   </data>
   <data name="MOUSE_POSITION_INFO" xml:space="preserve">
     <value>In this mode, Optikey will use the mouse cursor as input instead of talking directly to an eye tracker. You might want this if you're testing Optikey out, or if you want to use it with an alternative input device such as a head mouse or any eye tracker not in this list.</value>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-CN.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-CN.resx
@@ -144,9 +144,6 @@
   <data name="IRISBOND_DUO_INFO" xml:space="preserve">
     <value>如果您打算搭配 Irisbond Duo 眼动仪使用 Optikey，请确认您已安装 Irisbond Duo 驱动程序。它可以从 https://www.irisbond.com/en/producto/irisbond-duo-2 下载。</value>
   </data>
-  <data name="IRISBOND_HIRU_INFO" xml:space="preserve">
-    <value>如果您打算搭配 Irisbond Hiru 眼动仪使用 Optikey，请确认您已安装 Irisbond Hiru 驱动程序。它可以从 https://www.irisbond.com/en/producto/irisbond-duo-2 下载。</value>
-  </data>
   <data name="MOUSE_POSITION_INFO" xml:space="preserve">
     <value>在此模式下 Optikey 会使用鼠标光标位置作为输入而不是直接和眼动仪互动。当您想要测试 Optikey 时，您可能会选择这个模式，或是您想用其它替代输入设备，例如头部鼠标或未列入清单中的眼动仪。</value>
   </data>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-CN.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-CN.resx
@@ -1,4 +1,4 @@
-﻿?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,4 +117,46 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ALIENWARE_17" xml:space="preserve">
+    <value>Alienware 17 (EyeX)</value>
+  </data>
+  <data name="STEELSERIES_SENTRY" xml:space="preserve">
+    <value>Steelseries Sentry (EyeX)</value>
+  </data>
+  <data name="TOBII_EYE_TRACKER_4C" xml:space="preserve">
+    <value>Tobii Eye Tracker 4C</value>
+  </data>
+  <data name="TOBII_PCEYE_MINI" xml:space="preserve">
+    <value>Tobii PCEye Mini</value>
+  </data>
+  <data name="TOBII_X2_30" xml:space="preserve">
+    <value>Tobii X2-30</value>
+  </data>
+  <data name="TOBII_X2_60" xml:space="preserve">
+    <value>Tobii X2-60</value>
+  </data>
+  <data name="ALIENWARE_17_INFO" xml:space="preserve">
+    <value>这需要 Alienware 17 游戏笔记本，使用内建的 Tobii 眼动仪。</value>
+  </data>
+  <data name="GAZE_TRACKER_INFO" xml:space="preserve">
+    <value>这需要 ITU Gaze Tracking Library，它是能让您使用现成设备（例如摄像机、网络摄像头）的开源眼动追踪框架。</value>
+  </data>
+  <data name="IRISBOND_DUO_INFO" xml:space="preserve">
+    <value>如果您打算搭配 Irisbond Duo 眼动仪使用 Optikey，请确认您已安装 Irisbond Duo 驱动程序。它可以从 https://www.irisbond.com/en/producto/irisbond-duo-2 下载。</value>
+  </data>
+  <data name="IRISBOND_HIRU_INFO" xml:space="preserve">
+    <value>如果您打算搭配 Irisbond Hiru 眼动仪使用 Optikey，请确认您已安装 Irisbond Hiru 驱动程序。它可以从 https://www.irisbond.com/en/producto/irisbond-duo-2 下载。</value>
+  </data>
+  <data name="MOUSE_POSITION_INFO" xml:space="preserve">
+    <value>在此模式下 Optikey 会使用鼠标光标位置作为输入而不是直接和眼动仪互动。当您想要测试 Optikey 时，您可能会选择这个模式，或是您想用其它替代输入设备，例如头部鼠标或未列入清单中的眼动仪。</value>
+  </data>
+  <data name="TOBII_ASSISTIVE_INFO" xml:space="preserve">
+    <value>若要搭配辅助眼动仪来使用 Optikey，您需要安装新版的 Windows Control 或 Tobii Eye Tracking 引擎。若您需要使用旧版的 Tobii Windows Control 程序（包含 Tobii Gaze Interaction 设置），您需要改用鼠标位置控制 Optikey。</value>
+  </data>
+  <data name="TOBII_EYEX_INFO" xml:space="preserve">
+    <value>此选项适用于任何 Tobii 游戏眼动仪（5, 4C, EyeX, Alienware, Steelseries等）</value>
+  </data>
+  <data name="VI_MYGAZE_INFO" xml:space="preserve">
+    <value>唯有在您已安装 myGaze 客户端驱动程序时，才支持 Visual Interaction myGaze，但它已经不再提供下载了。若您未安装该驱动程序，你应改为选择“鼠标位置”，并搭配 myGaze EyeMousePlay 程序使用 Optikey 以移动光标。</value>
+  </data>
 </root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-CN.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-CN.resx
@@ -1,0 +1,120 @@
+﻿?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-TW.resx
+++ b/src/JuliusSweetland.OptiKey.Core/Properties/Resources.zh-TW.resx
@@ -2335,9 +2335,6 @@ Magyar
   <data name="IRISBOND_DUO_INFO" xml:space="preserve">
     <value>如果您打算搭配 Irisbond Duo 眼動儀使用 Optikey，請確認您已安裝 Irisbond Duo 驅動程式。它可以從 https://www.irisbond.com/en/producto/irisbond-duo-2 下載。</value>
   </data>
-  <data name="IRISBOND_HIRU_INFO" xml:space="preserve">
-    <value>如果您打算搭配 Irisbond Hiru 眼動儀使用 Optikey，請確認您已安裝 Irisbond Hiru 驅動程式。它可以從 https://www.irisbond.com/en/producto/irisbond-duo-2 下載。</value>
-  </data>
   <data name="MOUSE_POSITION_INFO" xml:space="preserve">
     <value>在此模式下 Optikey 會使用滑鼠遊標位置作為輸入而不是直接和眼動儀互動。當您想要測試 Optikey 時，您可能會選擇這個模式，或是您想用其它替代輸入裝置，例如頭部滑鼠或未列入清單中的眼動儀。</value>
   </data>

--- a/src/JuliusSweetland.OptiKey.InstallerActions/CustomAction.cs
+++ b/src/JuliusSweetland.OptiKey.InstallerActions/CustomAction.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Remoting.Messaging;
 using System.Text;
 using JuliusSweetland.OptiKey.Enums;
+using JuliusSweetland.OptiKey.Extensions;
 using JuliusSweetland.OptiKey.UI.ViewModels.Management;
 using Microsoft.Deployment.WindowsInstaller;
 
@@ -133,11 +134,19 @@ namespace JuliusSweetland.OptiKey.InstallerActions
                 string details_english = GetPointsSourceDetails(tracker.Value, new CultureInfo("en-GB"));
                 if (details == details_english)
                 {
-                    details_english = "";
+                    details_english = ""; // don't duplicate english tranlsation
                 }
                 else
                 {
-                    details_english = "Automatically translated from original text:\n" + details_english;
+                    if (details == "")
+                    { // no translation available, use english alone
+                        details = details_english;
+                        details_english = "";
+                    }
+                    else
+                    {
+                        details_english = "Automatically translated from original text:\n" + details_english;
+                    }
                 }
             
                 session["TRACKERINFO_" + SanitisePropName(trackerLabel)] = details;
@@ -161,8 +170,8 @@ namespace JuliusSweetland.OptiKey.InstallerActions
                 session["TRACKER_" + SanitisePropName(trackerLabel)] = trackerEnum;
 
                 // also the extended info, translated and original text 
-                string details = InstallerStrings.OTHER_TRACKER[closestCulture];
-                string details_english = InstallerStrings.OTHER_TRACKER[new CultureInfo("en-GB")];
+                string details = InstallerStrings.OTHER_TRACKER.GetValueOrDefault(closestCulture, "");
+                string details_english = InstallerStrings.OTHER_TRACKER.GetValueOrDefault(new CultureInfo("en-GB"), "");
                 if (details == details_english)
                 {
                     details_english = "";
@@ -229,23 +238,27 @@ namespace JuliusSweetland.OptiKey.InstallerActions
 
         private static string GetPointsSourceDetails(PointsSources pointSource, CultureInfo culture)
         {
-            switch (pointSource)
+            try
             {
-                // TODO check for culture not in dict, default empty?
-                case PointsSources.GazeTracker: return InstallerStrings.GAZE_TRACKER_INFO[culture];
-                case PointsSources.IrisbondDuo: return InstallerStrings.IRISBOND_DUO_INFO[culture];
-                case PointsSources.IrisbondHiru: return InstallerStrings.IRISBOND_HIRU_INFO[culture];
-                case PointsSources.MousePosition: return InstallerStrings.MOUSE_POSITION_INFO[culture];
-                case PointsSources.TobiiPcEyeGo: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
-                case PointsSources.TobiiPcEyeGoPlus: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
-                case PointsSources.TobiiPcEyeMini: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
-                case PointsSources.TobiiX2_30: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
-                case PointsSources.TobiiX2_60: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
-                default: return "";
+                switch (pointSource)
+                {
+                    // TODO check for culture not in dict, default empty?
+                    case PointsSources.GazeTracker: return InstallerStrings.GAZE_TRACKER_INFO[culture];
+                    case PointsSources.IrisbondDuo: return InstallerStrings.IRISBOND_DUO_INFO[culture];
+                    case PointsSources.IrisbondHiru: return InstallerStrings.IRISBOND_HIRU_INFO[culture];
+                    case PointsSources.MousePosition: return InstallerStrings.MOUSE_POSITION_INFO[culture];
+                    case PointsSources.TobiiPcEyeGo: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
+                    case PointsSources.TobiiPcEyeGoPlus: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
+                    case PointsSources.TobiiPcEyeMini: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
+                    case PointsSources.TobiiX2_30: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
+                    case PointsSources.TobiiX2_60: return InstallerStrings.TOBII_ASSISTIVE_INFO[culture];
+                    default: return "";
+                }
             }
-
-        }
-
-
+            catch(KeyNotFoundException e)
+            {
+                return ""; 
+            }
+        }        
     }
 }

--- a/src/JuliusSweetland.OptiKey.InstallerTranslations/ProcessInstallerTranslations.cs
+++ b/src/JuliusSweetland.OptiKey.InstallerTranslations/ProcessInstallerTranslations.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using JuliusSweetland.OptiKey.Enums;
 using JuliusSweetland.OptiKey.UI.ViewModels.Management;
+using System.Globalization;
 
 namespace InstallerTranslation
 {
@@ -22,10 +24,7 @@ namespace InstallerTranslation
 
                 Console.WriteLine("Extracting internationalised strings...");
 
-                // Get all Optikey languages
-                List<KeyValuePair<string, Languages>> languages = WordsViewModel.UiLanguages;
-
-                // Query resources to create multilingual dicts for key installer strings
+                // Create multilingual dicts for key installer strings
                 Dictionary<Languages, string> all_ALIENWARE_17_INFO = new Dictionary<Languages, string>();
                 Dictionary<Languages, string> all_GAZE_TRACKER_INFO = new Dictionary<Languages, string>();
                 Dictionary<Languages, string> all_IRISBOND_DUO_INFO = new Dictionary<Languages, string>();
@@ -36,20 +35,29 @@ namespace InstallerTranslation
                 Dictionary<Languages, string> all_MOUSE_POSITION = new Dictionary<Languages, string>();
                 Dictionary<Languages, string> all_OTHER_TRACKER = new Dictionary<Languages, string>();
 
-                foreach (KeyValuePair<string, Languages> entry in languages)
-                {
-                    Languages language = entry.Value;
-                    JuliusSweetland.OptiKey.Properties.Resources.Culture = language.ToCultureInfo();
+                // Get all Optikey languages
+                var languages = Enum.GetValues(typeof(Languages)).Cast<Languages>().ToList();
+                HashSet<CultureInfo> translatedCultures = new HashSet<CultureInfo>();
 
-                    all_ALIENWARE_17_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.ALIENWARE_17_INFO);
-                    all_GAZE_TRACKER_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.GAZE_TRACKER_INFO);
-                    all_IRISBOND_DUO_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.IRISBOND_DUO_INFO);
-                    all_IRISBOND_HIRU_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.IRISBOND_HIRU_INFO);
-                    all_MOUSE_POSITION_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.MOUSE_POSITION_INFO);
-                    all_TOBII_EYEX_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.TOBII_EYEX_INFO);
-                    all_TOBII_ASSISTIVE_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.TOBII_ASSISTIVE_INFO);                    
-                    all_MOUSE_POSITION.Add(language, JuliusSweetland.OptiKey.Properties.Resources.MOUSE_POSITION);
-                    all_OTHER_TRACKER.Add(language, JuliusSweetland.OptiKey.Properties.Resources.OTHER_TRACKER);
+                // Look up translations for each culture present
+                foreach (Languages language in languages)
+                {
+                    var culture = language.ToCultureInfo();
+                    JuliusSweetland.OptiKey.Properties.Resources.Culture = culture;
+
+                    if (!translatedCultures.Contains(culture)) {
+                        all_ALIENWARE_17_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.ALIENWARE_17_INFO);
+                        all_GAZE_TRACKER_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.GAZE_TRACKER_INFO);
+                        all_IRISBOND_DUO_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.IRISBOND_DUO_INFO);
+                        all_IRISBOND_HIRU_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.IRISBOND_HIRU_INFO);
+                        all_MOUSE_POSITION_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.MOUSE_POSITION_INFO);
+                        all_TOBII_EYEX_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.TOBII_EYEX_INFO);
+                        all_TOBII_ASSISTIVE_INFO.Add(language, JuliusSweetland.OptiKey.Properties.Resources.TOBII_ASSISTIVE_INFO);
+                        all_MOUSE_POSITION.Add(language, JuliusSweetland.OptiKey.Properties.Resources.MOUSE_POSITION);
+                        all_OTHER_TRACKER.Add(language, JuliusSweetland.OptiKey.Properties.Resources.OTHER_TRACKER);
+
+                        translatedCultures.Add(culture);
+                    }
                 }
 
                 // pre-amble


### PR DESCRIPTION
Fixes issue where system language is chinese (zh-CH). Optikey only has zh-TW translations, so crashed on attempt to translate. This was a nuance particular to chinese, where our UI support and our keyboard support differ. So depending what you queried, zh-CH claimed to be supported, but didn't have translations. 

This PR:
- makes sure a missing translation doesn't crash installer
- adds enough (auto) translations for zh-CH to cover what's in the installer
- makes sure installer translation logic includes keyboard languages as well as UI languages

